### PR TITLE
Add online tests for calculations per band, and CO2 (p,c,j,n) nonequilibrium modes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -232,7 +232,7 @@ See `awesome-spectra <https://github.com/erwanp/awesome-spectra>`__   |badge_awe
                   :target: https://travis-ci.com/radis/radis
                   :alt: Tests
 
-.. |badge_coverage| image:: https://codecov.io/gh/radis/radis/branch/master/graph/badge.svg
+.. |badge_coverage| image:: https://codecov.io/gh/radis/radis/branch/develop/graph/badge.svg
                     :target: https://codecov.io/gh/radis/radis
                     :alt: Coverage
 

--- a/radis/test/__init__.py
+++ b/radis/test/__init__.py
@@ -9,3 +9,5 @@ CNRS UPR 288
 """
 
 from __future__ import absolute_import, division, print_function, unicode_literals
+
+from .utils import setup_test_line_databases

--- a/radis/test/lbl/test_base.py
+++ b/radis/test/lbl/test_base.py
@@ -250,17 +250,14 @@ def test_optically_thick_limit_1iso(verbose=True, plot=True, *args, **kwargs):
         # %% Post process:
         # MAke optically thick, and compare with Planck
 
+        if plot:
+            s_plck.plot(wunit="nm", Iunit="mW/cm2/sr/nm", lw=2)
         for s in [s_eq, s_2T, s_4T]:
 
             s.rescale_path_length(1e6)
 
             if plot:
-
-                nfig = "test_opt_thick_limit_1iso {0}".format(s.name)
-                plt.figure(nfig).clear()
-                s.plot(wunit="nm", nfig=nfig, lw=4)
-                s_plck.plot(wunit="nm", nfig=nfig, Iunit="mW/cm2/sr/nm", lw=2)
-                plt.legend()
+                s.plot(wunit="nm", nfig="same", lw=4)
 
             if verbose:
                 printm(
@@ -272,6 +269,8 @@ def test_optically_thick_limit_1iso(verbose=True, plot=True, *args, **kwargs):
 
             #            assert get_residual(s, s_plck, 'radiance_noslit', ignore_nan=True) < 1e-3
             assert get_residual(s, s_plck, "radiance_noslit", ignore_nan=True) < 0.9e-4
+        if plot:
+            plt.legend()
 
         if verbose:
             printm("Tested optically thick limit is Planck (1 isotope): OK")

--- a/radis/test/levels/test_partfunc.py
+++ b/radis/test/levels/test_partfunc.py
@@ -710,7 +710,7 @@ def test_levels_regeneration(verbose=True, warnings=True, *args, **kwargs):
         # Now generate vibrational energies for a 2-T model
         levels = sf.parsum_calc["CO2"][1]["X"].df
         define_Evib_as_sum_of_Evibi(levels)
-        discard_lines_with_na_levels()
+        discard_lines_with_na_levels(sf)
 
         # Calculate populations using the non-equilibrium module:
         # This will crash the first time because the Levels Database is just a fragment and does not include all levels.

--- a/radis/test/levels/test_partfunc.py
+++ b/radis/test/levels/test_partfunc.py
@@ -719,8 +719,6 @@ def test_levels_regeneration(verbose=True, warnings=True, *args, **kwargs):
         except AssertionError:  # expected
             sf.df0.dropna(inplace=True)
 
-        getTestFile("HITEMP-CO2-HAMIL-TEST")
-
         s = sf.non_eq_spectrum(300, 300)
         s.plot()
 

--- a/radis/test/utils.py
+++ b/radis/test/utils.py
@@ -263,12 +263,31 @@ def setup_test_line_databases(verbose=True):
 # %% Edit existing Line databases
 
 
+def define_Evib_as_sum_of_Evibi(levels):
+    """ Note that this is arbitrary for a polyatomic molecule. 
+    Lookup Pannier, Dubuet and Laux 2020 for more.
+    
+    We also update Erot to maintain the sum Evib+Erot = E : 
+    
+    ::
+        
+        Evib = Evib1 + Evib2 + Evib3
+        Erot = E - Evib    # to be consistent with equilibrium 
+        
+    """
+
+    levels["Evib"] = levels.Evib1 + levels.Evib2 + levels.Evib3
+    levels["Erot"] = levels.E - levels.Evib
+
+    return levels
+
+
 def define_Evib_as_min_of_polyad(levels, keys):
     """ Here we define the vibrational energy as the minimum energy 
     in a polyad. Here, the polyad is defined for each combination of ``keys``
     Typically, ``keys=['p', 'c', 'N']`` or keys=['p', 'c'].
     
-    Rotational energy is the rest:
+    Rotational energy is the rest::
         
         Evib = min(E(p,c,j,n) for a given set of (p,c))
         Erot = E - Evib
@@ -312,11 +331,13 @@ def discard_lines_with_na_levels(sf):
     
     sf: SpectrumFactory
     """
-    import pytest
 
-    with pytest.raises(AssertionError):
+    # Calculate populations using the non-equilibrium module:
+    # This will crash the first time because the Levels Database is just a fragment and does not include all levels.
+    try:
         sf.non_eq_spectrum(300, 300)
-    sf.df0.dropna(inplace=True)
+    except AssertionError:  # expected
+        sf.df0.dropna(inplace=True)
 
 
 # %% Deal with missing databases


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/blob/develop/CONTRIBUTING.md . -->

### Description

Adapts the `test_all_calc_methods` that used local database to the new test databases based on fragments of the CDSD effective Hamiltonian levels.

This allows to improve coverage #62 

- cover with online tests parts of the code that were only covered by local tests, such as the advanced nonequilbirium CO2 cases with (p,c,j,n) nomenclature in `partfunc_cdsd.py` file
- calculate per bands and recombine, using `LevelsList`
