### PR TITLE
Support for `wmin` and `wmax` parameters in Spectrum Factory

### DIFF
--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -3338,7 +3338,7 @@ def get_waverange(
     wavenum_present = wavenum_min is not None or wavenum_max is not None
     wavelength_present = wavelength_min is not None or wavelength_max is not None
     if w_present + wavenum_present + wavelength_present >= 2:
-        raise ValueError("Cannot pass more than one set of values as input")
+        raise ValueError("Cannot pass more than one set of values as input: choose either wmin/wmax (with astropy.units), wavenum_min/wavenum_max, or wavelength_min/wavelength_max")
     assert medium in ["air", "vacuum"]
 
     # user has passed valid wmin/wmax with units

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -3249,8 +3249,7 @@ def get_waverange(
     wavelength_max=None,
     medium="air",
 ):
-    # check input consistency
-    # check if atleast one input is given
+
     if (
         wmin is None
         and wmax is None
@@ -3260,8 +3259,6 @@ def get_waverange(
         and wavenum_max is None
     ):
         raise ValueError("Give wavenumber or wavelength")
-
-    # check if only one pair of values has been passed
     w_present = wmin is not None and wmax is not None
     wavenum_present = wavenum_min is not None and wavenum_max is not None
     wavelength_present = wavelength_min is not None and wavelength_max is not None
@@ -3271,10 +3268,6 @@ def get_waverange(
             "choose either wmin/wmax (with astropy.units), "
             "wavenum_min/wavenum_max, or wavelength_min/wavelength_max"
         )
-
-    complete_pairs = 0
-
-    # check for unit consistency
 
     if not isinstance(wunit, Default):
         if not u.Unit(wunit).is_equivalent(u.m) and not u.Unit(wunit).is_equivalent(

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -3242,7 +3242,7 @@ class BaseFactory(DatabankLoader):
 def get_waverange(
     wmin=None,
     wmax=None,
-    wunit="cm-1_by_default",
+    wunit=None,
     wavenum_min=None,
     wavenum_max=None,
     wavelength_min=None,
@@ -3253,7 +3253,8 @@ def get_waverange(
     represent_wavenum = False
 
     # user did not pass wunit
-    if wunit == "cm-1_by_default":
+    if isinstance(wunit, Default):
+        wunit = wunit.value
         # user did not pass wmin or wmax
         if wmin is None or wmax is None:
             assert wmin is None and wmax is None
@@ -3271,7 +3272,6 @@ def get_waverange(
                     represent_wavenum = True
             # user did not pass wmin/wmax with unit
             else:
-                wunit = wunit[:-11]
                 assert not isinstance(wmin, u.Quantity)
                 assert not isinstance(wmax, u.Quantity)
                 wmin = wmin * u.Unit(wunit)

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -112,6 +112,20 @@ class SpectrumFactory(BandFactory):
     Parameters
     ----------
 
+    wmin: float or `~astropy.units.quantity.Quantity`
+        a hybrid parameter which can stand for minimum wavenumber or minimum
+        wavelength depending upon the unit accompanying it. If dimensionless,
+        wunit is considered as the accompanying unit.
+
+    wmax: float or `~astropy.units.quantity.Quantity`
+        a hybrid parameter which can stand for maximum wavenumber or maximum
+        wavelength depending upon the unit accompanying it. If dimensionless,
+        wunit is considered as the accompanying unit.
+
+    wunit: string
+        the unit accompanying wmin and wmax. Can only be passed with wmin
+        and wmax. Default is `cm-1`.
+
     wavenum_min: float(cm^-1) or `~astropy.units.quantity.Quantity`
         minimum wavenumber to be processed in cm^-1. 
         use astropy.units to specify arbitrary inverse-length units.

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -90,6 +90,7 @@ from radis.spectrum.spectrum import Spectrum
 from radis.spectrum.equations import calc_radiance
 from radis.misc.basics import is_float, list_if_float, flatten
 from radis.misc.printer import printg
+from radis.misc.utils import Default
 from radis.phys.convert import conv2
 from radis.phys.constants import k_b
 from radis.phys.units import convert_rad2nm, convert_emi2nm
@@ -333,6 +334,9 @@ class SpectrumFactory(BandFactory):
 
     def __init__(
         self,
+        wmin=None,
+        wmax=None,
+        wunit=Default("cm-1"),
         wavenum_min=None,
         wavenum_max=None,
         wavelength_min=None,
@@ -396,7 +400,14 @@ class SpectrumFactory(BandFactory):
 
         # Get wavenumber, based on whatever was given as input.
         wavenum_min, wavenum_max = get_waverange(
-            wavenum_min, wavenum_max, wavelength_min, wavelength_max, medium
+            wmin,
+            wmax,
+            wunit,
+            wavenum_min,
+            wavenum_max,
+            wavelength_min,
+            wavelength_max,
+            medium,
         )
 
         # calculated range is broader than output waverange to take into account off-range line broadening

--- a/radis/misc/utils.py
+++ b/radis/misc/utils.py
@@ -97,13 +97,23 @@ else:
 
 
 class Default:
-    """ Returns argument `unit` with an appended `_by_default` string
+    """ Contains a value
+    
+    Examples
+    --------
+    
+    ::
+    
+        a = Default("42")
+        isinstance(a, Default)
+        >>> True
+        
+        a.value
+        >>> 42
     """
 
-    def __new__(cls, unit):
-        cls.unit = unit + "_by_default"
-        return cls.unit
-
+    def __init__(self, value):
+        self.value= value
 
 def getarglist(function):
     """ Get list of arguments in a function 

--- a/radis/misc/utils.py
+++ b/radis/misc/utils.py
@@ -113,7 +113,8 @@ class Default:
     """
 
     def __init__(self, value):
-        self.value= value
+        self.value = value
+
 
 def getarglist(function):
     """ Get list of arguments in a function 

--- a/radis/misc/utils.py
+++ b/radis/misc/utils.py
@@ -96,6 +96,15 @@ else:
 # ==============================================================================
 
 
+class Default:
+    """ Returns argument `unit` with an appended `_by_default` string
+    """
+
+    def __new__(cls, unit):
+        cls.unit = unit + "_by_default"
+        return cls.unit
+
+
 def getarglist(function):
     """ Get list of arguments in a function 
     

--- a/radis/test/lbl/test_base.py
+++ b/radis/test/lbl/test_base.py
@@ -404,11 +404,15 @@ def test_optically_thick_limit_2iso(verbose=True, plot=True, *args, **kwargs):
 
 def test_get_waverange(*args, **kwargs):
 
+    # 'wunit' is none
+    # ...'wmin/wmax' is none
+    # ...... wavenumber is passed > should return the same wavenumbers
     assert get_waverange(wavenum_min=10, wavenum_max=20, wunit=Default("cm-1")) == (
         10,
         20,
     )
 
+    # ...... wavelength is passed > should convert and return the wavenumbers
     assert np.isclose(
         get_waverange(
             wavelength_min=1, wavelength_max=2, medium="vacuum", wunit=Default("cm-1")
@@ -416,6 +420,7 @@ def test_get_waverange(*args, **kwargs):
         (5000000.0, 10000000.0),
     ).all()
 
+    # ....... passed both wavenumber and wavelength > should throw error
     with pytest.raises(ValueError):
         get_waverange(
             wavenum_min=1000,
@@ -425,12 +430,23 @@ def test_get_waverange(*args, **kwargs):
             medium="vacuum",
             wunit=Default("cm-1"),
         )
+
+    # ...... passed neither wavenumber nor wavlength > should throw error
     with pytest.raises(ValueError):
         get_waverange(wunit=Default("cm-1"))
+
+    # ... 'wmin/wmax' are passed as values without accompanying units
+    # ...... wavenumber is passed > should throw error due to multiple input wavespace values
     with pytest.raises(ValueError):
         get_waverange(
             wavenum_min=1, wavenum_max=2, wmin=10, wmax=20, wunit=Default("cm-1")
         )
+
+    # ...... wavelength is passed > should throw error due to multiple input wavespace values
+    with pytest.raises(ValueError):
+        get_waverange(wmin=10, wmax=20, wavelength_min=1, wavelength_max=2)
+
+    # ...... passed both wavenumber and wavelength > should throw error due to multiple input wavespace values
     with pytest.raises(ValueError):
         get_waverange(
             wmin=1,
@@ -441,7 +457,12 @@ def test_get_waverange(*args, **kwargs):
             wavelength_max=200,
             wunit=Default("cm-1"),
         )
+
+    # ...... passed neither wavenumber nor wavelength > should return wavenumber after converting wmin/wmax assuming default units
     assert get_waverange(wmin=10, wmax=20, wunit=Default("cm-1")) == (10.0, 20.0)
+
+    # ... 'wmin/wmax' are passed as values with accompanying units
+    # ...... wavenumber is passed > should throw error due to multiple input wavespace values
     with pytest.raises(ValueError):
         get_waverange(
             wavenum_min=10,
@@ -450,6 +471,8 @@ def test_get_waverange(*args, **kwargs):
             wmax=200 * (1 / u.cm),
             wunit=Default("cm-1"),
         )
+
+    # ...... wavelength is passed > should throw error due to multiple input wavespace values
     with pytest.raises(ValueError):
         get_waverange(
             wmin=100 * (1 / u.cm),
@@ -458,6 +481,8 @@ def test_get_waverange(*args, **kwargs):
             wavelength_max=20,
             wunit=Default("cm-1"),
         )
+
+    # ...... passed both wavenumber and wavelength > should throw error due to multiple input wavespace values
     with pytest.raises(ValueError):
         get_waverange(
             wavenum_min=10,
@@ -468,6 +493,8 @@ def test_get_waverange(*args, **kwargs):
             wavelength_max=20,
             wunit=Default("cm-1"),
         )
+
+    # ...... passed neither wavenumber nor wavelength > should return wavenumber after converting wmin/wmax from accompanying unit
     assert get_waverange(
         wmin=100 * (1 / u.cm), wmax=200 * (1 / u.cm), wunit=Default("cm-1")
     ) == (100.0, 200.0)
@@ -479,10 +506,17 @@ def test_get_waverange(*args, **kwargs):
         (0.5, 1.0),
     ).all()
 
+    # 'wunit' is not none
+    # ... 'wmin/wmax' is none
+    # ...... wavenumber is passed > should throw error as wunit can only be passed with wmin/wmax
     with pytest.raises(ValueError):
         get_waverange(wavenum_min=1, wavenum_max=2, wunit="cm")
+
+    # ...... wavelength is passed > should throw error as wunit can only be passed with wmin/wmax
     with pytest.raises(ValueError):
         get_waverange(wavelength_min=1, wavelength_max=2, wunit="cm")
+
+    # ...... passed both wavenumber and wavelength > should throw error as wunit can only be passed with wmin/wmax
     with pytest.raises(ValueError):
         get_waverange(
             wavenum_min=1,
@@ -491,12 +525,21 @@ def test_get_waverange(*args, **kwargs):
             wavelength_max=20,
             wunit="cm",
         )
+
+    # ...... passed neither wavenumber nor wavlength > should throw error
     with pytest.raises(ValueError):
         get_waverange(wunit="cm")
+
+    # ... 'wmin/wmax' are passed as values without accompanying units
+    # ...... wavenumber is passed > should throw error as only one set of wavespace parameters can be passed
     with pytest.raises(ValueError):
         get_waverange(wmin=1, wmax=2, wavenum_min=10, wavenum_max=20, wunit="cm")
+
+    # ...... wavelength is passed > should throw error as only one set of wavespace parameters can be passed
     with pytest.raises(ValueError):
         get_waverange(wmin=1, wmax=2, wavelength_min=10, wavelength_max=20, wunit="cm")
+
+    # ...... passed both wavenumber and wavelength > should throw error as only one set of wavespace parameters can be passed
     with pytest.raises(ValueError):
         get_waverange(
             wmin=1,
@@ -507,17 +550,23 @@ def test_get_waverange(*args, **kwargs):
             wavelength_max=200,
             wunit="cm",
         )
+
+    # ...... passed neither wavenumber nor wavlength > should return wavenumber after converting wmin/wmax with given wunit
     assert np.isclose(
         get_waverange(wmin=1, wmax=2, wunit="cm"),
         (0.4998637271242577, 0.9997274542485038),
     ).all()
 
     assert get_waverange(wmin=1, wmax=2, wunit="cm-1") == (1.0, 2.0)
+
+    # ... 'wmin/wmax' are passed as values with accompanying units
+    # ...... wavenumber is passed > should throw error as only one set of wavespace parameters can be passed
     with pytest.raises(ValueError):
         get_waverange(
             wmin=1 * u.cm, wmax=2 * u.cm, wavenum_min=10, wavenum_max=20, wunit="cm"
         )
 
+    # ...... wavelength is passed > should throw error as only one set of wavespace parameters can be passed
     with pytest.raises(ValueError):
         get_waverange(
             wmin=1 * u.cm,
@@ -527,6 +576,19 @@ def test_get_waverange(*args, **kwargs):
             wunit="cm",
         )
 
+    # ...... passed both wavenumber and wavelength > should throw error as only one set of wavespace parameters can be passed
+    with pytest.raises(ValueError):
+        get_waverange(
+            wmin=1 * u.cm,
+            wmax=2 * u.cm,
+            wavenum_min=1,
+            wavenum_max=2,
+            wavelength_min=10,
+            wavelength_max=20,
+            wunit="cm",
+        )
+
+    # ...... passed neither wavenumber nor wavlength > should return wavenumber after converting wmin/wmax with given wunit
     assert np.isclose(
         get_waverange(wmin=1 * u.cm, wmax=2 * u.cm, wunit="cm"),
         (0.4998637271242577, 0.9997274542485038),
@@ -546,6 +608,8 @@ def test_get_waverange(*args, **kwargs):
         ),
         (0.4998637271242577, 0.9997274542485038),
     ).all()
+
+    # ... passed wmin/wmax with units different from wunit > should throw error due to conflicting units
     with pytest.raises(ValueError):
         get_waverange(wmin=1 * u.cm, wmax=2 * u.cm, wunit="cm-1")
 

--- a/radis/test/lbl/test_base.py
+++ b/radis/test/lbl/test_base.py
@@ -7,6 +7,7 @@ Created on Mon May  7 17:34:52 2018
 
 from __future__ import absolute_import, unicode_literals, division, print_function
 from radis.lbl import SpectrumFactory
+from radis.lbl.base import get_waverange
 from radis.misc.utils import DatabankNotFound
 from radis.misc.printer import printm
 from radis.test.utils import setup_test_line_databases
@@ -18,6 +19,7 @@ from radis.misc.progress_bar import ProgressBar
 from radis import get_residual, sPlanck
 import radis
 import matplotlib.pyplot as plt
+from radis.misc.utils import Default
 
 
 @pytest.mark.fast
@@ -400,12 +402,161 @@ def test_optically_thick_limit_2iso(verbose=True, plot=True, *args, **kwargs):
         radis.DEBUG_MODE = DEBUG_MODE
 
 
+def test_get_waverange(*args, **kwargs):
+
+    assert get_waverange(wavenum_min=10, wavenum_max=20, wunit=Default("cm-1")) == (
+        10,
+        20,
+    )
+
+    assert np.isclose(
+        get_waverange(
+            wavelength_min=1, wavelength_max=2, medium="vacuum", wunit=Default("cm-1")
+        ),
+        (5000000.0, 10000000.0),
+    ).all()
+
+    with pytest.raises(ValueError):
+        get_waverange(
+            wavenum_min=1000,
+            wavenum_max=2000,
+            wavelength_min=1,
+            wavelength_max=2,
+            medium="vacuum",
+            wunit=Default("cm-1"),
+        )
+    with pytest.raises(ValueError):
+        get_waverange(wunit=Default("cm-1"))
+    with pytest.raises(ValueError):
+        get_waverange(
+            wavenum_min=1, wavenum_max=2, wmin=10, wmax=20, wunit=Default("cm-1")
+        )
+    with pytest.raises(ValueError):
+        get_waverange(
+            wmin=1,
+            wmax=2,
+            wavenum_min=10,
+            wavenum_max=20,
+            wavelength_min=100,
+            wavelength_max=200,
+            wunit=Default("cm-1"),
+        )
+    assert get_waverange(wmin=10, wmax=20, wunit=Default("cm-1")) == (10.0, 20.0)
+    with pytest.raises(ValueError):
+        get_waverange(
+            wavenum_min=10,
+            wavenum_max=20,
+            wmin=100 * (1 / u.cm),
+            wmax=200 * (1 / u.cm),
+            wunit=Default("cm-1"),
+        )
+    with pytest.raises(ValueError):
+        get_waverange(
+            wmin=100 * (1 / u.cm),
+            wmax=200 * (1 / u.cm),
+            wavelength_min=10,
+            wavelength_max=20,
+            wunit=Default("cm-1"),
+        )
+    with pytest.raises(ValueError):
+        get_waverange(
+            wavenum_min=10,
+            wavenum_max=20,
+            wmin=100 * (1 / u.cm),
+            wmax=200 * (1 / u.cm),
+            wavelength_min=10,
+            wavelength_max=20,
+            wunit=Default("cm-1"),
+        )
+    assert get_waverange(
+        wmin=100 * (1 / u.cm), wmax=200 * (1 / u.cm), wunit=Default("cm-1")
+    ) == (100.0, 200.0)
+
+    assert np.isclose(
+        get_waverange(
+            wmin=1 * u.cm, wmax=2 * u.cm, medium="vacuum", wunit=Default("cm-1")
+        ),
+        (0.5, 1.0),
+    ).all()
+
+    with pytest.raises(ValueError):
+        get_waverange(wavenum_min=1, wavenum_max=2, wunit="cm")
+    with pytest.raises(ValueError):
+        get_waverange(wavelength_min=1, wavelength_max=2, wunit="cm")
+    with pytest.raises(ValueError):
+        get_waverange(
+            wavenum_min=1,
+            wavenum_max=2,
+            wavelength_min=10,
+            wavelength_max=20,
+            wunit="cm",
+        )
+    with pytest.raises(ValueError):
+        get_waverange(wunit="cm")
+    with pytest.raises(ValueError):
+        get_waverange(wmin=1, wmax=2, wavenum_min=10, wavenum_max=20, wunit="cm")
+    with pytest.raises(ValueError):
+        get_waverange(wmin=1, wmax=2, wavelength_min=10, wavelength_max=20, wunit="cm")
+    with pytest.raises(ValueError):
+        get_waverange(
+            wmin=1,
+            wmax=2,
+            wavenum_min=10,
+            wavenum_max=20,
+            wavelength_min=100,
+            wavelength_max=200,
+            wunit="cm",
+        )
+    assert np.isclose(
+        get_waverange(wmin=1, wmax=2, wunit="cm"),
+        (0.4998637271242577, 0.9997274542485038),
+    ).all()
+
+    assert get_waverange(wmin=1, wmax=2, wunit="cm-1") == (1.0, 2.0)
+    with pytest.raises(ValueError):
+        get_waverange(
+            wmin=1 * u.cm, wmax=2 * u.cm, wavenum_min=10, wavenum_max=20, wunit="cm"
+        )
+
+    with pytest.raises(ValueError):
+        get_waverange(
+            wmin=1 * u.cm,
+            wmax=2 * u.cm,
+            wavelength_min=10,
+            wavelength_max=20,
+            wunit="cm",
+        )
+
+    assert np.isclose(
+        get_waverange(wmin=1 * u.cm, wmax=2 * u.cm, wunit="cm"),
+        (0.4998637271242577, 0.9997274542485038),
+    ).all()
+
+    assert get_waverange(wmin=1 * (1 / u.cm), wmax=2 * (1 / u.cm), wunit="cm-1") == (
+        1.0,
+        2.0,
+    )
+    assert np.isclose(
+        get_waverange(wmin=1 * u.cm, wmax=2 * u.cm, wunit="cm"),
+        (0.4998637271242577, 0.9997274542485038),
+    ).all()
+    assert np.isclose(
+        get_waverange(
+            wavelength_min=1 * u.cm, wavelength_max=2 * u.cm, wunit=Default("cm-1")
+        ),
+        (0.4998637271242577, 0.9997274542485038),
+    ).all()
+    with pytest.raises(ValueError):
+        get_waverange(wmin=1 * u.cm, wmax=2 * u.cm, wunit="cm-1")
+
+
 def _run_testcases(verbose=True, plot=True):
 
     test_populations(plot=plot, verbose=verbose)
     test_populations_CO2_hamiltonian(plot=plot, verbose=verbose)
     test_optically_thick_limit_1iso(plot=plot, verbose=verbose)
     test_optically_thick_limit_2iso(plot=plot, verbose=verbose)
+    test_get_waverange()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This PR adds support for new parameters `wmin` and `wmax` in the SpectrumFactory. Most modifications have been made in the `base.py` file at `radis/lbl`.
New function calls can now look like:

```
calc_spectrum(1200 * u.cm, 1400 * u.cm,...)
calc_spectrum(1200 * u.cm**-1, 1400 * u.cm**-1, ...)

calc_spectrum(1200, 1400, wunit = 'nm') 
calc_spectrum(1200, 1400, wunit = '1/m')
```
while the current function calls are still supported:

```
get_waverange(wavenum_min=1200, wavenum_max=1400)
get_waverange(wavelength_min=1200 * u.cm, wavelength_max=1400 * u.cm)
```
A few things that are still up for discussion are:

1. Can we allow users to pass units with both the `wmin`/`wmax` parameters *and* `wunit`? If so, which unit takes precedence if they differ?
2. Currently, the code thows an error if calls like ` calc_spectrum(1200, 1400, ...) are made. I would like to change that to an assertion error as I personally feel the function call looks way too vague and should not be allowed.

Will fix #56 after tests, docstring changes and further discussion.
