### PR TITLE
Deploy astropy units throughout radis : Take I

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,7 +108,7 @@ intersphinx_mapping = {'joblib': ('https://joblib.readthedocs.io/en/latest/', No
                        'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
                        'scipy': ('http://docs.scipy.org/doc/scipy/reference', None),
                        'cantera': ('https://www.cantera.org/documentation/docs-2.4/sphinx/html/', None),
-                       'pytexit': ('https://pytexit.readthedocs.io/en/latest/', None)
+                       'pytexit': ('https://pytexit.readthedocs.io/en/latest/', None),
                        'astropy': ('http://docs.astropy.org/en/stable/', None),
                        }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,6 +109,7 @@ intersphinx_mapping = {'joblib': ('https://joblib.readthedocs.io/en/latest/', No
                        'scipy': ('http://docs.scipy.org/doc/scipy/reference', None),
                        'cantera': ('https://www.cantera.org/documentation/docs-2.4/sphinx/html/', None),
                        'pytexit': ('https://pytexit.readthedocs.io/en/latest/', None)
+                       'astropy': ('http://docs.astropy.org/en/stable/', None),
                        }
 
 napoleon_google_docstring = False

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,18 +57,19 @@ Calculate a CO equilibrium spectrum from the HITRAN database, using the
 .. figure:: examples/co_spectrum_700K.png
     :scale: 60 %
 
-Calculate a CO *nonequilibrium* spectrum from the HITRAN database
-(on your first call, this will calculate and cache the CO(X) rovibrational
-energies): ::
+Calculate a CO *nonequilibrium* spectrum from the HITRAN database, with
+arbitrary `~astropy.units` (on your first call, this will calculate and 
+cache the CO(X) rovibrational energies): ::
 
-    s2 = calc_spectrum(1900, 2300,         # cm-1
+    from astropy import units as u
+    s2 = calc_spectrum(1900 / u.cm, 2300 / u.cm,
                       molecule='CO',
                       isotope='1,2,3',
-                      pressure=1.01325,   # bar
-                      Tvib=700,           # K
-                      Trot=300,           # K
+                      pressure=1.01325 * u.bar,
+                      Tvib=700 * u.K,
+                      Trot=300 * u.K,
                       mole_fraction=0.1, 
-                      path_length=1,      # cm
+                      path_length=1 * u.cm,
                       )
     s2.apply_slit(0.5, 'nm')
     s2.plot('radiance', nfig='same')    # compare with previous

--- a/docs/lbl/lbl.rst
+++ b/docs/lbl/lbl.rst
@@ -33,6 +33,7 @@ class, which is the core of RADIS line-by-line calculations.
 for the simple cases. 
 
 The :py:class:`~radis.lbl.factory.SpectrumFactory` allows you to :
+
 - calculate multiple spectra (batch processing) with a same line database 
 - edit the line database manually 
 - have access to intermediary calculation variables
@@ -42,22 +43,24 @@ To use the :py:class:`~radis.lbl.factory.SpectrumFactory`, first
 load your own line database with :py:meth:`~radis.lbl.loader.DatabankLoader.load_databank`, 
 and then calculate several spectra in batch using 
 :py:meth:`~radis.lbl.factory.SpectrumFactory.eq_spectrum` and 
-:py:meth:`~radis.lbl.factory.SpectrumFactory.non_eq_spectrum` ::
+:py:meth:`~radis.lbl.factory.SpectrumFactory.non_eq_spectrum`, 
+and `~astropy.units` ::
 
+    import astropy.units as u
     from radis import SpectrumFactory
-    sf = SpectrumFactory(wavelength_min=4150, 
-                         wavelength_max=4400,
-                         path_length=1,             # cm
-                         pressure=0.020,            # bar
+    sf = SpectrumFactory(wavelength_min=4165 * u.nm, 
+                         wavelength_max=4200 * u.nm,
+                         path_length=0.1 * u.m,
+                         pressure=20 * u.mbar,
                          molecule='CO2',
                          isotope='1,2', 
                          cutoff=1e-25,              # cm/molecule  
                          broadening_max_width=10,   # cm-1
                          )
-    sf.load_databank('CDSD-HITEMP')        # this database must be defined in ~/.radis
-    s1 = sf.eq_spectrum(Tgas=300)
-    s2 = sf.eq_spectrum(Tgas=2000)
-    s3 = sf.non_eq_spectrum(Tvib=2000, Trot=300)
+    sf.load_databank('HITRAN-CO2-TEST')        # this database must be defined in ~/.radis
+    s1 = sf.eq_spectrum(Tgas=300 * u.K)
+    s2 = sf.eq_spectrum(Tgas=2000 * u.K)
+    s3 = sf.non_eq_spectrum(Tvib=2000 * u.K, Trot=300 * u.K)
 
 .. _label_lbl_config_file:
 

--- a/radis/lbl/bands.py
+++ b/radis/lbl/bands.py
@@ -46,6 +46,7 @@ PRIVATE METHODS
 from __future__ import absolute_import
 from __future__ import print_function
 from warnings import warn
+import astropy.units as u
 from radis.lbl.broadening import BroadenFactory
 from radis.spectrum.equations import calc_radiance
 from radis.spectrum.spectrum import Spectrum
@@ -54,6 +55,7 @@ from radis.io.hitran import get_molecule, HITRAN_CLASS1
 from radis.misc.basics import is_float
 from radis.misc.progress_bar import ProgressBar
 from radis.misc.basics import all_in
+from radis.phys.units_astropy import convert_and_strip_units
 from radis.phys.constants import k_b
 from radis.lbl.loader import KNOWN_DBFORMAT, KNOWN_LVLFORMAT
 from radis.lbl.labels import (vib_lvl_name_hitran_class1, vib_lvl_name_hitran_class5,
@@ -150,6 +152,11 @@ class BandFactory(BroadenFactory):
         '''
 
         try:
+
+            # Convert units
+            Tgas = convert_and_strip_units(Tgas, u.K)
+            path_length = convert_and_strip_units(path_length, u.cm) 
+            pressure = convert_and_strip_units(pressure, u.bar)
 
             # update defaults
             if path_length is not None:
@@ -436,6 +443,13 @@ class BandFactory(BroadenFactory):
 
         try:
 
+            # Convert units
+            Tvib = convert_and_strip_units(Tvib, u.K)
+            Trot = convert_and_strip_units(Trot, u.K) 
+            Ttrans = convert_and_strip_units(Ttrans, u.K) 
+            path_length = convert_and_strip_units(path_length, u.cm) 
+            pressure = convert_and_strip_units(pressure, u.bar)
+
             # check inputs, update defaults
             if path_length is not None:
                 self.input.path_length = path_length
@@ -443,7 +457,9 @@ class BandFactory(BroadenFactory):
                 self.input.mole_fraction = mole_fraction
             if pressure is not None:
                 self.input.pressure_mbar = pressure*1e3
-            if not (is_float(Tvib) or isinstance(Tvib, tuple)):
+            if isinstance(Tvib, tuple):
+                Tvib = tuple([convert_and_strip_units(T, u.K) for T in Tvib])
+            elif not is_float(Tvib):
                 raise TypeError('Tvib should be float, or tuple (got {0})'.format(type(Tvib)) +
                                 'For parallel processing use ParallelFactory with a ' +
                                 'list of float or a list of tuple')

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -85,8 +85,10 @@ from radis.misc.warning import OutOfBoundError
 from radis.io.hitran import get_molecule, get_molecule_identifier
 from radis.spectrum.utils import print_conditions
 from radis.phys.air import air2vacuum, vacuum2air
+from radis.phys.units_astropy import convert_and_strip_units
 from numpy import exp, pi
 import numpy as np
+from astropy import units as u
 import sys
 from time import time
 from six import string_types
@@ -2951,10 +2953,10 @@ def get_waverange(wavenum_min=None, wavenum_max=None, wavelength_min=None, wavel
     medium: ``'air'``, ``'vacuum'``
         propagation medium
 
-    wavenum_min, wavenum_max: float, or ``None``
+    wavenum_min, wavenum_max: float, or ~astropy.units.quantity.Quantity or ``None``
         wavenumbers
 
-    wavelength_min, wavelength_max: float, or ``None``
+    wavelength_min, wavelength_max: float, or ~astropy.units.quantity.Quantity or ``None``
         wavelengths in given ``medium``
 
     Returns
@@ -2966,6 +2968,8 @@ def get_waverange(wavenum_min=None, wavenum_max=None, wavelength_min=None, wavel
     '''
 
     # Check input
+    wavelength_min, wavelength_max = convert_and_strip_units(wavelength_min, u.nm), convert_and_strip_units(wavelength_max, u.nm)
+    wavenum_min, wavenum_max = convert_and_strip_units(wavenum_min, 1/u.cm), convert_and_strip_units(wavenum_max, 1/u.cm)
     if (wavelength_min is None and wavelength_max is None and
             wavenum_min is None and wavenum_max is None):
         raise ValueError('Give wavenumber or wavelength')

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -2968,8 +2968,10 @@ def get_waverange(wavenum_min=None, wavenum_max=None, wavelength_min=None, wavel
     '''
 
     # Check input
-    wavelength_min, wavelength_max = convert_and_strip_units(wavelength_min, u.nm), convert_and_strip_units(wavelength_max, u.nm)
-    wavenum_min, wavenum_max = convert_and_strip_units(wavenum_min, 1/u.cm), convert_and_strip_units(wavenum_max, 1/u.cm)
+    wavelength_min = convert_and_strip_units(wavelength_min, u.nm)
+    wavelength_max = convert_and_strip_units(wavelength_max, u.nm)
+    wavenum_min = convert_and_strip_units(wavenum_min, 1/u.cm)
+    wavenum_max = convert_and_strip_units(wavenum_max, 1/u.cm)
     if (wavelength_min is None and wavelength_max is None and
             wavenum_min is None and wavenum_max is None):
         raise ValueError('Give wavenumber or wavelength')

--- a/radis/lbl/calc.py
+++ b/radis/lbl/calc.py
@@ -60,31 +60,30 @@ def calc_spectrum(wavenum_min=None,
     Parameters
     ----------
 
-    wavenum_min: float [cm-1]
-        minimum wavenumber to be processed in cm^-1
-    wavenum_max: float [cm-1]
-        maximum wavenumber to be processed in cm^-1
+    wavenum_min: float(cm^-1) or `~astropy.units.quantity.Quantity`
+        minimum wavenumber.
+    wavenum_max: float(cm^-1) or `~astropy.units.quantity.Quantity`
+        maximum wavenumber.
 
-    wavelength_min: float [nm]
-        minimum wavelength to be processed in nm. Wavelength in ``'air'`` or 
+    wavelength_min: float(nm) or `~astropy.units.quantity.Quantity`
+        minimum wavelength. Wavelength in ``'air'`` or 
+        ``'vacuum'`` depending of the value of the parameter ``'medium='``
+    wavelength_max: float(nm) or `~astropy.units.quantity.Quantity`
+        maximum wavelength. Wavelength in ``'air'`` or 
         ``'vacuum'`` depending of the value of the parameter ``'medium='``
 
-    wavelength_max: float [nm]
-        maximum wavelength to be processed in nm. Wavelength in ``'air'`` or 
-        ``'vacuum'`` depending of the value of the parameter ``'medium='``
-
-    Tgas: float [K]
+    Tgas: float(K) or `~astropy.units.quantity.Quantity`
         Gas temperature. If non equilibrium, is used for Ttranslational. 
         Default ``300`` K
 
-    Tvib: float [K]
+    Tvib: float(K) or `~astropy.units.quantity.Quantity`
         Vibrational temperature. If ``None``, equilibrium calculation is run with Tgas
 
-    Trot: float [K]
+    Trot: float(K) or `~astropy.units.quantity.Quantity`
         Rotational temperature. If ``None``, equilibrium calculation is run with Tgas
 
-    pressure: float [bar]
-        partial pressure of gas in bar. Default ``1.01325`` (1 atm)
+    pressure: float(bar) or `~astropy.units.quantity.Quantity`
+        partial pressure of gas. Default ``1.01325`` (1 atm)
 
     overpopulation: dict
         dictionary of overpopulation compared to the given vibrational temperature. 
@@ -113,8 +112,8 @@ def calc_spectrum(wavenum_min=None,
     mole_fraction: float
         database species mole fraction. Default ``1``
 
-    path_length: float [cm]
-        slab size. Default ``1``.
+    path_length: float(cm) or `~astropy.units.quantity.Quantity`
+        slab size. Default ``1`` cm.
 
     databank: str
         can be either: 
@@ -142,7 +141,7 @@ def calc_spectrum(wavenum_min=None,
         Does not change anything when giving inputs in wavenumber. Default ``'air'``
 
     wstep: float (cm-1)
-        Spacing of calculated spectrum. Default ``0.01 cm-1``
+        Spacing of calculated spectrum. Default ``0.01`` cm-1.
 
     broadening_max_width: float (cm-1)
         Full width over which to compute the broadening. Large values will create

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -92,11 +92,13 @@ from radis.misc.printer import printg
 from radis.phys.convert import conv2
 from radis.phys.constants import k_b
 from radis.phys.units import convert_rad2nm, convert_emi2nm
+from radis.phys.units_astropy import convert_and_strip_units
 from radis import get_version
 from numpy import exp, arange
 from multiprocessing import cpu_count
 from time import time
 import numpy as np
+import astropy.units as u
 
 # %% Main functions
 
@@ -108,33 +110,42 @@ class SpectrumFactory(BandFactory):
     Parameters
     ----------
 
-    wavenum_min: cm-1
+    wavenum_min: float(cm^-1) or ~astropy.units.quantity.Quantity
         minimum wavenumber to be processed in cm^-1. 
+        use astropy.units to specify arbitrary inverse-length units.
 
-    wavenum_max: cm-1
-        maximum wavenumber to be processed in cm^-1
+    wavenum_max: float(cm^-1) or ~astropy.units.quantity.Quantity
+        maximum wavenumber to be processed in cm^-1.
+        use astropy.units to specify arbitrary inverse-length units.
 
-    wavelength_min: nm
+    wavelength_min: float(nm) or ~astropy.units.quantity.Quantity
         minimum wavelength to be processed in nm. This wavelength
         can be in ``'air'`` or ``'vacuum'`` depending on the value of the parameter
-        ``medium=``
+        ``medium=``.
+        use astropy.units to specify arbitrary length units.
 
-    wavelength_max: nm
-        maximum wavelength to be processed in nm
+    wavelength_max: float(nm) or ~astropy.units.quantity.Quantity
+        maximum wavelength to be processed in nm.
+        use astropy.units to specify arbitrary length units.
 
-    Tref: K
+    Tref: float(K) or ~astropy.units.quantity.Quantity
         reference temperature for calculations, HITRAN database uses 296 Kelvin
-        default: 3400K
+        default: 3400K. 
+        use astropy.units to specify arbitrary temperature units.
+        For example, ``200 * u.deg_C``.
 
-    pressure: bar
-        partial pressure of gas in bar. Default 1.01325 (1 atm)
+    pressure: float(bar) or ~astropy.units.quantity.Quantity
+        partial pressure of gas in bar. Default 1.01325 (1 atm).
+        use astropy.units to specify arbitrary pressure units.
+        For example, ``1013.25 * u.mbar``.
 
     mole_fraction: N/D
         species mole fraction. Default 1. Note that the rest of the gas
         is considered to be air for collisional broadening.
 
-    path_length: cm
+    path_length: float(cm) or ~astropy.units.quantity.Quantity
         path length in cm. Default 1.
+        use astropy.units to specify arbitrary length units.
 
     molecule: int, str, or ``None``
         molecule id (HITRAN format) or name. If ``None``, the molecule can be infered
@@ -405,11 +416,11 @@ class SpectrumFactory(BandFactory):
         # Initialize input conditions
         self.input.wavenum_min = wavenum_min
         self.input.wavenum_max = wavenum_max
-        self.input.Tref = Tref
-        self.input.pressure_mbar = pressure*1e3
+        self.input.Tref = convert_and_strip_units(Tref, u.K)
+        self.input.pressure_mbar = convert_and_strip_units(pressure, u.bar)*1e3
         self.input.mole_fraction = mole_fraction
 
-        self.input.path_length = path_length
+        self.input.path_length = convert_and_strip_units(path_length, u.cm)
         self.input.molecule = molecule  # if None, will be overwritten after reading database
         self.input.state = 'X'              # for the moment only ground-state is used
         # (but the code is electronic state aware)

--- a/radis/phys/__init__.py
+++ b/radis/phys/__init__.py
@@ -24,3 +24,5 @@ from .blackbody import planck, planck_wn, sPlanck
 
 from .units import (conv2, is_homogeneous, convert_rad2cm, convert_rad2nm,
                     convert_emi2cm, convert_emi2nm)
+
+from .units_astropy import convert_and_strip_units

--- a/radis/phys/units_astropy.py
+++ b/radis/phys/units_astropy.py
@@ -1,7 +1,7 @@
 import astropy.units as u
 
 
-def convert_and_strip_units(quantity, output_unit=None):
+def convert_and_strip_units(quantity, output_unit=None, digit=10):
     """
     Strips units and return the numerical value.
 
@@ -9,13 +9,29 @@ def convert_and_strip_units(quantity, output_unit=None):
     ----------
     quantity : int or float or list or None or ~astropy.units.quantity.Quantity
         Numerical quantity. Pass it without including units if default units are intended.
-    output_unit : ~astropy.units.core.UnitBase
+    output_unit : ~astropy.units.core.UnitBase or ~astropy.units.quantity.Quantity
         The default units in which the quantity is to be converted before extracting the value.
+
+    Other Parameters
+    ----------------
+    
+    round: int
+        round to that number of digit after conversion. Default ``10``. Set to 
+        ``None`` to disable.
 
     Returns
     -------
     int or float or None or ~numpy.ndarray
         The numerical value extracted from ``quantity``
+
+    Examples
+    --------
+    
+        >>> convert_and_strip_units(4.5 * u.um, u.nm)
+        <<< 4500.0
+
+        >>> convert_and_strip_units(200000 * (u.m)**-1, 1/u.cm)
+        <<< 2000.0
 
     Raises
     ------
@@ -24,12 +40,20 @@ def convert_and_strip_units(quantity, output_unit=None):
     
     """
     if isinstance(quantity, u.Quantity):
-        if isinstance(output_unit, u.UnitBase):
-            if output_unit in (u.deg_C, u.imperial.deg_F, u.K):
-                return quantity.to(output_unit, equivalencies = u.temperature()).value
-            else:
-                return quantity.to(output_unit).value
+        if output_unit in (u.deg_C, u.imperial.deg_F, u.K):
+            quantity = quantity.to_value(output_unit, equivalencies = u.temperature())
+        elif isinstance(output_unit, u.UnitBase) or isinstance(output_unit, u.Quantity):
+            quantity = quantity.to_value(output_unit, equivalencies=u.spectral())
         else:
-            raise TypeError("'output_unit' parameter is not a valid astropy unit")
-    else:
-        return quantity
+            raise TypeError("'output_unit' parameter is not a valid astropy unit: {0}".format(output_unit))
+        
+        if digit: 
+            quantity=round(quantity, digit)
+    
+    return quantity
+
+
+
+if __name__ == '__main__':
+    import pytest
+    pytest.main(['../test/phys/test_units.py'])

--- a/radis/phys/units_astropy.py
+++ b/radis/phys/units_astropy.py
@@ -42,7 +42,7 @@ def convert_and_strip_units(quantity, output_unit=None, digit=10):
     if isinstance(quantity, u.Quantity):
         if output_unit in (u.deg_C, u.imperial.deg_F, u.K):
             quantity = quantity.to_value(output_unit, equivalencies = u.temperature())
-        elif isinstance(output_unit, u.UnitBase) or isinstance(output_unit, u.Quantity):
+        elif isinstance(output_unit, (u.UnitBase, u.Quantity)):
             quantity = quantity.to_value(output_unit, equivalencies=u.spectral())
         else:
             raise TypeError("'output_unit' parameter is not a valid astropy unit: {0}".format(output_unit))

--- a/radis/phys/units_astropy.py
+++ b/radis/phys/units_astropy.py
@@ -1,0 +1,35 @@
+import astropy.units as u
+
+
+def convert_and_strip_units(quantity, output_unit=None):
+    """
+    Strips units and return the numerical value.
+
+    Parameters
+    ----------
+    quantity : int or float or list or None or ~astropy.units.quantity.Quantity
+        Numerical quantity. Pass it without including units if default units are intended.
+    output_unit : ~astropy.units.core.UnitBase
+        The default units in which the quantity is to be converted before extracting the value.
+
+    Returns
+    -------
+    int or float or None or ~numpy.ndarray
+        The numerical value extracted from ``quantity``
+
+    Raises
+    ------
+    TypeError
+        Raised when ``quantity`` is a astropy.units quantity and ``output_unit`` is ``None``.
+    
+    """
+    if isinstance(quantity, u.Quantity):
+        if isinstance(output_unit, u.UnitBase):
+            if output_unit in (u.deg_C, u.imperial.deg_F, u.K):
+                return quantity.to(output_unit, equivalencies = u.temperature()).value
+            else:
+                return quantity.to(output_unit).value
+        else:
+            raise TypeError("'output_unit' parameter is not a valid astropy unit")
+    else:
+        return quantity

--- a/radis/test/lbl/test_base.py
+++ b/radis/test/lbl/test_base.py
@@ -117,10 +117,8 @@ def test_optically_thick_limit_1iso(verbose=True, plot=True, *args, **kwargs):
     
     try:
         
-#        wavelength_min = 4500
-#        wavelength_max = 4800
-        wavelength_min = cm2nm(2284.6)
-        wavelength_max = cm2nm(2284.2)
+        wavenum_min = 2284.2
+        wavenum_max = 2284.6
     
         P = 0.017     # bar
         wstep = 0.001     # cm-1
@@ -129,7 +127,8 @@ def test_optically_thick_limit_1iso(verbose=True, plot=True, *args, **kwargs):
         
         # %% Generate some CO2 emission spectra
         # --------------
-        sf = SpectrumFactory(wavelength_min=wavelength_min, wavelength_max=wavelength_max,
+        sf = SpectrumFactory(wavenum_min=wavenum_min, 
+                             wavenum_max=wavenum_max,
                              molecule='CO2',
                              mole_fraction=1, path_length=0.05, cutoff=1e-25,
                              broadening_max_width=1,
@@ -225,21 +224,18 @@ def test_optically_thick_limit_2iso(verbose=True, plot=True, *args, **kwargs):
     
     try:
         
-#        wavelength_min = 4500
-#        wavelength_max = 4800
-        wavelength_min = cm2nm(2284.6)
-        wavelength_max = cm2nm(2284.2)
-#    2284.2, 2284.6,
-#                             wstep=0.001,                # cm-1
+        wavenum_min = 2284.2
+        wavenum_max = 2284.6
+
         P = 0.017     # bar
         wstep = 0.001     # cm-1
         
-            
         Tgas = 1200
         
         # %% Generate some CO2 emission spectra
         # --------------
-        sf = SpectrumFactory(wavelength_min=wavelength_min, wavelength_max=wavelength_max,
+        sf = SpectrumFactory(wavenum_min=wavenum_min, 
+                             wavenum_max=wavenum_max,
                              mole_fraction=1, path_length=0.05, cutoff=1e-25,
                              broadening_max_width=1,
                              export_populations = False, #'vib',
@@ -298,141 +294,6 @@ def test_optically_thick_limit_2iso(verbose=True, plot=True, *args, **kwargs):
     finally:
         # Reset DEBUG_MODE
         radis.DEBUG_MODE = DEBUG_MODE
-
-
-@pytest.mark.parametrize(
-    ("wavelength_min", "wavelength_max", "path_length", "P", "Tref"),
-    [  
-        (cm2nm(2284.6), cm2nm(2284.2), 0.05, 0.017, 296),
-        ((1/2284.6)*u.cm, (1/2284.2)*u.cm, 0.5*u.mm, 0.017*u.bar, 296*u.K),
-        ((10/2284.6)*u.mm, (0.01/2284.2)*u.m, 0.0005*u.m, 17*u.mbar, 22.85*u.deg_C)
-    ]
-)
-def test_optically_thick_limit_1iso_different_params(wavelength_min, wavelength_max, path_length, P, Tref, verbose=True, plot=True, *args, **kwargs):
-    ''' Test that we find Planck in the optically thick limit 
-    
-    In particular, this test will fail if :
-        
-    - linestrength are not properly calculated
-    
-    - at noneq, linestrength and emission integrals are mixed up
-    
-    The test should be run for 1 and several isotopes, because different
-    calculations paths are used internally, and this can lead to different
-    errors.
-    
-    Also, this test is used to run with DEBUG_MODE = True, which will 
-    check that isotopes and molecule ids are what we expect in all the 
-    groupby() loops that make the production code very fast. 
-    
-    Notes
-    -----
-    
-    switched from large band calculation with [HITRAN-2016]_ to a calculation with 
-    the embedded [HITEMP-2010]_ fragment (shorter range, but no need to download files)
-    
-    '''
-    
-    if plot:  # Make sure matplotlib is interactive so that test are not stuck in pytest
-        plt.ion()
-
-    # Force DEBUG_MODE
-    DEBUG_MODE = radis.DEBUG_MODE
-    radis.DEBUG_MODE = True
-    
-    try:
-        P = 0.017     # bar
-        wstep = 0.001     # cm-1
-            
-        Tgas = 1200
-        
-        # %% Generate some CO2 emission spectra
-        # --------------
-        sf = SpectrumFactory(wavelength_min=wavelength_min, wavelength_max=wavelength_max,
-                             molecule='CO2',
-                             mole_fraction=1, path_length=path_length, cutoff=1e-25,
-                             Tref=Tref,
-                             broadening_max_width=1,
-                             export_populations = False, #'vib',
-                             export_lines = False,
-                             isotope=1,
-                             use_cached=True,
-                             wstep=wstep,
-                             pseudo_continuum_threshold=0,
-                             pressure=P,
-                             verbose=False)
-#        sf.fetch_databank('astroquery')
-        sf.warnings['NegativeEnergiesWarning'] = 'ignore'
-        sf.load_databank('HITEMP-CO2-TEST')
-        pb = ProgressBar(3, active=verbose)
-        s_eq = sf.eq_spectrum(Tgas=Tgas,  mole_fraction=1, 
-                              name='Equilibrium')
-        pb.update(1)
-        s_2T = sf.non_eq_spectrum(Tvib=Tgas, Trot=Tgas, mole_fraction=1, 
-                                  name='Noneq (2T)')
-        pb.update(2)
-        s_4T = sf.non_eq_spectrum(Tvib=(Tgas, Tgas, Tgas), Trot=Tgas, mole_fraction=1, 
-                                  name='Noneq (4T)')
-        pb.update(3)
-        s_plck = sPlanck(wavelength_min=2000, #=wavelength_min, 
-                         wavelength_max=5000, #=wavelength_max - wstep,   # there is a border effect on last point
-                         T=Tgas)
-        pb.done()
-        
-        # %% Post process: 
-        # MAke optically thick, and compare with Planck
-        
-        for s in [s_eq, s_2T, s_4T]:
-        
-            s.rescale_path_length(1e6)
-            
-            if plot:
-                
-                nfig = 'test_opt_thick_limit_1iso {0}'.format(s.name)
-                plt.figure(nfig).clear()
-                s.plot(wunit='nm', nfig=nfig, lw=4)
-                s_plck.plot(wunit='nm', nfig=nfig, Iunit='mW/cm2/sr/nm', lw=2)
-                plt.legend()
-                
-            if verbose:
-                printm("Residual between opt. thick CO2 spectrum ({0}) and Planck: {1:.2g}".format(
-                        s.name, get_residual(s, s_plck, 'radiance_noslit', ignore_nan=True)))
-            
-#            assert get_residual(s, s_plck, 'radiance_noslit', ignore_nan=True) < 1e-3
-            assert get_residual(s, s_plck, 'radiance_noslit', ignore_nan=True) < 0.9e-4
-            
-        if verbose:
-            printm('Tested optically thick limit is Planck (1 isotope): OK')
-    
-    finally:
-        # Reset DEBUG_MODE
-        radis.DEBUG_MODE = DEBUG_MODE
-
-
-# @pytest.mark.fast
-# @pytest.mark.parametrize(
-#     ("input_wavelengths", "expected_wavelengths", "path_length", "P"),
-#     [
-#         [(4300, 4500), (4300, 4500), 1, 1.01325],
-#         [(4300 * u.nm, 4.5 * u.m), (4300, 4500), 0.01 * u.m, 1013.25 * u.mbar],
-#     ]
-# )
-# def test_waverange_units_conversion(input_wavelengths, expected_wavelengths, path_length, P, verbose=True, warnings=True, *args, **kwargs):
-#     wlmin, wlmax = input_wavelengths
-#     expected_wlmin, expected_wlmax = expected_wavelengths
-#     sf = SpectrumFactory(wavelength_min=wlmin, wavelength_max=wlmax,
-#                          wstep=0.01,
-#                          cutoff=1e-30,
-#                          pressure=P,
-#                          path_length=path_length, 
-#                          mole_fraction=1,
-#                          isotope=[1], 
-#                          verbose=verbose)
-#     s = sf.eq_spectrum(Tgas=300)
-
-#     assert np.isclose(s.get_wavelength()[0], expected_wlmin)
-#     assert np.isclose(s.get_wavelength()[-1], expected_wlmax)
-
 
 def _run_testcases(verbose=True, plot=True):
     

--- a/radis/test/lbl/test_factory.py
+++ b/radis/test/lbl/test_factory.py
@@ -20,6 +20,7 @@ Run only fast tests (i.e: tests that have a 'fast' label)::
 """
 
 from __future__ import unicode_literals, print_function, absolute_import, division
+import astropy.units as u
 import radis
 from radis.lbl import SpectrumFactory
 from radis.misc.printer import printm
@@ -341,21 +342,111 @@ def test_media_line_shift(plot=False, verbose=True, warnings=True, *args, **kwar
         assert IgnoreMissingDatabase(err, __file__, warnings)
 
 
-def _run_testcases(plot=True, verbose=True, *args, **kwargs):
-#
-    # Test power density
-    test_power_integral(verbose=verbose, *args, **kwargs)
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    ("input_wavelengths", "expected_wavelengths_nm"),
+    [
+        [(4300 * u.nm, 4.5 * u.um), (4300, 4500)],
+        [(4500, 5000), (4500, 5000)],
+    ]
+)
+def test_wavelength_units_conversion(input_wavelengths, expected_wavelengths_nm, 
+                                    verbose=True, *args, **kwargs):
+    setup_test_line_databases()  # add HITRAN-CO-TEST in ~/.radis if not there
+    
+    wlmin, wlmax = input_wavelengths
+    expected_wlmin, expected_wlmax = expected_wavelengths_nm
+    sf = SpectrumFactory(wavelength_min=wlmin, wavelength_max=wlmax,
+                         wstep=0.01,
+                         cutoff=1e-30,
+                         pressure=1,
+                         path_length=1, 
+                         mole_fraction=1,
+                         isotope=[1], 
+                         verbose=verbose)
+    sf.load_databank('HITRAN-CO-TEST')
+    s = sf.eq_spectrum(Tgas=300)
+    assert np.isclose(s.get_wavelength().min(), expected_wlmin)
+    assert np.isclose(s.get_wavelength().max(), expected_wlmax)
 
-#    # Show media line_shift
-    test_media_line_shift(plot=plot, verbose=verbose, *args, **kwargs)
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    ("input_wavenumbers", "expected_wavenumbers_cm1"),
+    [
+        [(2000 * 1/u.cm, 230000 * 1/u.m), (2000, 2300)],
+    ]
+)
+def test_wavenumber_units_conversion(input_wavenumbers, expected_wavenumbers_cm1, 
+                                    verbose=True, *args, **kwargs):
+    setup_test_line_databases()  # add HITRAN-CO-TEST in ~/.radis if not there
+    
+    wmin, wmax = input_wavenumbers
+    expected_wmin, expected_wmax = expected_wavenumbers_cm1
+    sf = SpectrumFactory(wavenum_min=wmin, wavenum_max=wmax,
+                         wstep=0.01,
+                         cutoff=1e-30,
+                         pressure=1,
+                         path_length=1, 
+                         mole_fraction=1,
+                         isotope=[1], 
+                         verbose=verbose)
+    sf.load_databank('HITRAN-CO-TEST')
+    s = sf.eq_spectrum(Tgas=300)
+    assert np.isclose(s.get_wavenumber().min(), expected_wmin)
+    assert np.isclose(s.get_wavenumber().max(), expected_wmax)
 
-    # Test spectrum generation
-    test_spec_generation(plot=plot, verbose=2*True, *args, **kwargs)
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    ("input_pressure, expected_pressure_bar"),
+    [(1, 1), 
+     (1*u.mbar, 1e-3),
+     (10*u.bar, 10),
+     ]
+)
+def test_pressure_units_conversion(input_pressure, expected_pressure_bar, 
+                                    verbose=True, *args, **kwargs):
+    setup_test_line_databases()  # add HITRAN-CO-TEST in ~/.radis if not there
+    
+    sf = SpectrumFactory(wavelength_min=4300, wavelength_max=4500,
+                         wstep=0.01,
+                         cutoff=1e-30,
+                         pressure=input_pressure,
+                         path_length=1, 
+                         mole_fraction=1,
+                         isotope=[1], 
+                         verbose=verbose)
+    sf.load_databank('HITRAN-CO-TEST')
+    s = sf.eq_spectrum(Tgas=300)
+    assert np.isclose(s.conditions['pressure_mbar'], expected_pressure_bar*1000)
 
-    return True
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    ("input_pathlength, expected_pathlength_cm"),
+    [(1, 1), 
+     (1*u.m, 100),
+     (1*u.cm, 1),
+     ]
+)
+def test_pathlength_units_conversion(input_pathlength, expected_pathlength_cm, 
+                                    verbose=True, *args, **kwargs):
+    setup_test_line_databases()  # add HITRAN-CO-TEST in ~/.radis if not there
+    
+    sf = SpectrumFactory(wavelength_min=4300, wavelength_max=4500,
+                         wstep=0.01,
+                         cutoff=1e-30,
+                         pressure=1,
+                         path_length=input_pathlength, 
+                         mole_fraction=1,
+                         isotope=[1], 
+                         verbose=verbose)
+    sf.load_databank('HITRAN-CO-TEST')
+    s = sf.eq_spectrum(Tgas=300)
+    assert np.isclose(s.conditions['path_length'], expected_pathlength_cm)
+
 
 
 # --------------------------
 if __name__ == '__main__':
     
-    printm('Testing factory:', _run_testcases(verbose=True))
+    printm('Testing factory:', pytest.main(['test_factory.py']))
+#    printm('Testing factory:', pytest.main(['test_factory.py', '-k', 'test_wavenumber_units_conversion']))

--- a/radis/test/lbl/test_factory.py
+++ b/radis/test/lbl/test_factory.py
@@ -443,6 +443,32 @@ def test_pathlength_units_conversion(input_pathlength, expected_pathlength_cm,
     s = sf.eq_spectrum(Tgas=300)
     assert np.isclose(s.conditions['path_length'], expected_pathlength_cm)
 
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    ("input_temperature, expected_temperature_K"),
+    [(300, 300), 
+     (300*u.K, 300),
+     (300*u.deg_C, 573.15),
+     ]
+)
+def test_temperature_units_conversion(input_temperature, expected_temperature_K, 
+                                    verbose=True, *args, **kwargs):
+    setup_test_line_databases()  # add HITRAN-CO-TEST in ~/.radis if not there
+    
+    sf = SpectrumFactory(wavelength_min=4300, wavelength_max=4500,
+                         wstep=0.01,
+                         cutoff=1e-30,
+                         pressure=1,
+                         mole_fraction=1,
+                         isotope=[1], 
+                         Tref=300 * u.K,
+                         verbose=verbose)
+    sf.load_databank('HITRAN-CO-TEST')
+    s = sf.eq_spectrum(Tgas=input_temperature, pressure = 20 * u.mbar, path_length=1 * u.mm)
+    assert np.isclose(s.conditions['Tgas'], expected_temperature_K)
+    assert np.isclose(s.conditions['path_length'], 0.1) # cm
+    assert np.isclose(s.conditions['pressure_mbar'], 20)
+
 
 
 # --------------------------

--- a/radis/test/phys/test_units.py
+++ b/radis/test/phys/test_units.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""
+Test conversion functions
+"""
+
+import astropy.units as u
+from radis.phys.units_astropy import convert_and_strip_units
+
+def test_convert():
+    
+    # Dimensionned input: should be converted
+    assert convert_and_strip_units(4500 * u.nm, u.um) == 4.5
+    assert convert_and_strip_units(4.5 * u.um, u.nm) == 4500  # uses round(10)
+    assert convert_and_strip_units(2000 * (1/u.cm), 1/u.m) == 200000
+    
+    # Convert using the spectral equivalencies (astropy.units.equivalencies)
+    assert convert_and_strip_units(5 * u.um, 1/u.cm) == 2000
+    assert convert_and_strip_units(60 * u.THz, 1/u.cm) == 2001.3845711889
+    
+    # Undimensionned input : shouldnt change
+    assert convert_and_strip_units(4500, u.um) == 4500
+    
+
+if __name__ == '__main__':
+    test_convert()

--- a/radis/test/phys/test_units.py
+++ b/radis/test/phys/test_units.py
@@ -16,9 +16,17 @@ def test_convert():
     # Convert using the spectral equivalencies (astropy.units.equivalencies)
     assert convert_and_strip_units(5 * u.um, 1/u.cm) == 2000
     assert convert_and_strip_units(60 * u.THz, 1/u.cm) == 2001.3845711889
+
+    # Covert using temperature equivalencies
+    assert convert_and_strip_units(0 * u.deg_C, u.K) == 273.15
+    assert convert_and_strip_units(300 * u.K, u.imperial.deg_F) == 80.33
     
     # Undimensionned input : shouldnt change
     assert convert_and_strip_units(4500, u.um) == 4500
+
+    # None type : should return None
+    assert convert_and_strip_units(None) is None
+    assert convert_and_strip_units(None, u.nm) is None
     
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(name='radis',
 #                        'matplotlib',    # let the user install it 
 #                        'pandas',        # let the user install it 
 #                        'sympy',         # let the user install it 
+                        'astropy',  # Unit aware calculations
                         'pint>=0.7.2',  # Unit aware calculations
                         'publib>=0.3.2', # Plotting styles for Matplotlib
                         'plotly>=2.5.1',    # for line survey HTML output  


### PR DESCRIPTION
Initial steps towards #54 @erwanp 

See if the current implementation is fine or should I proceed in some another way ?
I was trying to fix `SpectrumFactory` first as it is easy to understand and therefore made `get_waverange` units-aware. 

Kindly see the changes in `lbl/test_base.py`. Wavelengths are provided in `cm` and converted to `nm` internally.

If the solution is acceptable, I would proceed with fixing all parameters of `SpectrumFactory`.