### PR TITLE
(minor) Database - 'compress = 2' 

### DIFF
--- a/radis/test/tools/test_database.py
+++ b/radis/test/tools/test_database.py
@@ -122,11 +122,7 @@ def test_save_compressed2(verbose=True, *args, **kwargs):
     from radis.test.utils import setup_test_line_databases
     from radis import calc_spectrum, SpecDatabase
 
-    try:
-        # we want to make sure this folder is not generated from before
-        shutil.rmtree(dirname(getTestFile(".")) + "/newDb/")
-    except:
-        pass
+    shutil.rmtree(join(dirname(getTestFile(".")),newDb"), ignore_errors=True)
     
     try:
         #get the spectrum

--- a/radis/test/tools/test_database.py
+++ b/radis/test/tools/test_database.py
@@ -123,7 +123,6 @@ def test_save_compressed2(verbose=True, *args, **kwargs):
     from radis.test.utils import setup_test_line_databases
     from radis import calc_spectrum, SpecDatabase
 
-
     shutil.rmtree(join(dirname(getTestFile(".")), "newDb"), ignore_errors=True)
 
     try:

--- a/radis/test/tools/test_database.py
+++ b/radis/test/tools/test_database.py
@@ -114,56 +114,44 @@ def test_plot_spec(plot=True, close_plots=True, verbose=True, *args, **kwargs):
     if plot:
         plot_spec(getTestFile("N2C_specair_380nm.spec"))
 
+
 def test_save_compressed2():
+    "Check if saving a spectrum with compress = 2 does not change something."
     from radis import calc_spectrum, SpecDatabase
     import shutil
-    #s1 : cm-1, vacuum
-    #s2 : nm, air
-    s1 = calc_spectrum(
-                1900, 1950,         # cm-1
-                # wavelength_min=4160,   # nm
-                # wavelength_max=4190,   # nm
-                  molecule='CO',
-                  isotope='1,2,3',
-                  pressure=1.01325,   # bar
-                  Tgas=700,           # K
-                  mole_fraction=0.1,
-                  path_length=1,      # cm
-                  verbose=False,
-                  wstep=0.01,
-                  medium='vacuum',
-                  )
-    s2 = calc_spectrum(
-                1900, 1950,         # cm-1
-                # wavelength_min=4160,   # nm
-                # wavelength_max=4190,   # nm
-                  molecule='CO',
-                  isotope='1,2,3',
-                  pressure=1.01325,   # bar
-                  Tgas=700,           # K
-                  mole_fraction=0.1,
-                  path_length=1,      # cm
-                  verbose=False,
-                  wstep=0.01,
-                  medium='vacuum',
-                  )
-    
-    db = SpecDatabase(dirname(getTestFile("."))+'/newDb/')
-    for s in [s1, s2]:
-        db.add(s, compress=2, if_exists_then='replace')
-    
-    # s1_bis = db.get_unique(Tgas=700)
-    # s2_bis = db.get_unique(Tgas=1000)
-    s1_bis = db.get_closest(Tgas=700)
-    s2_bis = db.get_closest(Tgas=1000)
-    s2_bis.update()
-    
-    shutil.rmtree(dirname(getTestFile("."))+'/newDb/')
-    assert s1 == s1_bis
-    assert s2 == s2_bis
-    
+
+    # s1 : cm-1, vacuum
+    # s2 : nm, air
+    s = calc_spectrum(
+        1900,
+        1950,  # cm-1
+        # wavelength_min=4160,   # nm
+        # wavelength_max=4190,   # nm
+        molecule="CO",
+        isotope="1,2,3",
+        pressure=1.01325,  # bar
+        Tgas=700,  # K
+        mole_fraction=0.1,
+        path_length=1,  # cm
+        verbose=False,
+        wstep=0.01,
+        medium="vacuum",
+    )
+
+    db = SpecDatabase(dirname(getTestFile(".")) + "/newDb/")
+    db.add(s, compress=1, if_exists_then="error")
+
+    # s_bis = db.get_closest(Tgas=700)
+    s_bis = db.get_unique(Tgas=700)
+
+    shutil.rmtree(dirname(getTestFile(".")) + "/newDb/")
+    assert s.compare_with(s_bis)
+    assert s == s_bis
+
+
 if __name__ == "__main__":
     import pytest
+
     # -s is to plot
-    # pytest.main(['test_database.py', '-s'])
-    test_save_compressed2()
+    pytest.main(["test_database.py", "-s"])
+    # test_save_compressed2()

--- a/radis/test/tools/test_database.py
+++ b/radis/test/tools/test_database.py
@@ -147,7 +147,7 @@ def test_save_compressed2(verbose=True, *args, **kwargs):
         db.add(s, compress=2, if_exists_then="error")
     
         # simulate an experimentalist who come later and load the spectrum
-        db2 = SpecDatabase(dirname(getTestFile(".")) + "/newDb/")
+        db2 = SpecDatabase(join(dirname(getTestFile(".")),"newDb"))
         s_bis = db2.get_unique(Tgas=700)
         
         # we clean the folders for next times

--- a/radis/test/tools/test_database.py
+++ b/radis/test/tools/test_database.py
@@ -150,12 +150,9 @@ def test_save_compressed2(verbose=True, *args, **kwargs):
         db2 = SpecDatabase(join(dirname(getTestFile(".")),"newDb"))
         s_bis = db2.get_unique(Tgas=700)
         
-        # we clean the folders for next times
-        shutil.rmtree(dirname(getTestFile(".")) + "/newDb/")
-    
-    except:
+    finally:
         # we want to make sure this folder is deleted
-        shutil.rmtree(dirname(getTestFile(".")) + "/newDb/")
+        shutil.rmtree(join(dirname(getTestFile(".")),"newDb"))
     
     # we check the loaded spectrum contains less information than the calculated one
     assert not s == s_bis

--- a/radis/test/tools/test_database.py
+++ b/radis/test/tools/test_database.py
@@ -115,7 +115,7 @@ def test_plot_spec(plot=True, close_plots=True, verbose=True, *args, **kwargs):
         plot_spec(getTestFile("N2C_specair_380nm.spec"))
 
 
-def test_save_compressed2():
+def test_save_compressed2(verbose=True, *args, **kwargs):
     "Check if saving a spectrum with compress = 2 does not change something."
     import shutil
 

--- a/radis/test/tools/test_database.py
+++ b/radis/test/tools/test_database.py
@@ -154,7 +154,8 @@ def test_save_compressed2(verbose=True, *args, **kwargs):
     s_bis.update()
 
     # now we check if it works
-    assert s.compare_with(s_bis, spectra_only=True, plot=False)
+    for var in s.get_vars():
+        assert s.compare_with(s_bis, spectra_only=var, plot=False, verbose=verbose)
 
     # assert s == s_bis
     # print(s)

--- a/radis/test/tools/test_database.py
+++ b/radis/test/tools/test_database.py
@@ -143,7 +143,7 @@ def test_save_compressed2(verbose=True, *args, **kwargs):
         )
 
         # load in one databse
-        db = SpecDatabase(dirname(getTestFile(".")) + "/newDb/")
+        db = SpecDatabase(join(dirname(getTestFile(".")),"newDb"))
         db.add(s, compress=2, if_exists_then="error")
     
         # simulate an experimentalist who come later and load the spectrum

--- a/radis/test/tools/test_database.py
+++ b/radis/test/tools/test_database.py
@@ -151,6 +151,9 @@ def test_save_compressed2(verbose=True, *args, **kwargs):
 
     # we check the loaded spectrum contains less information than the calculated one
     assert not s == s_bis
+    assert s_bis.get_vars() == ['abscoeff']     # only this spectral quantity was stored
+    assert s_bis.lines is None
+    assert s_bis.conditions is not None  # we kept the metadata
     s_bis.update()
 
     # now we check if it works

--- a/radis/test/tools/test_database.py
+++ b/radis/test/tools/test_database.py
@@ -118,14 +118,16 @@ def test_plot_spec(plot=True, close_plots=True, verbose=True, *args, **kwargs):
 def test_save_compressed2(verbose=True, *args, **kwargs):
     "Check if saving a spectrum with compress = 2 does not change something."
     import shutil
+    from os.path import join
 
     from radis.test.utils import setup_test_line_databases
     from radis import calc_spectrum, SpecDatabase
 
-    shutil.rmtree(join(dirname(getTestFile(".")),newDb"), ignore_errors=True)
-    
+
+    shutil.rmtree(join(dirname(getTestFile(".")), "newDb"), ignore_errors=True)
+
     try:
-        #get the spectrum
+        # get the spectrum
         setup_test_line_databases()
         s = calc_spectrum(
             2000,
@@ -143,20 +145,20 @@ def test_save_compressed2(verbose=True, *args, **kwargs):
         )
 
         # load in one databse
-        db = SpecDatabase(join(dirname(getTestFile(".")),"newDb"))
+        db = SpecDatabase(join(dirname(getTestFile(".")), "newDb"))
         db.add(s, compress=2, if_exists_then="error")
-    
+
         # simulate an experimentalist who come later and load the spectrum
-        db2 = SpecDatabase(join(dirname(getTestFile(".")),"newDb"))
+        db2 = SpecDatabase(join(dirname(getTestFile(".")), "newDb"))
         s_bis = db2.get_unique(Tgas=700)
-        
+
     finally:
         # we want to make sure this folder is deleted
-        shutil.rmtree(join(dirname(getTestFile(".")),"newDb"))
-    
+        shutil.rmtree(join(dirname(getTestFile(".")), "newDb"))
+
     # we check the loaded spectrum contains less information than the calculated one
     assert not s == s_bis
-    assert s_bis.get_vars() == ['abscoeff']     # only this spectral quantity was stored
+    assert s_bis.get_vars() == ["abscoeff"]  # only this spectral quantity was stored
     assert s_bis.lines is None
     assert s_bis.conditions is not None  # we kept the metadata
     # now we check if it works
@@ -164,7 +166,6 @@ def test_save_compressed2(verbose=True, *args, **kwargs):
     for var in s.get_vars():
         assert s.compare_with(s_bis, spectra_only=var, plot=False, verbose=verbose)
 
-    
 
 if __name__ == "__main__":
     import pytest

--- a/radis/test/tools/test_database.py
+++ b/radis/test/tools/test_database.py
@@ -125,23 +125,23 @@ def test_save_compressed2(verbose=True, *args, **kwargs):
 
     shutil.rmtree(join(dirname(getTestFile(".")), "newDb"), ignore_errors=True)
 
+    # get the spectrum
+    setup_test_line_databases()
+    s = calc_spectrum(
+        2000,
+        2300,  # cm-1
+        molecule="CO",
+        isotope="1,2,3",
+        pressure=1.01325,  # bar
+        Tgas=700,  # K
+        mole_fraction=0.1,
+        path_length=1,  # cm
+        verbose=False,
+        wstep=0.01,
+        medium="vacuum",
+        databank="HITRAN-CO-TEST",
+    )
     try:
-        # get the spectrum
-        setup_test_line_databases()
-        s = calc_spectrum(
-            2000,
-            2300,  # cm-1
-            molecule="CO",
-            isotope="1,2,3",
-            pressure=1.01325,  # bar
-            Tgas=700,  # K
-            mole_fraction=0.1,
-            path_length=1,  # cm
-            verbose=False,
-            wstep=0.01,
-            medium="vacuum",
-            databank="HITRAN-CO-TEST",
-        )
 
         # load in one databse
         db = SpecDatabase(join(dirname(getTestFile(".")), "newDb"))

--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -2018,7 +2018,7 @@ class SpecDatabase(SpecList):
         compress: 0, 1, 2
             if ``True`` or 1, save the spectrum in a compressed form 
             
-            if 2, removes all quantities that can be regenerated with ``s.update()``,
+            if 2, removes all quantities that can be regenerated with :py:meth:`~radis.spectrum.spectrum.Spectrum.update`,
             e.g, transmittance if abscoeff and path length are given, radiance if
             emisscoeff and abscoeff are given in non-optically thin case, etc.
             If not given, use the value of ``SpecDatabase.binary``

--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -2015,7 +2015,7 @@ class SpecDatabase(SpecList):
             Other :py:meth:`~radis.spectrum.spectrum.Spectrum.store` parameters can be given 
             as kwargs arguments:
 
-        compress: boolean or int
+        compress: 0, 1, 2
             if ``True`` or 1, save the spectrum in a compressed form 
             
             if 2, removes all quantities that can be regenerated with ``s.update()``,

--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -2015,11 +2015,14 @@ class SpecDatabase(SpecList):
             Other :py:meth:`~radis.spectrum.spectrum.Spectrum.store` parameters can be given 
             as kwargs arguments:
 
-        compress: boolean
-            if ``True``, removes all quantities that can be regenerated with ``s.update()``,
+        compress: boolean or int
+            if ``True`` or 1, save the spectrum in a compressed form 
+            
+            if 2, removes all quantities that can be regenerated with ``s.update()``,
             e.g, transmittance if abscoeff and path length are given, radiance if
             emisscoeff and abscoeff are given in non-optically thin case, etc.
             If not given, use the value of ``SpecDatabase.binary``
+            The performances are usually better if compress = 2. See https://github.com/radis/radis/issues/84.
 
         add_info: list
             append these parameters and their values if they are in conditions


### PR DESCRIPTION
Hi guys,

The (fabulous) option `compress = 2` when saving a spectrum in a database is now documented and tested. The test consist in generating a spectrum, save it, load it, and compare it to the generated spectrum.

Minou