### PR TITLE
(MAJOR) quick fix to the unit problem in "get_residual"

### DIFF
--- a/radis/spectrum/operations.py
+++ b/radis/spectrum/operations.py
@@ -429,7 +429,7 @@ def _get_unique_var(s, var, inplace):
     return var
 
 
-def multiply(s, coef, var=None, inplace=False):
+def multiply(s, coef, Iunit=None, var=None, inplace=False):
     """Multiply s[var] by the float 'coef'
 
     Parameters
@@ -454,6 +454,8 @@ def multiply(s, coef, var=None, inplace=False):
     """
     # Check input
     var = _get_unique_var(s, var, inplace)
+    if Iunit == None:
+        Iunit = s.units[var]
 
     if not inplace:
         s = s.copy(quantity=var)
@@ -461,7 +463,7 @@ def multiply(s, coef, var=None, inplace=False):
     #            s.name = name
 
     # Multiply inplace       ( @dev: we have copied already if needed )
-    w, I = s.get(var, wunit=s.get_waveunit(), copy=False)
+    w, I = s.get(var, wunit=s.get_waveunit(), copy=False, Iunit=Iunit)
     I *= coef  # @dev: updates the Spectrum directly because of copy=False
 
     return s


### PR DESCRIPTION
Guys,

There is a BIG unit problem in the function `get_residual`. If the two function do not have the same unit, then the residual won't be correct. See the example below:

**Code:**
```
from radis import calc_spectrum, get_residual, experimental_spectrum
s1 = calc_spectrum(1900, 2300,
                  molecule='CO',
                  isotope='1,2,3',
                  pressure=1.01325,
                  Tgas=1000,
                  mole_fraction=0.1,
                  )
s1.apply_slit(1, 'nm')

#s2 is like s1 but at 1001 K
s2 = calc_spectrum(1900, 2300,         
                  molecule='CO',
                  isotope='1,2,3',
                  pressure=1.01325,
                  Tgas=1001, #HERE IS THE DIFFERENCE
                  mole_fraction=0.1,
                  )
s2.apply_slit(1, 'nm')
residual_ref = get_residual(s1, s2, 'radiance', ignore_nan=False, normalize=True)


w1, I1 = s1.get('radiance', copy=False, wunit=s1.get_waveunit())
#Fake experimental spectrum (identical)
s_expe_1 = experimental_spectrum(w1, I1, Iunit="mW/cm2/sr/nm", wunit="cm-1") 
#Fake experimental spectrum with a new unit (but identical)
s_expe_2 = experimental_spectrum(w1, I1*1e-3, Iunit="W/cm2/sr/nm", wunit="cm-1") 
residual1 = get_residual(s1, s_expe_1, 'radiance', ignore_nan=False, normalize=True)
residual2 = get_residual(s1, s_expe_2, 'radiance', ignore_nan=False, normalize=True)

print(residual1, residual2, residual_ref)
```

**Old Output:**
`0.0 0.8176423186518765 5.532303126258176e-07`

1. The first one is expected
2. The second one is the error !
3. The third is just to give you an idea what change will be induced by a increase of 1 K

With my fix, the difference is reduced. I'll open an issue about the remaining difference in a minute.

**New Output:**
`0.0 0.0008176423186518765 5.532303126258176e-07`