### PR TITLE
Refactor medium

### DIFF
--- a/radis/io/hapi.py
+++ b/radis/io/hapi.py
@@ -1420,7 +1420,7 @@ def subsetOfRowObject(ParameterNames, RowObject):
 
 
 #FORMAT_PYTHON_REGEX = '^\%([0-9]*)\.?([0-9]*)([dfs])$'
-FORMAT_PYTHON_REGEX = '^\%(\d*)(\.(\d*))?([edfsEDFS])$'
+FORMAT_PYTHON_REGEX = r'^\%(\d*)(\.(\d*))?([edfsEDFS])$'
 
 # Fortran string formatting
 #  based on a pythonic format string
@@ -1520,7 +1520,7 @@ def getRowObjectFromString(input_string, TableName):
         #print 'par_name: '+par_name #
         par_format = LOCAL_TABLE_CACHE[TableName]['header']['format'][par_name]
         #print 'par_format: '+par_format #
-        regex = '^\%([0-9]+)\.?[0-9]*([dfs])$'
+        regex = r'^\%([0-9]+)\.?[0-9]*([dfs])$'
         regex = FORMAT_PYTHON_REGEX
         #print 'par_name: '+par_name #
         (lng, trail, lngpnt, ty) = re.search(regex, par_format).groups()
@@ -1551,7 +1551,7 @@ def getRowObjectFromString(input_string, TableName):
             pos = 0
         for par_name in LOCAL_TABLE_CACHE[TableName]['header']['extra']:
             par_format = LOCAL_TABLE_CACHE[TableName]['header']['extra_format'][par_name]
-            regex = '^\%([0-9]+)\.?[0-9]*([dfs])$'
+            regex = r'^\%([0-9]+)\.?[0-9]*([dfs])$'
             regex = FORMAT_PYTHON_REGEX
             (lng, trail, lngpnt, ty) = re.search(regex, par_format).groups()
             lng = int(lng)
