### PR TITLE
#84 Improve json storage size and performance

### DIFF
--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -228,6 +228,7 @@ def save(
         with open(fout, "wb") as f:
             json_tricks.dump(
                 sjson, f, compression=True,  # calls gzip compression
+                properties={'ndarray_compact': True}  # use compact numpy format in json-tricks 3.15+
             )
     else:
         with open(fout, "w") as f:
@@ -463,10 +464,10 @@ def load_spec(file, binary=False):  # , return_binary_status=False):
     def _load(binary):
         if not binary:
             with open(file, "r") as f:
-                sload = json_tricks.load(f, preserve_order=False)
+                sload = json_tricks.load(f, preserve_order=False, ignore_comments=True)
         else:
             with open(file, "rb") as f:
-                sload = json_tricks.load(f, preserve_order=False)
+                sload = json_tricks.load(f, preserve_order=False, ignore_comments=True)
         return sload
 
     # first try to open with given binary info

--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -227,8 +227,12 @@ def save(
     if compress:
         with open(fout, "wb") as f:
             json_tricks.dump(
-                sjson, f, compression=True,  # calls gzip compression
-                properties={'ndarray_compact': True}  # use compact numpy format in json-tricks 3.15+
+                sjson,
+                f,
+                compression=True,  # calls gzip compression
+                properties={
+                    "ndarray_compact": True
+                },  # use compact numpy format in json-tricks 3.15+
             )
     else:
         with open(fout, "w") as f:

--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,7 @@ setup(
         "six",  # python 2-3 compatibility
         "configparser",
         "astroquery>=0.3.9",  # to fetch HITRAN databases
-        "json-tricks>=3.13.6",  # to deal with non jsonable formats
+        "json-tricks>=3.15.0",  # to deal with non jsonable formats
         "tables",  # for pandas to HDF5 export
         "pytest",  # to run test suite
         "h5py",  # to write HDF5 files


### PR DESCRIPTION
Don't know if anyone is following the json-tricks issue so I'll repost here in response to #84:

* Compact format was released in json-tricks v3.15.0. It saves about 20% over the old compressed mode, it's also substantially faster.
* Using ignore_comments=False where possible makes loading noticeably faster.