@@ -2954,10 +2954,10 @@ def group(TableName, DestinationTableName=QUERY_BUFFER, ParameterNames=None, Gro
 # EXTRACTING ========================================================
 
 
-REGEX_INTEGER = '[+-]?\d+'
-REGEX_STRING = '[^\s]+'
-REGEX_FLOAT_F = '[+-]?\d*\.?\d+'
-REGEX_FLOAT_E = '[+-]?\d*\.?\d+[eEfF]?[+-]?\d+'
+REGEX_INTEGER = r'[+-]?\d+'
+REGEX_STRING = r'[^\s]+'
+REGEX_FLOAT_F = r'[+-]?\d*\.?\d+'
+REGEX_FLOAT_E = r'[+-]?\d*\.?\d+[eEfF]?[+-]?\d+'
 
 
 def REGEX_INTEGER_FIXCOL(n): return '\d{%d}' % n
@@ -3082,7 +3082,7 @@ def extractColumns(TableName, SourceParameterName, ParameterFormats, ParameterNa
         def_val = getDefaultValue(par_type)
         LOCAL_TABLE_CACHE[TableName]['header']['default'][par_name] = def_val
         i += 1
-    format_regex = '\s*'.join(format_regex)
+    format_regex = r'\s*'.join(format_regex)
     # print 'format_regex='+str(format_regex)
     # return format_regex
     # loop through values of SourceParameter

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -2874,9 +2874,10 @@ class BaseFactory(DatabankLoader):
         fix_style('origin')
 
 
-def get_all_waveranges(medium, wavenum_min=None, wavenum_max=None, wavelength_min=None, wavelength_max=None):
-    ''' Give either lambda_min, lambda_max or nu_min, nu_max and you get 
-    everything, in the given propagation ``medium`` 
+def get_waverange(wavenum_min=None, wavenum_max=None, wavelength_min=None, wavelength_max=None,
+                  medium='air'):
+    ''' Returns wavenumber based on whatever input was given: either ν_min, ν_max 
+    directly, or λ_min, λ_max  in the given propagation ``medium``.
 
     Parameters
     ----------
@@ -2884,19 +2885,19 @@ def get_all_waveranges(medium, wavenum_min=None, wavenum_max=None, wavelength_mi
     medium: ``'air'``, ``'vacuum'``
         propagation medium
 
-    wavenum_min, wavenum_max: float, or None
+    wavenum_min, wavenum_max: float, or ``None``
         wavenumbers
 
-    wavelength_min, wavelength_max: float, or None
+    wavelength_min, wavelength_max: float, or ``None``
         wavelengths in given ``medium``
 
     Returns
     -------
 
-    wavenum_min, wavenum_max, wavelength_min, wavelength_max: float
-        wavenumbers, wavelengths in given ``medium``
+    wavenum_min, wavenum_max,: float
+        wavenumbers
+
     '''
-    # TODO: can probably be removed after Refactor #49
 
     # Check input
     if (wavelength_min is None and wavelength_max is None and
@@ -2934,20 +2935,12 @@ def get_all_waveranges(medium, wavenum_min=None, wavenum_max=None, wavelength_mi
         # Test range is correct:
         assert wavenum_min < wavenum_max
 
-        wavelength_min_vac = cm2nm(wavenum_max)
-        wavelength_max_vac = cm2nm(wavenum_min)
-
-        # Convert to expected medium if needed:
-        if medium == 'air':
-            wavelength_min = vacuum2air(wavelength_min_vac)
-            wavelength_max = vacuum2air(wavelength_max_vac)
-
-    return wavenum_min, wavenum_max, wavelength_min, wavelength_max
+    return wavenum_min, wavenum_max
 
 
 if __name__ == '__main__':
     from radis.test.lbl.test_base import _run_testcases
     _run_testcases()
 
-    _, _, wlmin, wlmax = get_all_waveranges('air', 2000, 2400)
-    np.allclose((wlmin, wlmax), (4165.53069, 4998.6369))
+    _, _, wlmin, wlmax = get_waverange('air', 2000, 2400)
+    assert np.allclose((wlmin, wlmax), (4165.53069, 4998.6369))

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -2876,7 +2876,7 @@ class BaseFactory(DatabankLoader):
 
 def get_all_waveranges(medium, wavenum_min=None, wavenum_max=None, wavelength_min=None, wavelength_max=None):
     ''' Give either lambda_min, lambda_max or nu_min, nu_max and you get 
-    everything, in the request propagation ``medium`` 
+    everything, in the given propagation ``medium`` 
 
     Parameters
     ----------
@@ -2896,6 +2896,7 @@ def get_all_waveranges(medium, wavenum_min=None, wavenum_max=None, wavelength_mi
     wavenum_min, wavenum_max, wavelength_min, wavelength_max: float
         wavenumbers, wavelengths in given ``medium``
     '''
+    # TODO: can probably be removed after Refactor #49
 
     # Check input
     if (wavelength_min is None and wavelength_max is None and

--- a/radis/lbl/calc.py
+++ b/radis/lbl/calc.py
@@ -66,11 +66,11 @@ def calc_spectrum(wavenum_min=None,
 
     wavelength_min: float [nm]
         minimum wavelength to be processed in nm. Wavelength in ``'air'`` or 
-        'vacuum' depending of the value of the parameter ``'medium='``
+        ``'vacuum'`` depending of the value of the parameter ``'medium='``
 
     wavelength_max: float [nm]
         maximum wavelength to be processed in nm. Wavelength in ``'air'`` or 
-        'vacuum' depending of the value of the parameter ``'medium='``
+        ``'vacuum'`` depending of the value of the parameter ``'medium='``
 
     Tgas: float [K]
         Gas temperature. If non equilibrium, is used for Ttranslational. 
@@ -136,13 +136,12 @@ def calc_spectrum(wavenum_min=None,
         information on line databases, and :data:`~radis.misc.config.DBFORMAT` for 
         your ``~/.radis`` file format 
 
-    medium: 'air', vacuum'
-        propagating medium: choose whether to return wavelength in air or vacuum.
-        Note that the  input wavelength range ("wavenum_min", "wavenum_max") changes. 
-        Default 'air'
+    medium: ``'air'``, ``'vacuum'``
+        propagating medium when giving inputs with ``'wavenum_min'``, ``'wavenum_max'``. 
+        Does not change anything when giving inputs in wavenumber. Default ``'air'``
 
-    wstep: cm-1
-        Spacing of calculated spectrum. Default 0.01 cm-1
+    wstep: float (cm-1)
+        Spacing of calculated spectrum. Default ``0.01 cm-1``
 
     Other Parameters
     ----------------

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -104,15 +104,15 @@ class SpectrumFactory(BandFactory):
     ----------
 
     wavenum_min: cm-1
-        minimum wavenumber to be processed in cm^-1. Note that this wavenumber
-        can be in 'air' or 'vacuum' depending on the value of the parameter
-        "medium="
+        minimum wavenumber to be processed in cm^-1. 
 
     wavenum_max: cm-1
         maximum wavenumber to be processed in cm^-1
 
     wavelength_min: nm
-        minimum wavelength to be processed in nm
+        minimum wavelength to be processed in nm. This wavelength
+        can be in ``'air'`` or ``'vacuum'`` depending on the value of the parameter
+        ``medium=``
 
     wavelength_max: nm
         maximum wavelength to be processed in nm
@@ -146,7 +146,7 @@ class SpectrumFactory(BandFactory):
 
     medium: ``'air'``, ``'vacuum'``
         propagating medium: choose whether to return wavelength in air or vacuum.
-        Note that the  input wavelength range ("wavenum_min", "wavenum_max") changes.
+        Used when the wavespace is given in wavelength (``wavenum_min=``, ``wavenum_max=``). 
         Default ``'air'``
 
     Other Parameters

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -79,7 +79,7 @@ from six import string_types
 from warnings import warn
 from radis.io.hitran import get_molecule
 from radis.lbl.bands import BandFactory
-from radis.lbl.base import get_all_waveranges
+from radis.lbl.base import get_waverange
 from radis.spectrum.spectrum import Spectrum
 from radis.spectrum.equations import calc_radiance
 from radis.misc.basics import is_float, list_if_float, flatten
@@ -145,9 +145,8 @@ class SpectrumFactory(BandFactory):
         times!). Default 'all'
 
     medium: ``'air'``, ``'vacuum'``
-        propagating medium: choose whether to return wavelength in air or vacuum.
-        Used when the wavespace is given in wavelength (``wavenum_min=``, ``wavenum_max=``). 
-        Default ``'air'``
+        propagating medium when giving inputs with ``'wavenum_min'``, ``'wavenum_max'``. 
+        Does not change anything when giving inputs in wavenumber. Default ``'air'``
 
     Other Parameters
     ----------------
@@ -365,9 +364,10 @@ class SpectrumFactory(BandFactory):
         # calculate waveranges
         # --------------------
 
-        # Get wavelength & wavenumbers in correct propagation medium
-        wavenum_min, wavenum_max, wavelength_min, wavelength_max = get_all_waveranges(
-            medium, wavenum_min, wavenum_max, wavelength_min, wavelength_max)
+        # Get wavenumber, based on whatever was given as input.
+        wavenum_min, wavenum_max = get_waverange(wavenum_min, wavenum_max, 
+                                                      wavelength_min, wavelength_max,
+                                                      medium)
 
         # calculated range is broader than output waverange to take into account off-range line broadening
         wavenumber, wavenumber_calc = _generate_wavenumber_range(wavenum_min, wavenum_max,
@@ -396,10 +396,6 @@ class SpectrumFactory(BandFactory):
         # Initialize input conditions
         self.input.wavenum_min = wavenum_min
         self.input.wavenum_max = wavenum_max
-        self.input.wavelength_min = wavelength_min
-        self.input.wavelength_max = wavelength_max
-        # propagating medium. Calculations are done in vacuum anyway
-        self.input.medium = medium
         self.input.Tref = Tref
         self.input.pressure_mbar = pressure*1e3
         self.input.mole_fraction = mole_fraction

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -309,7 +309,6 @@ class Input(ConditionDict):
         self.Tvib = None      #: float: vibrational temperature. Overwritten by SpectrumFactory.eq/noneq_spectrum
         self.Trot = None      #: float: rotational temperature. Overwritten by SpectrumFactory.eq/noneq_spectrum
         self.isotope = None   #: str: isotope list. Can be '1,2,3', etc. or 'all'
-        self.medium = 'vacuum'         #: str: propagation medium (air, vacuum)
         self.mole_fraction = None      #: float: mole fraction 
         self.molecule = None           #: str: molecule
         self.overpopulation = None     #: dict: overpopulation
@@ -319,8 +318,6 @@ class Input(ConditionDict):
         self.self_absorption = True    #: bool: self absorption (if True, not optically thin)
         self.state = None              #: str: electronic state 
         self.vib_distribution = 'boltzmann'  #: str: vibrational levels distribution (boltzmann, treanor)
-        self.wavelength_max = None     #: str: wavelength max (nm)
-        self.wavelength_min = None     #: str: wavelength min (nm)
         self.wavenum_max = None        #: str: wavenumber max (cm-1)
         self.wavenum_min = None        #: str: wavenumber min (cm-1)
 

--- a/radis/phys/blackbody.py
+++ b/radis/phys/blackbody.py
@@ -223,5 +223,5 @@ def sPlanck(wavenum_min=None, wavenum_max=None,
 
 
 if __name__ == '__main__':
-    from radis.test.phys.test_blackbody import test_planck
-    test_planck()
+    from radis.test.phys.test_blackbody import _run_testcases
+    _run_testcases(plot=True)

--- a/radis/phys/convert.py
+++ b/radis/phys/convert.py
@@ -182,7 +182,7 @@ def dcm2dnm(delta_nu, nu_0):
     -------
 
     delta_nm: float (nm)
-        broadening in wavelength
+        broadening in wavelength (vacuum)
 
     '''
     return cm2nm(nu_0-delta_nu/2)-cm2nm(nu_0+delta_nu/2)
@@ -196,10 +196,10 @@ def dnm2dcm(delta_lbd, lbd_0):
     ----------
 
     delta_lbd: float (nm)
-        wavelength broadening
+        wavelength broadening (vacuum)
 
     lbd_0: float (nm)
-        center wavelength
+        center wavelength (vacuum)
 
     Returns
     -------
@@ -209,6 +209,51 @@ def dnm2dcm(delta_lbd, lbd_0):
 
     '''
     return nm2cm(lbd_0-delta_lbd/2)-nm2cm(lbd_0+delta_lbd/2)
+
+def dcm2dnm_air(delta_nu, nu_0):
+    ''' Converts (ex: FWHM) from Δcm to Δnm
+
+
+    Parameters    
+    ----------
+
+    delta_nu: float (cm-1)
+        wavenumber broadening
+
+    nu_0: float (cm-1)
+        center wavenumber
+
+    Returns
+    -------
+
+    delta_nm: float (nm)
+        broadening in wavelength (air)
+
+    '''
+    return cm2nm_air(nu_0-delta_nu/2)-cm2nm_air(nu_0+delta_nu/2)
+
+
+def dnm_air2dcm(delta_lbd, lbd_0):
+    ''' Converts (ex: FWHM) from Δnm to Δcm
+
+
+    Parameters    
+    ----------
+
+    delta_lbd: float (nm)
+        wavelength broadening (air)
+
+    lbd_0: float (nm)
+        center wavelength (air)
+
+    Returns
+    -------
+
+    delta_cm: float (cm-1)
+        broadening in wavenumber
+
+    '''
+    return nm_air2cm(lbd_0-delta_lbd/2)-nm_air2cm(lbd_0+delta_lbd/2)
 
 
 def dhz2dnm(deltaf_hz, f_0):

--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -47,7 +47,7 @@ from six.moves import zip
 # XXX =====================================================================
 
 
-def get_diff(s1, s2, var, wunit='default', Iunit='default', medium='default',
+def get_diff(s1, s2, var, wunit='default', Iunit='default',
              resample=True, diff_window=0):
     # type: (Spectrum, Spectrum, str, str, str, str, bool, int) -> np.array, np.array
     ''' Get the difference between 2 spectra. 
@@ -68,8 +68,8 @@ def get_diff(s1, s2, var, wunit='default', Iunit='default', medium='default',
     var: str
         spectral quantity (ex: ``'radiance'``, ``'transmittance'``...)
 
-    wunit: 'nm', 'cm-1'
-        waveunit to compare in
+    wunit: ``'nm'``, ``'cm-1'``, ``'nm_vac'``
+        waveunit to compare in: wavelength air, wavenumber, wavelength vacuum
 
     Iunit: str
         if ``'default'`` use s1 unit for variable var
@@ -112,7 +112,7 @@ def get_diff(s1, s2, var, wunit='default', Iunit='default', medium='default',
     '''
     
     w1, I1, w2, I2 = _get_defaults(s1, s2, var=var, wunit=wunit, Iunit=Iunit,
-                                   medium=medium, assert_same_wavelength=not resample)
+                                   assert_same_wavelength=not resample)
 
     # basically w1, I1 - I2 (on same range)
     w1, Idiff = curve_substract(w1, I1, w2, I2)
@@ -134,7 +134,7 @@ def get_diff(s1, s2, var, wunit='default', Iunit='default', medium='default',
 
 
 def get_ratio(s1, s2, var, 
-              wunit='default', Iunit='default', medium='default', resample=True):
+              wunit='default', Iunit='default', resample=True):
     # type: (Spectrum, Spectrum, str, str, str, str, bool) -> np.array, np.array
     ''' Get the ratio between two spectra
     Basically returns w1, I1 / I2 where (w1, I1) and (w2, I2) are the values of
@@ -149,18 +149,16 @@ def get_ratio(s1, s2, var,
     ----------
 
     s1, s2: Spectrum objects
+        :py:class:`~radis.spectrum.spectrum.Spectrum`
 
     var: str
         spectral quantity 
 
-    wunit: 'nm', 'cm-1'
-        waveunit to compare in
+    wunit: ``'nm'``, ``'cm-1'``, ``'nm_vac'``
+        waveunit to compare in: wavelength air, wavenumber, wavelength vacuum
 
     Iunit: str
         if ``'default'`` use s1 unit for variable var
-
-    medium: 'air', 'vacuum', default'
-        propagating medium to compare in (if in wavelength)
 
     Notes
     -----
@@ -181,14 +179,14 @@ def get_ratio(s1, s2, var,
     '''
     
     w1, I1, w2, I2 = _get_defaults(s1, s2, var=var, wunit=wunit, Iunit=Iunit,
-                                   medium=medium, assert_same_wavelength=not resample)
+                                   assert_same_wavelength=not resample)
 
     # basically w1, I1 - I2 (on same range)
     return curve_divide(w1, I1, w2, I2)
 
 
 def get_distance(s1, s2, var, 
-                 wunit='default', Iunit='default', medium='default', resample=True):
+                 wunit='default', Iunit='default', resample=True):
     # type: (Spectrum, Spectrum, str, str, str, str, bool) -> np.array, np.array
     ''' Get a regularized Euclidian distance between two spectra ``s1`` and ``s2`` 
 
@@ -220,12 +218,13 @@ def get_distance(s1, s2, var,
     ----------
 
     s1, s2: Spectrum objects
+        :py:class:`~radis.spectrum.spectrum.Spectrum`
 
     var: str
         spectral quantity 
 
-    wunit: 'nm', 'cm-1'
-        waveunit to compare in
+    wunit: ``'nm'``, ``'cm-1'``, ``'nm_vac'``
+        waveunit to compare in: wavelength air, wavenumber, wavelength vacuum
 
     Iunit: str
         if ``'default'`` use s1 unit for variable var
@@ -252,7 +251,7 @@ def get_distance(s1, s2, var,
     # TODO: normalize with Imax, wmax 
 
     w1, I1, w2, I2 = _get_defaults(s1, s2, var=var, wunit=wunit, Iunit=Iunit,
-                                   medium=medium, assert_same_wavelength=not resample)
+                                   assert_same_wavelength=not resample)
 
     # euclidian distance from w1, I1
     return curve_distance(w1, I1, w2, I2, discard_out_of_bounds=True)
@@ -428,6 +427,7 @@ def get_residual_integral(s1, s2, var,
     ----------
 
     s1, s2: Spectrum objects
+        :py:class:`~radis.spectrum.spectrum.Spectrum`
 
     var: str
         spectral quantity
@@ -496,7 +496,7 @@ def get_residual_integral(s1, s2, var,
 
 
 def _get_defaults(s1, s2, var, 
-                  wunit='default', Iunit='default', medium='default',
+                  wunit='default', Iunit='default', 
                   assert_same_wavelength=False):
     # type: (Spectrum, Spectrum, str, str, str, bool) -> (np.array, np.array, np.array, np.array)
     ''' Returns w1, I1, w2, I2  in the same waveunit, unit and medium.
@@ -514,13 +514,11 @@ def _get_defaults(s1, s2, var,
     if wunit == 'default':
         wunit = s1.get_waveunit()
     wunit = cast_waveunit(wunit)
-    if medium == 'default':
-        medium = s1.conditions.get('medium', None)
 
     # Get data
     # ----
-    w1, I1 = s1.get(var, wunit=wunit, Iunit=Iunit, medium=medium)
-    w2, I2 = s2.get(var, wunit=wunit, Iunit=Iunit, medium=medium)
+    w1, I1 = s1.get(var, wunit=wunit, Iunit=Iunit)
+    w2, I2 = s2.get(var, wunit=wunit, Iunit=Iunit)
     
     if assert_same_wavelength:
         if not array_allclose(w1, w2):
@@ -531,7 +529,7 @@ def _get_defaults(s1, s2, var,
 
 
 def plot_diff(s1, s2, var=None, 
-              wunit='default', Iunit='default', medium='default',
+              wunit='default', Iunit='default', 
               resample=True, method='diff', diff_window=0, show_points=False,
               label1=None, label2=None, figsize=None, title=None, nfig=None,
               normalize=False, verbose=True, save=False, show=True,
@@ -553,14 +551,12 @@ def plot_diff(s1, s2, var=None,
         plot the first one in the Spectrum from ``'radiance'``, 
         ``'radiance_noslit'``, ``'transmittance'``, etc.
 
-    wunit: ``'default'``, ``'nm'``, ``'cm-1'``
-        if ``'default'``, use first spectrum wunit
+    wunit: ``'default'``, ``'nm'``, ``'cm-1'``, ``'nm_vac'``
+        wavespace unit:  wavelength air, wavenumber, wavelength vacuum. 
+        If ``'default'``, use first spectrum wunit
 
     Iunit: str
         if ``'default'``, use first spectrum unit
-
-    medium: ``'air'``, ``'vacuum'``, ``'default'``
-        if ``'default'``, use first spectrum propagating medium
 
     method: ``'distance'``, ``'diff'``, ``'ratio'``, or list of them.
         If ``'diff'``, plot difference of the two spectra.
@@ -713,8 +709,6 @@ def plot_diff(s1, s2, var=None,
                            "Cant use default unit. Specify unit in s.units['{0}'].".format(var))
     if wunit == 'default':
         wunit = s1.get_waveunit()
-    if medium == 'default':
-        medium = s1.conditions.get('medium', None)
         
     if isinstance(method, list):
         methods = method
@@ -744,15 +738,12 @@ def plot_diff(s1, s2, var=None,
         for method in methods:
             if not normalize:
                 if method == 'distance':
-                    wdiff, Idiff = get_distance(
-                        s1, s2, var=var, wunit=wunit, Iunit=Iunit, medium=medium)
+                    wdiff, Idiff = get_distance(s1, s2, var=var, wunit=wunit, Iunit=Iunit)
                 elif method == 'diff':
-                    wdiff, Idiff = get_diff(
-                        s1, s2, var=var, wunit=wunit, Iunit=Iunit, medium=medium, 
+                    wdiff, Idiff = get_diff(s1, s2, var=var, wunit=wunit, Iunit=Iunit, 
                         diff_window=diff_window)
                 elif method == 'ratio':
-                    wdiff, Idiff = get_ratio(
-                        s1, s2, var=var, wunit=wunit, Iunit=Iunit, medium=medium)
+                    wdiff, Idiff = get_ratio(s1, s2, var=var, wunit=wunit, Iunit=Iunit)
                 else:
                     raise ValueError('Unknown comparison method: {0}'.format(method))
                 wdiffs.append(wdiff)
@@ -763,8 +754,7 @@ def plot_diff(s1, s2, var=None,
                 elif method == 'diff':
                     wdiff, Idiff = curve_substract(w1, I1, w2, I2)
                 elif method == 'ratio':
-                    wdiff, Idiff = get_ratio(
-                        s1, s2, var=var, wunit=wunit, Iunit=Iunit, medium=medium)
+                    wdiff, Idiff = get_ratio(s1, s2, var=var, wunit=wunit, Iunit=Iunit)
                 else:
                     raise ValueError('Unknown comparison method: {0}'.format(method))
                 wdiffs.append(wdiff)
@@ -819,9 +809,9 @@ def plot_diff(s1, s2, var=None,
         ax0.plot(w1, I1, style, color='k', lw=3*lw_multiplier, label=label1)
         ax0.plot(w2, I2, style, color='r', lw=1*lw_multiplier, label=label2)
     else:
-        ax0.plot(*s1.get(var, wunit=wunit, Iunit=Iunit, medium=medium),
+        ax0.plot(*s1.get(var, wunit=wunit, Iunit=Iunit),
                  style, color='k', lw=3*lw_multiplier, label=label1)
-        ax0.plot(*s2.get(var, wunit=wunit, Iunit=Iunit, medium=medium),
+        ax0.plot(*s2.get(var, wunit=wunit, Iunit=Iunit),
                  style, color='r', lw=1*lw_multiplier, label=label2)
 
     Iunit = make_up(Iunit)  # cosmetic changes

--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -27,7 +27,8 @@ Routine Listings
 from __future__ import print_function, absolute_import, division, unicode_literals
 from radis.misc.arrays import array_allclose
 from radis.misc.curve import curve_substract, curve_distance, curve_divide
-from radis.spectrum.spectrum import Spectrum, make_up, cast_waveunit, is_spectrum
+from radis.spectrum.spectrum import Spectrum, is_spectrum
+from radis.spectrum.utils import format_xlabel, make_up, cast_waveunit
 from radis.misc.basics import compare_lists, compare_dict
 from six import string_types
 
@@ -532,9 +533,9 @@ def plot_diff(s1, s2, var=None,
               wunit='default', Iunit='default', 
               resample=True, method='diff', diff_window=0, show_points=False,
               label1=None, label2=None, figsize=None, title=None, nfig=None,
-              normalize=False, verbose=True, save=False, show=True,
+              normalize=False, verbose=True, save=False, show=True, 
               show_residual=False, lw_multiplier=1, diff_scale_multiplier=1,
-              discard_centile=0):
+              discard_centile=0, plot_medium=False):
     ''' Plot two spectra, and the difference between them. ``method=`` allows
     you to plot the absolute difference, ratio, or both. 
 
@@ -629,6 +630,10 @@ def plot_diff(s1, s2, var=None,
         a plot feature.
         Default ``0`` 
         
+    plot_medium: bool
+        if ``True`` and ``wunit`` are wavelengths, plot the propagation medium
+        in the xaxis label (air or vacuum). Default ``False``
+
     Returns
     -------
     
@@ -767,11 +772,7 @@ def plot_diff(s1, s2, var=None,
     # ----
 
     # Format units
-    wunit = cast_waveunit(wunit)
-    if wunit == 'cm-1':
-        xlabel = 'Wavenumber (cm-1)'
-    elif wunit == 'nm':
-        xlabel = 'Wavelength (nm)'
+    xlabel = format_xlabel(wunit, plot_medium)
 
     # Init figure
     set_style('origin')

--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -535,7 +535,7 @@ def plot_diff(s1, s2, var=None,
               label1=None, label2=None, figsize=None, title=None, nfig=None,
               normalize=False, verbose=True, save=False, show=True, 
               show_residual=False, lw_multiplier=1, diff_scale_multiplier=1,
-              discard_centile=0, plot_medium=False):
+              discard_centile=0, plot_medium='vacuum_only'):
     ''' Plot two spectra, and the difference between them. ``method=`` allows
     you to plot the absolute difference, ratio, or both. 
 
@@ -629,10 +629,13 @@ def plot_diff(s1, s2, var=None,
         Note that this does not change the values of the residual. It's just 
         a plot feature.
         Default ``0`` 
-        
-    plot_medium: bool
+    
+    plot_medium: bool, ``'vacuum_only'``
         if ``True`` and ``wunit`` are wavelengths, plot the propagation medium
-        in the xaxis label (air or vacuum). Default ``False``
+        in the xaxis label (``[air]`` or ``[vacuum]``). If ``'vacuum_only'``, 
+        plot only if ``wunit=='nm_vac'``. Default ``'vacuum_only'`` 
+        (prevents from inadvertently plotting spectra with different propagation 
+        medium on the same graph).
 
     Returns
     -------

--- a/radis/spectrum/models.py
+++ b/radis/spectrum/models.py
@@ -45,8 +45,9 @@ def calculated_spectrum(w, I, wunit='nm', Iunit='mW/cm2/sr/nm',
     I: np.array 
         intensity (no slit)
 
-    wunit: 'nm', 'cm-1'
-        wavespace unit
+    wunit: ``'nm'``, ``'cm-1'``, ``'nm_vac'``
+        wavespace unit: wavelength in air (``'nm'``), wavenumber 
+        (``'cm-1'``), or wavelength in vacuum (``'nm_vac'``). Default ``'nm'``. 
 
     Iunit: str
         intensity unit (can be 'counts', 'mW/cm2/sr/nm', etc...). Default
@@ -114,8 +115,9 @@ def transmittance_spectrum(w, T, wunit='nm', Tunit='I/I0',
     T: np.array 
         transmittance (no slit)
 
-    wunit: ``'nm'``, ``'cm-1'``
-        wavespace unit
+    wunit: ``'nm'``, ``'cm-1'``, ``'nm_vac'``
+        wavespace unit: wavelength in air (``'nm'``), wavenumber 
+        (``'cm-1'``), or wavelength in vacuum (``'nm_vac'``). Default ``'nm'``. 
 
     Iunit: str
         intensity unit. Default ``'I/I0'``
@@ -162,7 +164,7 @@ def transmittance_spectrum(w, T, wunit='nm', Tunit='I/I0',
                                name=name)
 
 
-def experimental_spectrum(w, I, wunit='nm', Iunit='counts', medium='air',
+def experimental_spectrum(w, I, wunit='nm', Iunit='counts', 
                           conditions={}, cond_units=None, name=None): # -> Spectrum:
     ''' Convert ``(w, I)`` into a :py:class:`~radis.spectrum.spectrum.Spectrum` 
     object that has unit conversion and plotting
@@ -179,8 +181,9 @@ def experimental_spectrum(w, I, wunit='nm', Iunit='counts', medium='air',
     I: np.array 
         intensity
 
-    wunit: 'nm', 'cm-1'
-        wavespace unit
+    wunit: ``'nm'``, ``'cm-1'``, ``'nm_vac'``
+        wavespace unit: wavelength in air (``'nm'``), wavenumber 
+        (``'cm-1'``), or wavelength in vacuum (``'nm_vac'``). Default ``'nm'``. 
 
     Iunit: str
         intensity unit (can be 'counts', 'mW/cm2/sr/nm', etc...). Default
@@ -188,9 +191,6 @@ def experimental_spectrum(w, I, wunit='nm', Iunit='counts', medium='air',
 
     Other Parameters
     ----------------
-
-    medium: 'air', 'vacuum'
-        which medium. Default 'air'
 
     conditions: dict
         (optional) calculation conditions to be stored with Spectrum
@@ -223,12 +223,7 @@ def experimental_spectrum(w, I, wunit='nm', Iunit='counts', medium='air',
     :func:`~radis.tools.database.load_spec`
 
     '''
-    
-    if 'medium' in conditions:
-        assert conditions['medium'] == medium
-    else:
-        conditions.update({'medium':medium})
-        
+
     return Spectrum.from_array(np.array(w), np.array(I), 'radiance',
                                waveunit=wunit, unit=Iunit,
                                conditions=conditions, cond_units=cond_units,

--- a/radis/spectrum/operations.py
+++ b/radis/spectrum/operations.py
@@ -57,7 +57,7 @@ from __future__ import print_function, absolute_import, division, unicode_litera
 #from radis.misc.curve import curve_substract, curve_add
 from radis.spectrum import Spectrum
 from radis.phys.convert import (cm2nm, nm2cm, cm2nm_air, nm_air2cm, air2vacuum, vacuum2air,
-                                dcm2dnm, dnm2dcm)
+                                dcm2dnm, dnm2dcm, dcm2dnm_air, dnm_air2dcm)
 from numpy import ones_like, hstack
 from warnings import warn
 
@@ -231,8 +231,7 @@ def PerfectAbsorber(s):
 # %% Change wavelength
     
 
-def crop(s, wmin=None, wmax=None, wunit=None, medium=None,
-         inplace=False):
+def crop(s, wmin=None, wmax=None, wunit=None, inplace=False):
     # type: (Spectrum, float, float, str, str, bool) -> Spectrum
     ''' Crop spectrum to ``wmin-wmax`` range in ``wunit``
     
@@ -245,13 +244,11 @@ def crop(s, wmin=None, wmax=None, wunit=None, medium=None,
     wmin, wmax: float, or None
         boundaries of spectral range (in ``wunit``)
         
-    wunit: ``'nm'``, ``'cm-1'``
-        which waveunit to use for ``wmin, wmax``. Default ``default``: 
-        just use the Spectrum wavespace. 
+        wunit: ``'nm'``, ``'cm-1'``, ``'nm_vac'``
+            which waveunit to use for ``wmin, wmax``. If ``default``: 
+            use the default Spectrum wavespace defined with 
+            :meth:`~radis.spectrum.spectrum.Spectrum.get_waveunit`. 
 
-    medium: 'air', vacuum'
-        necessary if cropping in 'nm'
-        
     Other Parameters
     ----------------
     
@@ -284,13 +281,10 @@ def crop(s, wmin=None, wmax=None, wunit=None, medium=None,
     if wunit is None:
         raise ValueError('Please precise unit for wmin and wmax with `unit=`')
     assert wunit in ['nm', 'cm-1']
-    if wunit == 'nm' and medium is None:
-        raise ValueError("Precise wavelength medium with medium='air' or "+\
-                         "medium='vacuum'")
     if (wmin is not None and wmax is not None) and wmin >= wmax:
         raise ValueError('wmin should be < wmax (Got: {0:.2f}, {1:.2f})'.format(
                 wmin, wmax))
-    
+
     if len(s._q)>0 and len(s._q_conv)>0:
         raise NotImplementedError('Cant crop this Spectrum as there are both convoluted '+\
                                   'and not convoluted quantities stored')
@@ -303,37 +297,50 @@ def crop(s, wmin=None, wmax=None, wunit=None, medium=None,
     if not inplace:
         s = s.copy()
     
-    # Convert wmin, wmax to Spectrum wavespace    
+    # Convert wmin, wmax to Spectrum wavespace  (stored_waveunit)  
     # (deal with cases where wavelength are given in 'air' or 'vacuum')
     # TODO @dev: rewrite with wunit='cm-1', 'nm_air', 'nm_vac'
-    waveunit = s.get_waveunit()
+    stored_waveunit = s.get_waveunit()
     wmin0, wmax0 = wmin, wmax
-    if wunit == 'nm' and waveunit == 'cm-1':
-        if medium == 'air':
-            if wmax0: wmin = nm_air2cm(wmax0)   # reverted
-            if wmin0: wmax = nm_air2cm(wmin0)   # reverted
+    if stored_waveunit == 'cm-1':
+        # convert wmin, wmax to wavenumber
+        if wunit == 'nm':
+            if wmax0: wmin = nm_air2cm(wmax0)   # note: min/max inverted
+            if wmin0: wmax = nm_air2cm(wmin0)   # note: min/max inverted
+        elif wunit == 'nm_vac':
+            if wmax0: wmin = nm2cm(wmax0)   # note: min/max inverted
+            if wmin0: wmax = nm2cm(wmin0)   # note: min/max inverted
+        elif wunit == 'cm-1':
+            pass
         else:
-            if wmax0: wmin = nm2cm(wmax0)   # reverted
-            if wmin0: wmax = nm2cm(wmin0)   # reverted
-    elif wunit == 'cm-1' and waveunit == 'nm':
-        if s.get_medium() == 'air':
-            if wmax0: wmin = cm2nm_air(wmax0)   # nm in air
-            if wmin0: wmax = cm2nm_air(wmin0)   # nm in air
-        else:
-            if wmax0: wmin = cm2nm(wmax0)   # get nm in vacuum
-            if wmin0: wmax = cm2nm(wmin0)   # get nm in vacuum
-    elif wunit == 'nm' and waveunit == 'nm':
-        if s.get_medium() == 'air' and medium == 'vacuum':
-            # convert from given medium ('vacuum') to spectrum medium ('air')
+            raise ValueError(wunit)
+    elif stored_waveunit == 'nm':
+        # convert wmin, wmax to wavelength air
+        if wunit == 'nm':
+            pass
+        elif wunit == 'nm_vac':
             if wmin0: wmin = vacuum2air(wmin0)
             if wmax0: wmax = vacuum2air(wmax0)
-        elif s.get_medium() == 'vacuum' and medium == 'air':
-            # the other way around
+        elif wunit == 'cm-1':
+            if wmax0: wmin = cm2nm_air(wmax0)   # note: min/max inverted
+            if wmin0: wmax = cm2nm_air(wmin0)   # note: min/max inverted
+        else:
+            raise ValueError(wunit)
+    elif stored_waveunit == 'nm_vac':
+        # convert wmin, wmax to wavelength vacuum
+        if wunit == 'nm':
             if wmin0: wmin = air2vacuum(wmin0)
             if wmax0: wmax = air2vacuum(wmax0)
+        elif wunit == 'nm_vac':
+            pass
+        elif wunit == 'cm-1':
+            if wmax0: wmin = cm2nm(wmax0)   # note: min/max inverted
+            if wmin0: wmax = cm2nm(wmin0)   # note: min/max inverted
+        else:
+            raise ValueError(wunit)
     else:
-        assert wunit == waveunit           # correct wmin, wmax
-    
+        raise ValueError(stored_waveunit)
+
     # Crop non convoluted
     if len(s._q)>0:
         b = ones_like(s._q['wavespace'], dtype=bool)
@@ -417,7 +424,7 @@ def multiply(s, coef, var=None, inplace=False):
 
     return s
 
-def add_constant(s, cst, unit=None, var=None, wunit='nm', inplace=False):
+def add_constant(s, cst, unit=None, var=None, inplace=False):
     '''Return a new spectrum with a constant added to s[var]. 
     Equivalent to::
         
@@ -435,8 +442,6 @@ def add_constant(s, cst, unit=None, var=None, wunit='nm', inplace=False):
     var: str, or ``None``
         'radiance', 'transmittance', ... If ``None``, get the unique spectral
         quantity of ``s`` or raises an error if there is any ambiguity
-    wunit: str
-        'nm'or 'cm-1'
     inplace: bool
         if ``True``, modifies ``s`` directly. Else, returns a copy. 
         Default ``False``
@@ -475,7 +480,7 @@ def add_constant(s, cst, unit=None, var=None, wunit='nm', inplace=False):
 
     return s
 
-def add_array(s, a, unit=None, var=None, wunit='nm', inplace=False):
+def add_array(s, a, unit=None, var=None, inplace=False):
     '''Return a new spectrum with a constant added to s[var]. 
     Equivalent to::
         
@@ -494,8 +499,6 @@ def add_array(s, a, unit=None, var=None, wunit='nm', inplace=False):
     var: str, or ``None``
         'radiance', 'transmittance', ... If ``None``, get the unique spectral
         quantity of ``s`` or raises an error if there is any ambiguity
-    wunit: str
-        'nm'or 'cm-1'
     inplace: bool
         if ``True``, modifies ``s`` directly. Else, returns a copy. 
         Default ``False``
@@ -540,8 +543,7 @@ def add_array(s, a, unit=None, var=None, wunit='nm', inplace=False):
 
     return s
 
-def sub_baseline(s, left, right, unit=None, var=None, wunit='nm',
-                  inplace=False):
+def sub_baseline(s, left, right, unit=None, var=None, inplace=False):
     '''Return a new spectrum with a baseline substracted to s[var] 
     
     Parameters    
@@ -559,8 +561,6 @@ def sub_baseline(s, left, right, unit=None, var=None, wunit='nm',
     var: str
         'radiance', 'transmittance', ...  If ``None``, get the unique spectral
         quantity of ``s`` or raises an error if there is any ambiguity
-    wunit: str
-        'nm'or 'cm-1'
     inplace: bool
         if ``True``, modifies ``s`` directly. Else, returns a copy. 
         Default ``False``
@@ -605,7 +605,7 @@ def sub_baseline(s, left, right, unit=None, var=None, wunit='nm',
 
     return s
     
-def add_spectra(s1, s2, var=None, wunit='nm', force=False):
+def add_spectra(s1, s2, var=None, force=False):
     '''Return a new spectrum with ``s2`` added to ``s1``. 
     Equivalent to::
         
@@ -625,8 +625,6 @@ def add_spectra(s1, s2, var=None, wunit='nm', force=False):
         quantity to manipulate: 'radiance', 'transmittance', ... If ``None``, 
         get the unique spectral quantity of ``s1``, or the unique spectral
         quantity of ``s2``, or raises an error if there is any ambiguity
-    wunit: str
-        'nm'or 'cm-1'
         
     Returns    
     -------
@@ -660,34 +658,27 @@ def add_spectra(s1, s2, var=None, wunit='nm', force=False):
                          'you sure of what you are doing? See also `//` (MergeSlabs), `>` '+\
                          "(SerialSlabs) and `concat_spectra`. If you're sure, use `force=True`")
     
-    # Use same units 
-    Iunit = s1.units[var]            
-    wunit = s1.get_waveunit()
-    medium = s1.get_medium()
+    # Get s1 units 
+    Iunit1 = s1.units[var]            
+    wunit1 = s1.get_waveunit()
 
-    # Resample
-    if wunit == 'nm':
-        s2 = s2.resample(s1.get_wavelength(), 'nm', inplace=False)
-    elif wunit == 'cm-1':
-        s2 = s2.resample(s1.get_wavenumber(), 'cm-1', inplace=False)
-    else:
-        raise ValueError('Unexpected wunit: {0}'.format(wunit))
+    # Resample s2 on s1 
+    s2 = s2.resample(s1, inplace=False)
     
-    # Add
-    w1, I1 = s1.get(var=var, Iunit=Iunit, wunit=wunit, medium=medium)
-    w2, I2 = s2.get(var=var, Iunit=Iunit, wunit=wunit, medium=medium)
+    # Add, change output unit if needed.
+    w1, I1 = s1.get(var=var, Iunit=Iunit1, wunit=wunit1)
+    w2, I2 = s2.get(var=var, Iunit=Iunit1, wunit=wunit1)
 
     name = s1.get_name()+'+'+s2.get_name()
     
     sub = Spectrum.from_array(w1, I1 + I2, var, 
-                               waveunit=wunit, 
-                               unit=Iunit,
-                               conditions={'medium' : medium}, 
+                               waveunit=wunit1, 
+                               unit=Iunit1,
                                name=name)
 #    warn("Conditions of the left spectrum were copied in the substraction.", Warning)
     return sub
 
-def substract_spectra(s1, s2, var=None, wunit='nm'):
+def substract_spectra(s1, s2, var=None):
     '''Return a new spectrum with ``s2`` substracted from ``s1``. 
     Equivalent to::
         
@@ -702,9 +693,7 @@ def substract_spectra(s1, s2, var=None, wunit='nm'):
         quantity to manipulate: 'radiance', 'transmittance', ... If ``None``, 
         get the unique spectral quantity of ``s1``, or the unique spectral
         quantity of ``s2``, or raises an error if there is any ambiguity
-    wunit: str
-        'nm'or 'cm-1'
-        
+
     Returns    
     -------
     
@@ -732,28 +721,21 @@ def substract_spectra(s1, s2, var=None, wunit='nm'):
         raise KeyError('Variable {0} not in Spectrum {1}'.format(var, s1.get_name()))
     
     # Use same units 
-    Iunit = s1.units[var]            
-    wunit = s1.get_waveunit()
-    medium = s1.get_medium()
+    Iunit1 = s1.units[var]            
+    wunit1 = s1.get_waveunit()
 
-    # Resample
-    if wunit == 'nm':
-        s2 = s2.resample(s1.get_wavelength(), 'nm', inplace=False)
-    elif wunit == 'cm-1':
-        s2 = s2.resample(s1.get_wavenumber(), 'cm-1', inplace=False)
-    else:
-        raise ValueError('Unexpected wunit: {0}'.format(wunit))
+    # Resample s2 on s1 
+    s2 = s2.resample(s1, inplace=False)
     
     # Substract
-    w1, I1 = s1.get(var=var, Iunit=Iunit, wunit=wunit, medium=medium)
-    w2, I2 = s2.get(var=var, Iunit=Iunit, wunit=wunit, medium=medium)
+    w1, I1 = s1.get(var=var, Iunit=Iunit1, wunit=wunit1)
+    w2, I2 = s2.get(var=var, Iunit=Iunit1, wunit=wunit1)
 
     name = s1.get_name()+'-'+s2.get_name()
     
     sub = Spectrum.from_array(w1, I1 - I2, var, 
-                               waveunit=wunit, 
-                               unit=Iunit,
-                               conditions={'medium' : medium}, 
+                               waveunit=wunit1, 
+                               unit=Iunit1,
                                name=name)
 #    warn("Conditions of the left spectrum were copied in the substraction.", Warning)
     return sub
@@ -819,20 +801,19 @@ def concat_spectra(s1, s2, var=None):
              '(SerialSlabs)')
     
     # Use same units 
-    Iunit = s1.units[var]            
-    wunit = s1.get_waveunit()
-    medium = s1.get_medium()
+    Iunit1 = s1.units[var]            
+    wunit1 = s1.get_waveunit()
 
     # Get the value, on the same wunit)
     w1, I1 = s1.get(var=var, copy=False)  # @dev: faster to just get the stored value. 
                                           # it's copied in hstack() below anyway). 
-    w2, I2 = s2.get(var=var, Iunit=Iunit, wunit=wunit, medium=medium)
+    w2, I2 = s2.get(var=var, Iunit=Iunit1, wunit=wunit1)
     
     if not (w1.max() < w2.min() or w2.max() > w1.min()):
         raise ValueError("You cannot use concat_spectra for overlapping spectral ranges. "+\
                          "Got: {0:.2f}-{1:.2f} and {2:.2f}-{3:.2f} {4}. ".format(w1.min(), w1.max(),
                                                                w2.min(), w2.max(),
-                                                               wunit)+\
+                                                               wunit1)+\
                          "Use MergeSlabs instead, with the correct `out=` parameter "+\
                          "for your case")
                          
@@ -842,9 +823,8 @@ def concat_spectra(s1, s2, var=None):
     name = s1.get_name()+'&'+s2.get_name()     # use "&" instead of "+" 
     
     concat = Spectrum.from_array(w_tot, I_tot, var, 
-                               waveunit=wunit, 
-                               unit=Iunit,
-                               conditions={'medium' : medium}, 
+                               waveunit=wunit1, 
+                               unit=Iunit1,
                                name=name)
     
     return concat
@@ -883,21 +863,54 @@ def offset(s, offset, unit, name=None, inplace=False):
     has_var = len(s._q)>0
     has_conv_var = len(s._q_conv)>0
     
-    # Convert to correct unit:
-    if unit == 'nm' and s.get_waveunit() == 'cm-1':
-        # Note @EP: technically we should check the medium is air or vacuum...  TODO
-        # Note @EP: here we're offsetting by a constant value in 'cm-1', which is
-        # not a constant value in 'nm'. We end of with offset as an array 
-        if has_var: offset_q = - dnm2dcm(offset, s.get_wavelength(which='non_convoluted'))  # this is an array
-        if has_conv_var: offset_qconv = - dnm2dcm(offset, s.get_wavelength(which='convoluted'))  # this is an array
-    elif unit == 'cm-1' and s.get_waveunit() == 'nm':
-        if has_var: offset_q = - dcm2dnm(offset, s.get_wavenumber(which='non_convoluted'))  # this is an array
-        if has_conv_var: offset_qconv = - dcm2dnm(offset, s.get_wavenumber(which='convoluted'))  # this is an array
+    stored_waveunit = s.get_waveunit()
+    
+    # Convert offset to correct unit:
+    if stored_waveunit == 'cm-1':
+        if unit == 'nm':
+            # Note @EP: here we're offsetting by a constant value in 'nm', which is
+            # not a constant value in 'cm-1'. The offset is an array 
+            if has_var: offset_q = - dnm_air2dcm(offset, s.get_wavelength(which='non_convoluted'))  # this is an array
+            if has_conv_var: offset_qconv = - dnm_air2dcm(offset, s.get_wavelength(which='convoluted'))  # this is an array
+        elif unit == 'nm_vac':
+            if has_var: offset_q = - dnm2dcm(offset, s.get_wavelength(which='non_convoluted'))  # this is an array
+            if has_conv_var: offset_qconv = - dnm2dcm(offset, s.get_wavelength(which='convoluted'))  # this is an array
+        elif unit == 'cm-1':
+            if has_var: offset_q = offset
+            if has_conv_var: offset_qconv = offset
+        else:
+            raise ValueError(unit)
+    elif stored_waveunit == 'nm':  # wavelength air
+        if unit == 'nm':
+            if has_var: offset_q = offset
+            if has_conv_var: offset_qconv = offset
+        elif unit == 'nm_vac':
+            # Note @EP: strictly speaking, the offset should change a little bit
+            # as nm_vac > nm depends on the wavelength. Neglected here. # TODO ? 
+            if has_var: offset_q = offset
+            if has_conv_var: offset_qconv = offset
+        elif unit == 'cm-1':
+            if has_var: offset_q = - dcm2dnm_air(offset, s.get_wavenumber(which='non_convoluted'))  # this is an array
+            if has_conv_var: offset_qconv = - dcm2dnm_air(offset, s.get_wavenumber(which='convoluted'))  # this is an array
+        else:
+            raise ValueError(unit)
+    elif stored_waveunit == 'nm_vac':  # wavelength vacuum
+        if unit == 'nm':
+            # Note @EP: strictly speaking, the offset should change a little bit
+            # as nm > nm_vac depends on the wavelength. Neglected here. # TODO ? 
+            if has_var: offset_q = offset
+            if has_conv_var: offset_qconv = offset
+        elif unit == 'nm_vac':
+            if has_var: offset_q = offset
+            if has_conv_var: offset_qconv = offset
+        elif unit == 'cm-1':
+            if has_var: offset_q = - dcm2dnm(offset, s.get_wavenumber(which='non_convoluted'))  # this is an array
+            if has_conv_var: offset_qconv = - dcm2dnm(offset, s.get_wavenumber(which='convoluted'))  # this is an array
+        else:
+            raise ValueError(unit)
     else:
-        assert unit == s.get_waveunit()
-        if has_var: offset_q = offset
-        if has_conv_var: offset_qconv = offset
-        
+        raise ValueError(stored_waveunit)
+    
     if not inplace:
         s = s.copy()
         
@@ -913,13 +926,17 @@ def offset(s, offset, unit, name=None, inplace=False):
         
     return s
 
-def get_baseline(s, var='radiance', wunit='nm', medium='air', Iunit=None):
+def get_baseline(s, var='radiance', Iunit=None):
     '''Calculate and returns a baseline 
 
     Parameters    
     ----------
     s: Spectrum
         Spectrum which needs a baseline
+        
+    var: str
+        on which spectral quantity to read the baseline. Default ``'radiance'``. 
+        See :py:data:`~radis.spectrum.utils.SPECTRAL_QUANTITIES`
 
     Returns    
     -------
@@ -932,12 +949,10 @@ def get_baseline(s, var='radiance', wunit='nm', medium='air', Iunit=None):
     :py:func:`~radis.spectrum.operations.sub_baseline`
     '''
     import peakutils 
-    w1, I1 = s.get(var=var, Iunit=Iunit, wunit=wunit, medium=medium)
+    w1, I1 = s.get(var=var, Iunit=Iunit)
     baseline = peakutils.baseline(I1, deg=1, max_it = 500)
     baselineSpectrum = Spectrum.from_array(w1, baseline, var, 
-                               waveunit=wunit, 
                                unit=Iunit,
-                               conditions={'medium' : medium}, 
                                name=s.get_name()+'_baseline')
     return baselineSpectrum
 # %% Tests

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -49,7 +49,8 @@ from radis.phys.convert import conv2, cm2nm, nm2cm
 from radis.phys.units import Q_, convert_universal
 from radis.phys.air import vacuum2air, air2vacuum
 from radis.spectrum.utils import (CONVOLUTED_QUANTITIES, NON_CONVOLUTED_QUANTITIES, WAVESPACE,
-                                  make_up, cast_waveunit, print_conditions)
+                                  make_up, cast_waveunit, print_conditions,
+                                  format_xlabel)
 from radis.spectrum.rescale import update, rescale_path_length, rescale_mole_fraction
 #from radis.lbl.base import print_conditions
 from radis.misc.arrays import (evenly_distributed, count_nans, 
@@ -1398,8 +1399,8 @@ class Spectrum(object):
                 s2.plot(nfig='same')
 
         plot_medium: bool
-            if ``True`` and ``wunit`` are wavelengths, plot whether it's air 
-            or vacuum. Default ``False``
+            if ``True`` and ``wunit`` are wavelengths, plot the propagation medium
+            in the xaxis label (air or vacuum). Default ``False``
 
         yscale: 'linear', 'log'
             plot yscale
@@ -1470,20 +1471,7 @@ class Spectrum(object):
         x, y = self.get(var, wunit=wunit, Iunit=Iunit)
 
         # Get labels
-        if wunit == 'cm-1':
-            xlabel = 'Wavenumber (cm-1)'
-        else:  # wunit == 'nm'
-            if plot_medium:
-                if wunit == 'nm':
-                    wmedium = ' [air]'
-                elif wunit == 'nm_vac':
-                    wmedium = ' [vacuum]'
-                else:
-                    raise ValueError(wunit)
-            else:
-                wmedium = ''
-            xlabel = 'Wavelength {0}(nm)'.format(wmedium)
-        xlabel = make_up(xlabel)
+        xlabel=format_xlabel(wunit, plot_medium)
 
         if Iunit == 'default':
             try:

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -1363,7 +1363,7 @@ class Spectrum(object):
         return items
 
     def plot(self, var=None, wunit='default', Iunit='default', show_points=False,
-             nfig=None, yscale='linear', plot_medium=False,
+             nfig=None, yscale='linear', plot_medium='vacuum_only',
              normalize=False, force=False,
              **kwargs):
         ''' Plot a :py:class:`~radis.spectrum.spectrum.Spectrum` object. 
@@ -1400,9 +1400,12 @@ class Spectrum(object):
                 s1.plot()
                 s2.plot(nfig='same')
 
-        plot_medium: bool
+        plot_medium: bool, ``'vacuum_only'``
             if ``True`` and ``wunit`` are wavelengths, plot the propagation medium
-            in the xaxis label (air or vacuum). Default ``False``
+            in the xaxis label (``[air]`` or ``[vacuum]``). If ``'vacuum_only'``, 
+            plot only if ``wunit=='nm_vac'``. Default ``'vacuum_only'`` 
+            (prevents from inadvertently plotting spectra with different propagation 
+            medium on the same graph).
 
         yscale: 'linear', 'log'
             plot yscale

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -122,10 +122,11 @@ class Spectrum(object):
         linestrength in SpectrumFactory). Refer to the code to know what they mean
         (and their units)
 
-    wavespace: ``'nm'`` or ``'cm-1'``, or ``None``
-        define whether wavenumber or wavelength are used in 'quantities' tuples.
+    wavespace: ``'nm'``, ``'cm-1'``, ``'nm_vac'`` or ``None``
+        wavelength in air (``'nm'``), wavenumber (``'cm-1'``), or wavelength in vacuum (``'nm_vac'``). 
         Quantities should be evenly distributed along this space for fast
         convolution with the slit function
+        If ``None``, ``'wavespace'`` must be defined in ``conditions``. 
         (non-uniform slit function is not implemented anyway... )
         Defaults None (but raises an error if wavespace is not defined in
         conditions neither)
@@ -329,8 +330,8 @@ class Spectrum(object):
             spectral quantity name
 
         waveunit: ``'nm'``, ``'cm-1'``, ``'nm_vac'``
-            unit of waverange: wavelength in air, wavenumber, or wavelength in 
-            vacuum.
+            unit of waverange:         wavelength in air (``'nm'``), wavenumber 
+            (``'cm-1'``), or wavelength in vacuum (``'nm_vac'``). 
 
         unit: str
             spectral quantity unit (arbitrary). Ex: 'mW/cm2/sr/nm' for radiance_noslit
@@ -432,8 +433,8 @@ class Spectrum(object):
             spectral quantity name
 
         waveunit: ``'nm'``, ``'cm-1'``, ``'nm_vac'``
-            unit of waverange: wavelength in air, wavenumber, or wavelength in 
-            vacuum.
+            unit of waverange: wavelength in air (``'nm'``), wavenumber 
+            (``'cm-1'``), or wavelength in vacuum (``'nm_vac'``). 
 
         unit: str
             spectral quantity unit
@@ -580,7 +581,8 @@ class Spectrum(object):
             the :meth:`~radis.spectrum.spectrum.Spectrum.get_vars` method.
 
         wunit: ``'nm'``, ``'cm'``, ``'nm_vac'``.
-            wavespace unit: wavenumber, wavelength in air, wavelength in vacuum.
+            wavespace unit: wavelength in air (``'nm'``), wavenumber 
+            (``'cm-1'``), or wavelength in vacuum (``'nm_vac'``). 
             Default ``nm`` (wavelength in air).
 
         Iunit: unit for variable ``var``

--- a/radis/spectrum/utils.py
+++ b/radis/spectrum/utils.py
@@ -139,6 +139,24 @@ def make_up(label):
     
     return label
 
+def format_xlabel(wunit, plot_medium):
+    ''' Used by :py:meth:`radis.spectrum.spectrum.Spectrum.plot` and 
+    :py:func:`radis.spectrum.compare.plot_diff`
+    '''
+    if wunit == 'cm-1':
+        xlabel = 'Wavenumber (cm-1)'
+    else:  # wunit == 'nm'
+        if plot_medium:
+            if wunit == 'nm':
+                wmedium = ' [air]'
+            elif wunit == 'nm_vac':
+                wmedium = ' [vacuum]'
+            else:
+                raise ValueError(wunit)
+        else:
+            wmedium = ''
+        xlabel = 'Wavelength {0}(nm)'.format(wmedium)
+    return make_up(xlabel)
 
 def print_conditions(conditions, units,
                      phys_param_list=PHYSICAL_PARAMS, info_param_list=INFORMATIVE_PARAMS):

--- a/radis/spectrum/utils.py
+++ b/radis/spectrum/utils.py
@@ -16,6 +16,11 @@ from radis.misc.basics import partition
 # Waverange, wavespaces
 WAVENUM_UNITS = ['cm', 'cm-1', 'cm_1', 'wavenumber']
 WAVELEN_UNITS = ['nm', 'wavelength']
+WAVESPACE = ['nm', 'nm_vac', 'cm-1']
+''' list: wavespace:
+- ``'nm'``: wavelength (in air)
+- ``'nm_vac'``: wavelength (in vacuum)
+- ``'cm-1'``: wavenumber'''
 
 # Spectral quantities
 CONVOLUTED_QUANTITIES = ['radiance', 'transmittance', 'emissivity']
@@ -25,6 +30,9 @@ NON_CONVOLUTED_QUANTITIES = ['radiance_noslit', 'transmittance_noslit',
                              'absorbance', 'abscoeff',
                              'abscoeff_continuum', 'emissivity_noslit']
 '''list: name of spectral quantities not convolved with slit function'''
+SPECTRAL_QUANTITIES = CONVOLUTED_QUANTITIES + NON_CONVOLUTED_QUANTITIES
+'''list: all spectral quantities defined in a :class:`~radis.spectrum.spectrum.Spectrum` 
+object'''
 
 # note: it is hardcoded (and needed) that quantities that are convoluted are
 # generated from a non convoluted quantity with the same name + _noslit

--- a/radis/spectrum/utils.py
+++ b/radis/spectrum/utils.py
@@ -142,20 +142,37 @@ def make_up(label):
 def format_xlabel(wunit, plot_medium):
     ''' Used by :py:meth:`radis.spectrum.spectrum.Spectrum.plot` and 
     :py:func:`radis.spectrum.compare.plot_diff`
+
+    Parameters
+    ----------
+    
+    wunit: ``'default'``, ``'nm'``, ``'cm-1'``, ``'nm_vac'``, 
+        wavelength air, wavenumber, or wavelength vacuum. If ``'default'``, 
+        Spectrum :py:meth:`~radis.spectrum.spectrum.Spectrum.get_waveunit` is used.
+
+    plot_medium: bool, ``'vacuum_only'``
+        if ``True`` and ``wunit`` are wavelengths, plot the propagation medium
+        in the xaxis label (``[air]`` or ``[vacuum]``). If ``'vacuum_only'``, 
+        plot only if ``wunit=='nm_vac'``. Default ``'vacuum_only'`` 
+        (prevents from inadvertently plotting spectra with different propagation 
+        medium on the same graph).
+
     '''
     if wunit == 'cm-1':
         xlabel = 'Wavenumber (cm-1)'
-    else:  # wunit == 'nm'
-        if plot_medium:
-            if wunit == 'nm':
-                wmedium = ' [air]'
-            elif wunit == 'nm_vac':
-                wmedium = ' [vacuum]'
-            else:
-                raise ValueError(wunit)
+    elif wunit == 'nm':
+        if plot_medium and plot_medium != 'vacuum_only':
+            xlabel = 'Wavelength [air] (nm)'
         else:
-            wmedium = ''
-        xlabel = 'Wavelength {0}(nm)'.format(wmedium)
+            xlabel = 'Wavelength (nm)'
+    elif wunit == 'nm_vac':
+        if plot_medium and plot_medium != 'vacuum_only':
+            xlabel = 'Wavelength [vacuum] (nm)'
+        else:
+            xlabel = 'Wavelength (nm)'
+    else:
+        raise ValueError(wunit)
+
     return make_up(xlabel)
 
 def print_conditions(conditions, units,

--- a/radis/spectrum/utils.py
+++ b/radis/spectrum/utils.py
@@ -14,8 +14,11 @@ from radis.misc.basics import partition
 # %% Definitions
 
 # Waverange, wavespaces
+# ... aliases:
 WAVENUM_UNITS = ['cm', 'cm-1', 'cm_1', 'wavenumber']
 WAVELEN_UNITS = ['nm', 'wavelength']
+WAVELENVAC_UNITS = ['nm_vac', 'nm_vacuum']
+# ... internal names
 WAVESPACE = ['nm', 'nm_vac', 'cm-1']
 ''' list: wavespace:
 - ``'nm'``: wavelength (in air)
@@ -98,11 +101,13 @@ def cast_waveunit(unit, force_match=True):
     ''' Standardize unit formats '''
     if unit in WAVELEN_UNITS:
         return 'nm'
+    if unit in WAVELENVAC_UNITS:
+        return 'nm_vac'
     elif unit in WAVENUM_UNITS:
         return 'cm-1'
     elif force_match:
-        raise ValueError('Unknown wavespace unit: {0}. Should be one of {1}'.format(unit,
-                                                                                    WAVELEN_UNITS+WAVENUM_UNITS))
+        raise ValueError('Unknown wavespace unit: {0}. Should be one of {1}'.format(
+                unit, WAVELEN_UNITS+WAVELENVAC_UNITS+WAVENUM_UNITS))
     else:
         return unit  # dont convert
 

--- a/radis/test/lbl/test_factory.py
+++ b/radis/test/lbl/test_factory.py
@@ -342,7 +342,7 @@ def test_media_line_shift(plot=False, verbose=True, warnings=True, *args, **kwar
                     lw=2, color='r', label='Air')
 
         # ... there should be about ~1.25 nm shift at 4.5 µm:
-        assert np.isclose(sv.get('radiance_noslit', wunit='nm')[0][0] -
+        assert np.isclose(sv.get('radiance_noslit', wunit='nm_vac')[0][0] -
                           sa.get('radiance_noslit', wunit='nm')[0][0],
                           1.2540436086346745)
 

--- a/radis/test/lbl/test_factory.py
+++ b/radis/test/lbl/test_factory.py
@@ -323,27 +323,20 @@ def test_media_line_shift(plot=False, verbose=True, warnings=True, *args, **kwar
         sf.warnings['GaussianBroadeningWarning'] = 'ignore'
         sf.load_databank('HITRAN-CO-TEST')
 
-        # Calculate in Vacuum
-        sv = sf.eq_spectrum(2000)
-        assert sv.conditions['medium'] == 'vacuum'
-
-        # Calculate in Air
-        # change input (not recommended to access this directly!)
-        sf.input.medium = 'air'
-        sa = sf.eq_spectrum(2000)
-        assert sa.conditions['medium'] == 'air'
+        # Calculate a spectrum
+        s = sf.eq_spectrum(2000)
 
         # Compare
         if plot:
             fig = plt.figure(fig_prefix+'Propagating media line shift')
-            sv.plot('radiance_noslit', nfig=fig.number, lw=2, label='Vacuum')
+            s.plot('radiance_noslit', wunit='nm_vac', nfig=fig.number, lw=2, label='Vacuum')
             plt.title('CO spectrum (2000 K)')
-            sa.plot('radiance_noslit', nfig=fig.number,
+            s.plot('radiance_noslit', wunit='nm', nfig=fig.number,
                     lw=2, color='r', label='Air')
 
         # ... there should be about ~1.25 nm shift at 4.5 µm:
-        assert np.isclose(sv.get('radiance_noslit', wunit='nm_vac')[0][0] -
-                          sa.get('radiance_noslit', wunit='nm')[0][0],
+        assert np.isclose(s.get('radiance_noslit', wunit='nm_vac')[0][0] -
+                          s.get('radiance_noslit', wunit='nm')[0][0],
                           1.2540436086346745)
 
     except DatabankNotFound as err:

--- a/radis/test/lbl/test_factory.py
+++ b/radis/test/lbl/test_factory.py
@@ -181,18 +181,16 @@ def test_spec_generation(plot=True, verbose=2, warnings=True, *args, **kwargs):
         # Compare with harcoded results
         # ... code previously used to export hardcoded results:
         # ... and header contains all input conditions:
-#        np.savetxt('output.txt', np.vstack(s.get('abscoeff', wunit='nm', medium='air')).T[::10])
+#        np.savetxt('output.txt', np.vstack(s.get('abscoeff', wunit='nm')).T[::10])
 #        print(s)
         # ................
         from radis.test.utils import getTestFile
         wref, Iref = np.loadtxt(getTestFile(
             'CO2abscoeff_300K_4150_4400nm.txt')).T
-        match_reference = np.allclose(
-            s.get('abscoeff', wunit='nm', medium='air')[1][::10], Iref)
+        match_reference = np.allclose(s.get('abscoeff', wunit='nm')[1][::10], Iref)
         if not match_reference:
             # give some more information before raising error
-            printm('Error: {0:.2f}%'.format(np.mean(abs(s.get('abscoeff', wunit='nm',
-                                                              medium='air')[1][::10]/Iref-1))*100))
+            printm('Error: {0:.2f}%'.format(np.mean(abs(s.get('abscoeff', wunit='nm')[1][::10]/Iref-1))*100))
             # Store the faulty spectrum
             s.store('test_factory_failed_{0}.spec'.format(radis.get_version()),
                     if_exists_then='replace')

--- a/radis/test/lbl/test_spectrum.py
+++ b/radis/test/lbl/test_spectrum.py
@@ -221,8 +221,8 @@ def test_medium(plot=False, verbose=True, debug=False, warnings=True, *args, **k
 
         if plot:
             plt.figure(fig_prefix+'Propagating medium conversions')
-            s.plot(nfig='same', lw=3, medium='vacuum', label='vacuum')
-            s.plot(nfig='same', medium='air', label='air')
+            s.plot(wunit='nm_vac', nfig='same', lw=3, label='vacuum')
+            s.plot(wunit='nm', nfig='same', label='air')
 
         assert np.allclose(s.get_wavenumber(), s_air.get_wavenumber())
         assert np.allclose(s.get_wavelength(medium='vacuum'),

--- a/radis/test/phys/test_blackbody.py
+++ b/radis/test/phys/test_blackbody.py
@@ -57,7 +57,7 @@ def test_planck_nm(verbose=True, plot=True, *args, **kwargs):
     s = sPlanck(wavelength_min=300, wavelength_max=8000, T=T, eps=eps,
                 wstep=0.1)
 
-    w_nm = s.get_wavelength()
+    w_nm = s.get_wavelength(medium='vacuum')
     w_cm = s.get_wavenumber()
 
     Iunit_per_nm = 'W/sr/nm/m2'
@@ -90,7 +90,7 @@ def test_planck_nm(verbose=True, plot=True, *args, **kwargs):
 
     # Check that max is correct
     # hardcoded for 2200 K, epsilon = 0.36 (~1.3 µm)
-    assert I_nm.max() == 75.987331723070341
+    assert I_nm.max() == 75.98733181512608
 
     # Test planck and planck_wn
     assert np.allclose(planck(w_nm, T, eps, unit=Iunit_per_nm), I_nm)

--- a/radis/test/spectrum/test_spectrum.py
+++ b/radis/test/spectrum/test_spectrum.py
@@ -294,8 +294,8 @@ def test_resampling_function(verbose=True, plot=True, close_plots=True, *args, *
     s2 = s.copy()
     s2b = s.copy()
     s3 = s.copy()
-    s2.resample(np.linspace(4500, 4700, 10000), unit='nm', medium='vacuum')
-    s2b.resample(np.linspace(4500, 4700, 10000), unit='nm', medium='air')
+    s2.resample(np.linspace(4500, 4700, 10000), unit='nm_vac')
+    s2b.resample(np.linspace(4500, 4700, 10000), unit='nm')
     s3.resample(np.linspace(2127.2, 2227.7, 10000), unit='cm-1')
     s2.name = 'resampled in nm (vacuum)'
     s2b.name = 'resampled in nm (air)'

--- a/radis/test/spectrum/test_spectrum.py
+++ b/radis/test/spectrum/test_spectrum.py
@@ -180,8 +180,7 @@ def test_store_functions(verbose=True, *args, **kwargs):
         'CO_Tgas1500K_mole_fraction0.01.spec'), binary=True)
     s.update()
     try:
-        s.savetxt(temp_file, 'transmittance_noslit',
-                  wunit='nm', medium='vacuum')
+        s.savetxt(temp_file, 'transmittance_noslit', wunit='nm_vac')
         w, T = np.loadtxt(temp_file).T
     finally:
         os.remove(temp_file)

--- a/radis/test/spectrum/test_spectrum.py
+++ b/radis/test/spectrum/test_spectrum.py
@@ -186,8 +186,7 @@ def test_store_functions(verbose=True, *args, **kwargs):
     finally:
         os.remove(temp_file)
 
-    s2 = transmittance_spectrum(
-        w, T, wunit='nm', conditions={'medium': 'vacuum'})
+    s2 = transmittance_spectrum(w, T, wunit='nm_vac')
     assert s.compare_with(s2, spectra_only='transmittance_noslit', plot=False)
 
     # TODO: add test that ensures we can load a binary file without binary=True
@@ -210,8 +209,7 @@ def test_intensity_conversion(verbose=True, *args, **kwargs):
     w_cm = nm2cm(w_nm)
     I_nm = planck(w_nm, T=6000, unit='mW/sr/cm2/nm')
 
-    s = calculated_spectrum(w_nm, I_nm, wunit='nm', Iunit='mW/sr/cm2/nm',
-                            conditions={'medium': 'vacuum'})
+    s = calculated_spectrum(w_nm, I_nm, wunit='nm_vac', Iunit='mW/sr/cm2/nm',)
 
     # mW/sr/cm2/nm -> mW/sr/cm2/cm-1
     w, I = s.get('radiance_noslit', Iunit='mW/sr/cm2/cm_1')

--- a/radis/test/spectrum/test_spectrum.py
+++ b/radis/test/spectrum/test_spectrum.py
@@ -62,7 +62,6 @@ def test_spectrum_get_methods(verbose=True, plot=True, close_plots=True, *args, 
     assert s.get_power(
         unit='W/cm2/sr') == s.get_integral('radiance_noslit', Iunit='W/cm2/sr/nm')
     assert s.get_conditions()['Tgas'] == 1500
-    assert s.get_medium() == 'air'
     assert len(s.get_vars()) == 2
     assert s.is_at_equilibrium() == False
     assert s.is_optically_thin() == False

--- a/radis/test/tools/test_slit.py
+++ b/radis/test/tools/test_slit.py
@@ -60,8 +60,7 @@ def test_all_slit_shapes(FWHM=0.4, verbose=True, plot=True, close_plots=True, *a
     from radis.test.utils import getTestFile
     from radis.spectrum.spectrum import Spectrum
     s = Spectrum.from_txt(getTestFile('calc_N2C_spectrum_Trot1200_Tvib3000.txt'),
-                          quantity='radiance_noslit', waveunit='nm', unit='mW/cm2/sr/µm',
-                          conditions={'medium': 'air'})
+                          quantity='radiance_noslit', waveunit='nm', unit='mW/cm2/sr/µm')
     wstep = np.diff(s.get_wavelength())[0]
 
     # Plot all slits
@@ -174,8 +173,7 @@ def test_slit_unit_conversions_spectrum_in_nm(verbose=True, plot=True, close_plo
 
     s_nm = Spectrum.from_txt(getTestFile('calc_N2C_spectrum_Trot1200_Tvib3000.txt'),
                              quantity='radiance_noslit', waveunit='nm', unit='mW/cm2/sr/µm',
-                             conditions={'medium': 'air',
-                                         'self_absorption': False})
+                             conditions={'self_absorption': False})
 
     with catch_warnings():
         filterwarnings(
@@ -254,8 +252,7 @@ def test_against_specair_convolution(plot=True, close_plots=True, verbose=True, 
     # Plot calculated vs convolved with slit
     # Specair units: mW/cm2/sr/µm
     w, I = np.loadtxt(getTestFile('calc_N2C_spectrum_Trot1200_Tvib3000.txt')).T
-    s = calculated_spectrum(w, I, conditions={'Tvib': 3000, 'Trot': 1200,
-                                              'medium': 'air'},
+    s = calculated_spectrum(w, I, conditions={'Tvib': 3000, 'Trot': 1200},
                             Iunit='mW/cm2/sr/µm')
 
     if plot:
@@ -605,11 +602,9 @@ def test_resampling(rtol=1e-2, verbose=True, plot=True, warnings=True, *args, **
         plCO.load_databank('HITRAN-CO-TEST')
         sCO = plCO.eq_spectrum(Tgas=300)
 
-        w_nm, T_nm = sCO.get('transmittance_noslit', wunit='nm', medium='air')
-        w_nm, I_nm = sCO.get('radiance_noslit', wunit='nm',
-                             Iunit='mW/cm2/sr/nm')
-        sCO_nm = transmittance_spectrum(w_nm, T_nm, wunit='nm',
-                                        conditions={'medium': 'air'})  # a new spectrum stored in nm
+        w_nm, T_nm = sCO.get('transmittance_noslit', wunit='nm')
+        w_nm, I_nm = sCO.get('radiance_noslit', wunit='nm', Iunit='mW/cm2/sr/nm')
+        sCO_nm = transmittance_spectrum(w_nm, T_nm, wunit='nm')  # a new spectrum stored in nm
         # sCO_nm = theoretical_spectrum(w_nm, I_nm, wunit='nm', Iunit='mW/cm2/sr/nm') #  a new spectrum stored in nm
 
         if plot:

--- a/radis/test/tools/test_slit.py
+++ b/radis/test/tools/test_slit.py
@@ -660,38 +660,38 @@ def test_resampling(rtol=1e-2, verbose=True, plot=True, warnings=True, *args, **
 
 def _run_testcases(plot=True, close_plots=False, verbose=True, *args, **kwargs):
 
-#    # Validation
-#    test_against_specair_convolution(plot=plot, close_plots=close_plots, verbose=verbose,
-#                                     *args, **kwargs)
-#    
-#    # Different modes
-#    test_normalisation_mode(plot=plot, close_plots=close_plots, verbose=verbose, 
-#                            *args, **kwargs)
-#    
-#    # Resampling
-#    test_slit_energy_conservation(plot=plot, close_plots=close_plots, verbose=verbose, 
-#                                  *args, **kwargs)
-#    
-#    # Linear dispersion
-#    test_linear_dispersion_effect(plot=plot, close_plots=close_plots, verbose=verbose, 
-#                                  *args, **kwargs)
+    # Validation
+    test_against_specair_convolution(plot=plot, close_plots=close_plots, verbose=verbose,
+                                     *args, **kwargs)
+    
+    # Different modes
+    test_normalisation_mode(plot=plot, close_plots=close_plots, verbose=verbose, 
+                            *args, **kwargs)
+    
+    # Resampling
+    test_slit_energy_conservation(plot=plot, close_plots=close_plots, verbose=verbose, 
+                                  *args, **kwargs)
+    
+    # Linear dispersion
+    test_linear_dispersion_effect(plot=plot, close_plots=close_plots, verbose=verbose, 
+                                  *args, **kwargs)
     test_auto_correct_dispersion(plot=plot, close_plots=close_plots, verbose=verbose, 
                                  *args, **kwargs)
     
-#    
-#    # Different shapes
-#    test_all_slit_shapes(plot=plot, close_plots=close_plots,
-#                         verbose=verbose, *args, **kwargs)
-#    
-#    # Units
-#    test_slit_unit_conversions_spectrum_in_cm(
-#        verbose=verbose, plot=plot, close_plots=close_plots, *args, **kwargs)
-#    test_slit_unit_conversions_spectrum_in_nm(
-#        verbose=verbose, plot=plot, close_plots=close_plots, *args, **kwargs)
-#    test_convoluted_quantities_units(*args, **kwargs)
-#    
-#    
-#    test_resampling(plot=plot, verbose=verbose, *args, **kwargs)
+    
+    # Different shapes
+    test_all_slit_shapes(plot=plot, close_plots=close_plots,
+                         verbose=verbose, *args, **kwargs)
+    
+    # Units
+    test_slit_unit_conversions_spectrum_in_cm(
+        verbose=verbose, plot=plot, close_plots=close_plots, *args, **kwargs)
+    test_slit_unit_conversions_spectrum_in_nm(
+        verbose=verbose, plot=plot, close_plots=close_plots, *args, **kwargs)
+    test_convoluted_quantities_units(*args, **kwargs)
+    
+    
+    test_resampling(plot=plot, verbose=verbose, *args, **kwargs)
 
     return True
 

--- a/radis/test/validation/test_RADIS_vs_HAPI_line_broadening.py
+++ b/radis/test/validation/test_RADIS_vs_HAPI_line_broadening.py
@@ -154,8 +154,7 @@ def test_line_broadening(rtol=1e-3, verbose=True, plot=False, *args, **kwargs):
             fig.savefig('out/test_RADIS_vs_HAPI_line_broadening.pdf')
 
     # Compare integrals
-    diff = abs(s.get_integral('transmittance_noslit', medium='vacuum') /
-               s_hapi.get_integral('transmittance_noslit', medium='vacuum')-1)
+    diff = abs(s.get_integral('transmittance_noslit') / s_hapi.get_integral('transmittance_noslit')-1)
     b = diff < rtol
 
     if verbose:

--- a/radis/test/validation/test_validation_vs_specair_noneqCO.py
+++ b/radis/test/validation/test_validation_vs_specair_noneqCO.py
@@ -115,7 +115,8 @@ def test_validation_vs_specair(rtol=1e-2, verbose=True, plot=False,
                   title=r'T$_\mathregular{vib}$ 300 K, T$_\mathregular{rot}$ 300 K',
                   diff_window=int(0.02//wstep),  # compensate for small shifts in both codes. we're comparing intensities here.
                   lw_multiplier=1, #0.75, 
-                  medium='vacuum',
+                  wunit='nm_vac',
+                  plot_medium=True,
                   )
         plt.xlim((4500, 4900))
         if article_version:
@@ -126,7 +127,8 @@ def test_validation_vs_specair(rtol=1e-2, verbose=True, plot=False,
                   title=r'T$_\mathregular{vib}$ 2000 K, T$_\mathregular{rot}$ 300 K',
                   diff_window=int(0.02//wstep),  # compensate for small shifts in both codes. we're comparing intensities here.
                   lw_multiplier=1, #0.75, 
-                  medium='vacuum',
+                  wunit='nm_vac',
+                  plot_medium=True,
                   )
         plt.xlim((4500, 4900))
         if article_version:
@@ -137,7 +139,8 @@ def test_validation_vs_specair(rtol=1e-2, verbose=True, plot=False,
                   title=r'T$_\mathregular{vib}$ 300 K, T$_\mathregular{rot}$ 2000 K',
                   diff_window=int(0.02//wstep),  # compensate for small shifts in both codes. we're comparing intensities here.
                   lw_multiplier=1, #0.75, 
-                  medium='vacuum',
+                  wunit='nm_vac',
+                  plot_medium=True,
                   )
         plt.xlim((4500, 4900))
         if article_version:

--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -596,6 +596,28 @@ def _fix_format(file, sload):
             raise KeyError("Spectrum 'conditions' dict should at least have a " +
                            "'waveunit' key. Got: {0}".format(list(sload['conditions'].keys())))
 
+    # propagation medium removed in 0.9.22, replaced with 'nm' and 'nm_vac' in 
+    # waveunit directly
+    if 'medium' in sload['conditions']:
+        printr("File {0}".format(basename(file))+" has a deprecrated structure (key " +
+             "medium removed in 0.9.22). Fixing this time, but regenerate " +
+             "database ASAP.") #, DeprecationWarning)
+        # Fix: rewrite waveunit
+        assert 'waveunit' in sload['conditions']
+        if sload['conditions']['waveunit'] == 'cm-1':
+            pass   # does not change anything, no need to report
+        else: # wavelength is in air or vacuum. 
+            assert sload['conditions']['waveunit'] == 'nm'
+            if sload['conditions']['medium'] == 'air':
+                sload['conditions']['waveunit'] = 'nm'
+            elif sload['conditions']['medium'] == 'vacuum':
+                sload['conditions']['waveunit'] = 'nm_vac'
+            else:
+                raise ValueError(sload['conditions']['medium'])
+        # fix: delete medium key
+        del sload['conditions']['medium']
+        fixed = True
+
     if 'isotope_identifier' in sload['conditions']:
         printr("File {0}".format(basename(file))+" has a deprecrated structure (key " +
              "isotope_identifier replaced with isotope). Fixed this time, but regenerate " +


### PR DESCRIPTION
Refactor to Fix #49  

Formerly:

    'wavespace' = 'nm', 'cm-1'
    'medium' = 'air' / 'vacuum'

Now:

    'wavespace' = 'nm', 'cm-1', 'nm_vac' 

- [x] Spectrum object updated 
- [x] test updated
- [x] automatic fixing of old .spec files 

Added in 062c7ae1:

- [x] prevents from inadvertently plotting spectra with different propagation medium on the same graph