### PR TITLE
Replaces pint with astropy.units

### DIFF
--- a/docs/spectrum/spectrum.rst
+++ b/docs/spectrum/spectrum.rst
@@ -85,7 +85,7 @@ From numpy arrays, use :py:meth:`~radis.spectrum.spectrum.Spectrum.from_array` :
     # w, T are two numpy arrays 
     from radis import Spectrum
     s = Spectrum.from_array(w, T, 'transmittance_noslit', 
-                               waveunit='nm', unit='1')
+                               waveunit='nm', unit='') # adimensioned
                                
               
 From a file, use :py:meth:`~radis.spectrum.spectrum.Spectrum.from_txt` ::

--- a/docs/spectrum/spectrum.rst
+++ b/docs/spectrum/spectrum.rst
@@ -85,7 +85,7 @@ From numpy arrays, use :py:meth:`~radis.spectrum.spectrum.Spectrum.from_array` :
     # w, T are two numpy arrays 
     from radis import Spectrum
     s = Spectrum.from_array(w, T, 'transmittance_noslit', 
-                               waveunit='nm', unit='I/I0')
+                               waveunit='nm', unit='1')
                                
               
 From a file, use :py:meth:`~radis.spectrum.spectrum.Spectrum.from_txt` ::

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,6 @@ dependencies:
 - h5py
 - numba
 - astropy  # Unit aware calculations
-- pint>=0.7.2  # Unit aware calculations
 - plotly>=2.5.1  # for line survey HTML output
 - termcolor  # terminal colors
 - six  # python 2-3 compatibility

--- a/radis/lbl/bands.py
+++ b/radis/lbl/bands.py
@@ -606,7 +606,7 @@ class BandFactory(BroadenFactory):
                 emisscoeff_v_bands,
             ) = self._calc_broadening_noneq_bands()
             #    :         :            :
-            #   cm-1    1/(#.cm-2)   mW/sr/cm_1
+            #   cm-1    1/(#.cm-2)   mW/sr/cm-1
 
             #            # ... add semi-continuum (optional)
             #            abscoeff_v_bands = self._add_pseudo_continuum(abscoeff_v_bands, I_continuum)
@@ -666,7 +666,7 @@ class BandFactory(BroadenFactory):
                 # (#/cm3)
 
                 abscoeff = abscoeff_v * density  # cm-1
-                emisscoeff = emisscoeff_v * density  # m/sr/cm3/cm_1
+                emisscoeff = emisscoeff_v * density  # m/sr/cm3/cm-1
 
                 # ==============================================================================
                 # Warning
@@ -693,15 +693,15 @@ class BandFactory(BroadenFactory):
                     radiance_noslit[b] = emisscoeff[b] * path_length
                 else:
                     # Note that for k -> 0,
-                    radiance_noslit = emisscoeff * path_length  # (mW/sr/cm2/cm_1)
+                    radiance_noslit = emisscoeff * path_length  # (mW/sr/cm2/cm-1)
 
-                # Convert `radiance_noslit` from (mW/sr/cm2/cm_1) to (mW/sr/cm2/nm)
+                # Convert `radiance_noslit` from (mW/sr/cm2/cm-1) to (mW/sr/cm2/nm)
                 radiance_noslit = convert_rad2nm(
-                    radiance_noslit, wavenumber, "mW/sr/cm2/cm_1", "mW/sr/cm2/nm"
+                    radiance_noslit, wavenumber, "mW/sr/cm2/cm-1", "mW/sr/cm2/nm"
                 )
-                # Convert 'emisscoeff' from (mW/sr/cm3/cm_1) to (mW/sr/cm3/nm)
+                # Convert 'emisscoeff' from (mW/sr/cm3/cm-1) to (mW/sr/cm3/nm)
                 emisscoeff = convert_emi2nm(
-                    emisscoeff, wavenumber, "mW/sr/cm3/cm_1", "mW/sr/cm3/nm"
+                    emisscoeff, wavenumber, "mW/sr/cm3/cm-1", "mW/sr/cm3/nm"
                 )
                 # Note: emissivity not defined under non equilibrium
 

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -102,7 +102,7 @@ class BaseFactory(DatabankLoader):
 
     # Output units
     units = {
-        "absorbance": "1",
+        "absorbance": "",
         "abscoeff": "cm-1",
         "abscoeff_continuum": "cm-1",
         # TODO: deal with case where 'cm-1' is given as input for a Spectrum
@@ -113,10 +113,10 @@ class BaseFactory(DatabankLoader):
         "radiance_noslit": "mW/cm2/sr/nm",  # it's actually a spectral radiance
         "emisscoeff": "mW/cm3/sr/nm",
         "emisscoeff_continuum": "mW/cm3/sr/nm",
-        "emissivity": "1",
-        "emissivity_noslit": "1",
-        "transmittance": "1",
-        "transmittance_noslit": "1",
+        "emissivity": "",
+        "emissivity_noslit": "",
+        "transmittance": "",
+        "transmittance_noslit": "",
     }
 
     # Calculation Conditions units

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -103,8 +103,8 @@ class BaseFactory(DatabankLoader):
     # Output units
     units = {
         "absorbance": "-ln(I/I0)",
-        "abscoeff": "cm_1",
-        "abscoeff_continuum": "cm_1",
+        "abscoeff": "cm-1",
+        "abscoeff_continuum": "cm-1",
         # TODO: deal with case where 'cm-1' is given as input for a Spectrum
         # (write a cast_unit of some kind)
         # different in Specair (mw/cm2/sr) because slit
@@ -162,7 +162,7 @@ class BaseFactory(DatabankLoader):
         # dont change this without making sure your line database
         # is correct, and the units conversions (ex: radiance)
         # are changed accordingly
-        # Note that radiance are converted from ~ [mW/cm2/sr/cm_1]
+        # Note that radiance are converted from ~ [mW/cm2/sr/cm-1]
         # to ~ [mW/cm/sr/nm]
         assert self.params.waveunit == self.cond_units["wstep"]
 

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -102,7 +102,7 @@ class BaseFactory(DatabankLoader):
 
     # Output units
     units = {
-        "absorbance": "-ln(I/I0)",
+        "absorbance": "1",
         "abscoeff": "cm-1",
         "abscoeff_continuum": "cm-1",
         # TODO: deal with case where 'cm-1' is given as input for a Spectrum
@@ -113,10 +113,10 @@ class BaseFactory(DatabankLoader):
         "radiance_noslit": "mW/cm2/sr/nm",  # it's actually a spectral radiance
         "emisscoeff": "mW/cm3/sr/nm",
         "emisscoeff_continuum": "mW/cm3/sr/nm",
-        "emissivity": "eps",
-        "emissivity_noslit": "eps",
-        "transmittance": "I/I0",
-        "transmittance_noslit": "I/I0",
+        "emissivity": "1",
+        "emissivity_noslit": "1",
+        "transmittance": "1",
+        "transmittance_noslit": "1",
     }
 
     # Calculation Conditions units

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -1020,7 +1020,7 @@ class SpectrumFactory(BandFactory):
             # ... (this is the performance bottleneck)
             wavenumber, abscoeff_v, emisscoeff_v = self._calc_broadening_noneq()
             #    :         :            :
-            #   cm-1    1/(#.cm-2)   mW/sr/cm_1
+            #   cm-1    1/(#.cm-2)   mW/sr/cm-1
 
             # ... add semi-continuum (optional)
             abscoeff_v = self._add_pseudo_continuum(abscoeff_v, k_continuum)
@@ -1038,7 +1038,7 @@ class SpectrumFactory(BandFactory):
             # (#/cm3)
 
             abscoeff = abscoeff_v * density  # cm-1
-            emisscoeff = emisscoeff_v * density  # mW/sr/cm3/cm_1
+            emisscoeff = emisscoeff_v * density  # mW/sr/cm3/cm-1
 
             # ... # TODO: if the code is extended to multi-species, then density has to be added
             # ... before lineshape broadening (as it would not be constant for all species)
@@ -1061,15 +1061,15 @@ class SpectrumFactory(BandFactory):
                 radiance_noslit[b] = emisscoeff[b] * path_length
             else:
                 # Note that for k -> 0,
-                radiance_noslit = emisscoeff * path_length  # (mW/sr/cm2/cm_1)
+                radiance_noslit = emisscoeff * path_length  # (mW/sr/cm2/cm-1)
 
-            # Convert `radiance_noslit` from (mW/sr/cm2/cm_1) to (mW/sr/cm2/nm)
+            # Convert `radiance_noslit` from (mW/sr/cm2/cm-1) to (mW/sr/cm2/nm)
             radiance_noslit = convert_rad2nm(
-                radiance_noslit, wavenumber, "mW/sr/cm2/cm_1", "mW/sr/cm2/nm"
+                radiance_noslit, wavenumber, "mW/sr/cm2/cm-1", "mW/sr/cm2/nm"
             )
-            # Convert 'emisscoeff' from (mW/sr/cm3/cm_1) to (mW/sr/cm3/nm)
+            # Convert 'emisscoeff' from (mW/sr/cm3/cm-1) to (mW/sr/cm3/nm)
             emisscoeff = convert_emi2nm(
-                emisscoeff, wavenumber, "mW/sr/cm3/cm_1", "mW/sr/cm3/nm"
+                emisscoeff, wavenumber, "mW/sr/cm3/cm-1", "mW/sr/cm3/nm"
             )
 
             if self.verbose >= 2:

--- a/radis/phys/blackbody.py
+++ b/radis/phys/blackbody.py
@@ -27,7 +27,8 @@ from __future__ import absolute_import
 from numpy import exp, arange, ones_like, zeros_like, inf
 from radis.phys.constants import k_b, c, h
 from radis.phys.constants import k_b_CGS, c_CGS, h_CGS
-from radis.phys.units import conv2, Q_
+from radis.phys.units import conv2
+from radis.phys.units import Unit as Q_
 from radis.phys.air import air2vacuum
 
 

--- a/radis/phys/blackbody.py
+++ b/radis/phys/blackbody.py
@@ -72,7 +72,7 @@ def planck(lmbda, T, eps=1, unit="mW/sr/cm2/nm"):
     return iplanck
 
 
-def planck_wn(wavenum, T, eps=1, unit="mW/sr/cm2/cm_1"):
+def planck_wn(wavenum, T, eps=1, unit="mW/sr/cm2/cm-1"):
     """ Planck function for blackbody radiation, wavenumber version
 
 
@@ -89,13 +89,13 @@ def planck_wn(wavenum, T, eps=1, unit="mW/sr/cm2/cm_1"):
         default 1
 
     unit: str
-        output unit. Default 'mW/sr/cm2/cm_1'
+        output unit. Default 'mW/sr/cm2/cm-1'
 
 
     Returns
     -------
 
-    planck: np.array   default (mW/sr/cm2/cm_1)
+    planck: np.array   default (mW/sr/cm2/cm-1)
         equilibrium radiance
 
     """
@@ -110,8 +110,8 @@ def planck_wn(wavenum, T, eps=1, unit="mW/sr/cm2/cm_1"):
     # iplanck in erg/s/sr/cm2/cm-1
     iplanck *= 1e-4  # erg/s/sr/cm2/cm-1 > mW/sr/cm^2/cm-1
 
-    if Q_(unit) != Q_("mW/sr/cm2/cm_1"):
-        iplanck = conv2(iplanck, "mW/sr/cm2/cm_1", unit)
+    if Q_(unit) != Q_("mW/sr/cm2/cm-1"):
+        iplanck = conv2(iplanck, "mW/sr/cm2/cm-1", unit)
 
     return iplanck
 
@@ -204,7 +204,7 @@ def sPlanck(
     if waveunit == "cm-1":
         # generate the vector of wavenumbers (shape M)
         w = arange(wavenum_min, wavenum_max + wstep, wstep)
-        Iunit = "mW/sr/cm2/cm_1"
+        Iunit = "mW/sr/cm2/cm-1"
         I = planck_wn(w, T, eps=eps, unit=Iunit)
     else:
         # generate the vector of lengths (shape M)
@@ -230,8 +230,8 @@ def sPlanck(
         conditions=conditions,
         units={
             "radiance_noslit": Iunit,
-            "transmittance_noslit": "I/I0",
-            "absorbance": "-ln(I/I0)",
+            "transmittance_noslit": "1",
+            "absorbance": "1",
         },
         cond_units={"wstep": waveunit},
         waveunit=waveunit,

--- a/radis/phys/blackbody.py
+++ b/radis/phys/blackbody.py
@@ -228,11 +228,7 @@ def sPlanck(
             "absorbance": (w, ones_like(w) * inf),
         },
         conditions=conditions,
-        units={
-            "radiance_noslit": Iunit,
-            "transmittance_noslit": "1",
-            "absorbance": "1",
-        },
+        units={"radiance_noslit": Iunit, "transmittance_noslit": "", "absorbance": "",},
         cond_units={"wstep": waveunit},
         waveunit=waveunit,
         name="Planck {0}K, eps={1:.2g}".format(T, eps),

--- a/radis/phys/units.py
+++ b/radis/phys/units.py
@@ -158,7 +158,7 @@ def convert_emi2cm(j_nm, wavenum, Iunit0, Iunit):
     # But both plots look alright
 
     # Convert to whatever was wanted
-    j_cm = conv2(j_cm, "mW/cm**3/sr/cm-1", Iunit)
+    j_cm = conv2(j_cm, "mW/cm3/sr/cm-1", Iunit)
 
     return j_cm
 
@@ -209,7 +209,7 @@ def convert_emi2nm(j_cm, wavenum, Iunit0, Iunit):
     # But both plots look alright
 
     # Convert to whatever was wanted
-    j_nm = conv2(j_nm, "mW/cm**3/sr/nm", Iunit)
+    j_nm = conv2(j_nm, "mW/cm3/sr/nm", Iunit)
 
     return j_nm
 
@@ -326,7 +326,7 @@ def convert_rad2nm(l_cm, wavenum, Iunit0, Iunit):
     # But both plots look alright
 
     # Convert to whatever was wanted
-    l_nm = conv2(l_nm, "mW/cm**2/sr/nm", Iunit)
+    l_nm = conv2(l_nm, "mW/cm2/sr/nm", Iunit)
 
     return l_nm
 
@@ -336,8 +336,8 @@ def convert_universal(
     from_unit,
     to_unit,
     spec=None,
-    per_nm_is_like="mW/sr/cm**2/nm",
-    per_cm_is_like="mW/sr/cm**2/cm-1",
+    per_nm_is_like="mW/sr/cm2/nm",
+    per_cm_is_like="mW/sr/cm2/cm-1",
 ):
     """ Return variable var in whatever unit, and converts to to_unit
     Also deal with cases where var is in ~1/nm (per_nm_is_like) or ~1/cm-1

--- a/radis/phys/units.py
+++ b/radis/phys/units.py
@@ -29,49 +29,9 @@ from __future__ import print_function
 from __future__ import unicode_literals
 import numpy as np
 from os.path import join, dirname, abspath, exists
-from pint import UnitRegistry, DimensionalityError
+from astropy import units as u
 
-ureg = UnitRegistry()
-_units_file = abspath(join(dirname(__file__), "units.txt"))
-# make sure file exists
-if not exists(_units_file):
-    raise AssertionError("Couldn't find units file in : {0}".format(_units_file))
-ureg.load_definitions(_units_file)
-Q_ = ureg.Quantity
-
-# %% Pint aware arrays
-
-
-class uarray(np.ndarray):
-    """ Unit-aware array based on Pint
-
-    Example
-    -------
-
-    >>> a = uarray(np.linspace(10, 100, 10), 'Td')
-
-    """
-
-    def __new__(cls, input_array, unit=None):
-        # Input array is an already formed ndarray instance
-        # We first cast to be our class type
-
-        obj = np.asarray(input_array).view(cls)
-        # add the new attribute to the created instance
-
-        if unit is not None:
-            obj = Q_(obj, unit)
-
-        # Finally, we must return the newly created object:
-        return obj
-
-    def __array_finalize__(self, obj):
-        # see InfoArray.__array_finalize__ for comments
-        if obj is None:
-            return
-
-
-#        self.info = getattr(obj, 'info', None)
+Q_ = u.Unit
 
 
 def conv2(quantity, fromunit, tounit):
@@ -102,46 +62,19 @@ def conv2(quantity, fromunit, tounit):
     sure the units in which some of our quantities will be created, and just
     want to let the users choose another output unit 
 
-    2. 
-    
-    because angles are dimensionless a 'mW/cm2/sr/nm' > 'mW/cm2/nm' conversion 
-    is considered  valid, while we expected the Luminance to be converted to 
-    an exitance/irradiance and thus multiplied by Pi !
-    Here we prevent this behavior by considering 
-        
-    
 
     """
 
     try:
-        a = Q_(quantity, fromunit)
-        a = a.to(tounit)
+        a = quantity * u.Unit(fromunit)
+        a = a.to(u.Unit(tounit))
 
-        # Hardcoded: 'pint' considers angles to be dimensionless (which they are)
-        # so a 'mW/cm2/sr/nm' > 'mW/cm2/nm' conversion is then considered  valid,
-        # while we expected the Luminance to be converted to an Exitance/Irradiance
-        # and thus multiplied by Pi !!
-        # Here we prevent this behavior:
+    except u.UnitConversionError:
+        raise TypeError(
+            "Cannot convert quantity to the specified unit. Please check the dimensions."
+        )
 
-        if "sr" in fromunit and "sr" not in tounit:
-            raise DimensionalityError(fromunit, tounit)
-        if "sr" in tounit and "sr" not in fromunit:
-            raise DimensionalityError(fromunit, tounit)
-
-    except TypeError:
-        if "cm-1" in fromunit or "cm-1" in tounit:
-            #            raise TypeError('Use cm_1 instead of cm-1 else it triggers errors in '+\
-            #                            'pint (symbolic unit converter)')
-            return conv2(
-                quantity,
-                fromunit.replace("cm-1", "cm_1"),
-                tounit.replace("cm-1", "cm_1"),
-            )
-
-        else:
-            raise
-
-    return a.magnitude
+    return a.value
 
 
 def is_homogeneous(unit1, unit2):
@@ -157,9 +90,9 @@ def is_homogeneous(unit1, unit2):
     """
 
     try:
-        Q_(unit1) + Q_(unit2)
+        1 * u.Unit(unit1) + 1 * u.Unit(unit2)
         return True
-    except DimensionalityError:
+    except u.UnitConversionError:
         return False
 
 
@@ -169,7 +102,7 @@ def is_homogeneous(unit1, unit2):
 def convert_emi2cm(j_nm, wavenum, Iunit0, Iunit):
     """
     Convert spectral emission density in wavelength base (typically ~mW/cm3/sr/nm) 
-    to spectral emission density in wavenumber base (~mW/cm3/sr/cm_1)
+    to spectral emission density in wavenumber base (~mW/cm3/sr/cm-1)
 
 
     Parameters    
@@ -207,7 +140,7 @@ def convert_emi2cm(j_nm, wavenum, Iunit0, Iunit):
     Validation:
 
         >>> w_nm, j_nm = s.get('emisscoeff', 'nm', 'mW/cm2/sr/nm')
-        >>> w_cm, j_cm = s.get('emisscoeff', 'cm', 'mW/cm2/sr/cm_1')
+        >>> w_cm, j_cm = s.get('emisscoeff', 'cm', 'mW/cm2/sr/cm-1')
         >>> print(trapz(y_nm, x_nm))
         >>> print(trapz(y_cm, x_cm))
 
@@ -215,12 +148,9 @@ def convert_emi2cm(j_nm, wavenum, Iunit0, Iunit):
 
     """
 
-    if Q_(Iunit0) != Q_(
-        "mW/cm3/sr/nm"
-    ):  # Q_ makes sure 'mW/sr/cm3/nm' == 'mW/cm3/sr/nm'
-        j_nm = conv2(j_nm, Iunit0, "mW/cm3/sr/nm")
+    j_nm = conv2(j_nm, Iunit0, "mW/cm**3/sr/nm")
 
-    # Convert ''mW/cm3/sr/nm' to 'mW/cm3/sr/cm_1'
+    # Convert ''mW/cm3/sr/nm' to 'mW/cm3/sr/cm-1'
     j_cm = j_nm * 1e7 / wavenum ** 2
     # note that we discard the - sign.
     # This means that one of the integrals `trapz(j_nm, wavelen)` or
@@ -228,14 +158,14 @@ def convert_emi2cm(j_nm, wavenum, Iunit0, Iunit):
     # But both plots look alright
 
     # Convert to whatever was wanted
-    j_cm = conv2(j_cm, "mW/cm3/sr/cm_1", Iunit)
+    j_cm = conv2(j_cm, "mW/cm**3/sr/cm-1", Iunit)
 
     return j_cm
 
 
 def convert_emi2nm(j_cm, wavenum, Iunit0, Iunit):
     """
-    Convert spectral emission density in wavenumber base (typically ~mW/cm3/sr/cm_1) to 
+    Convert spectral emission density in wavenumber base (typically ~mW/cm3/sr/cm-1) to
     spectral radiance in wavelength base (~mW/cm3/sr/nm)
 
 
@@ -269,10 +199,9 @@ def convert_emi2nm(j_cm, wavenum, Iunit0, Iunit):
 
     """
 
-    if Q_(Iunit0) != Q_("mW/cm3/sr/cm_1"):
-        j_cm = conv2(j_cm, Iunit0, "mW/cm3/sr/cm_1")
+    j_cm = conv2(j_cm, Iunit0, "mW/cm3/sr/cm-1")
 
-    # Convert 'mW/cm3/sr/cm_1' to 'mW/cm3/sr/nm'
+    # Convert 'mW/cm3/sr/cm-1' to 'mW/cm3/sr/nm'
     j_nm = j_cm * 1e-7 * wavenum ** 2
     # note that we discard the - sign.
     # This means that one of the integrals `trapz(L_nm, wavelen)` or
@@ -280,7 +209,7 @@ def convert_emi2nm(j_cm, wavenum, Iunit0, Iunit):
     # But both plots look alright
 
     # Convert to whatever was wanted
-    j_nm = conv2(j_nm, "mW/cm3/sr/nm", Iunit)
+    j_nm = conv2(j_nm, "mW/cm**3/sr/nm", Iunit)
 
     return j_nm
 
@@ -291,7 +220,7 @@ def convert_emi2nm(j_cm, wavenum, Iunit0, Iunit):
 def convert_rad2cm(l_nm, wavenum, Iunit0, Iunit):
     """
     Convert spectral radiance in wavelength base (~1/nm) to spectral radiance in
-    wavenumber base (~1/cm_1)
+    wavenumber base (~1/cm-1)
 
 
     Parameters    
@@ -329,7 +258,7 @@ def convert_rad2cm(l_nm, wavenum, Iunit0, Iunit):
     Validation:
 
         >>> x_nm, y_nm = s.get('radiance_noslit', 'nm', 'mW/cm2/sr/nm')
-        >>> x_cm, y_cm = s.get('radiance_noslit', 'cm', 'mW/cm2/sr/cm_1')
+        >>> x_cm, y_cm = s.get('radiance_noslit', 'cm', 'mW/cm2/sr/cm-1')
         >>> print(trapz(y_nm, x_nm))
         >>> print(trapz(y_cm, x_cm))
 
@@ -337,12 +266,9 @@ def convert_rad2cm(l_nm, wavenum, Iunit0, Iunit):
 
     """
 
-    if Q_(Iunit0) != Q_(
-        "mW/cm2/sr/nm"
-    ):  # Q_ makes sure 'mW/sr/cm2/nm' == 'mW/cm2/sr/nm'
-        l_nm = conv2(l_nm, Iunit0, "mW/cm2/sr/nm")
+    l_nm = conv2(l_nm, Iunit0, "mW/cm2/sr/nm")
 
-    # Convert ''mW/cm2/sr/nm' to 'mW/cm2/sr/cm_1'
+    # Convert ''mW/cm2/sr/nm' to 'mW/cm2/sr/cm-1'
     l_cm = l_nm * 1e7 / wavenum ** 2
     # note that we discard the - sign.
     # This means that one of the integrals `trapz(L_nm, wavelen)` or
@@ -350,14 +276,14 @@ def convert_rad2cm(l_nm, wavenum, Iunit0, Iunit):
     # But both plots look alright
 
     # Convert to whatever was wanted
-    l_cm = conv2(l_cm, "mW/cm2/sr/cm_1", Iunit)
+    l_cm = conv2(l_cm, "mW/cm2/sr/cm-1", Iunit)
 
     return l_cm
 
 
 def convert_rad2nm(l_cm, wavenum, Iunit0, Iunit):
     """
-    Convert spectral radiance in wavenumber base (~1/cm_1) to spectral radiance in
+    Convert spectral radiance in wavenumber base (~1/cm-1) to spectral radiance in
     wavelength base (~1/nm)
 
 
@@ -390,12 +316,9 @@ def convert_rad2nm(l_cm, wavenum, Iunit0, Iunit):
 
     """
 
-    if Q_(Iunit0) != Q_(
-        "mW/cm2/sr/cm_1"
-    ):  # Q_ makes sure 'mW/sr/cm2/cm_1' == 'mW/cm2/sr/cm_1'
-        l_cm = conv2(l_cm, Iunit0, "mW/cm2/sr/cm_1")
+    l_cm = conv2(l_cm, Iunit0, "mW/cm2/sr/cm-1")
 
-    # Convert 'mW/cm2/sr/cm_1' to 'mW/cm2/sr/nm'
+    # Convert 'mW/cm2/sr/cm-1' to 'mW/cm2/sr/nm'
     l_nm = l_cm * 1e-7 * wavenum ** 2
     # note that we discard the - sign.
     # This means that one of the integrals `trapz(L_nm, wavelen)` or
@@ -403,7 +326,7 @@ def convert_rad2nm(l_cm, wavenum, Iunit0, Iunit):
     # But both plots look alright
 
     # Convert to whatever was wanted
-    l_nm = conv2(l_nm, "mW/cm2/sr/nm", Iunit)
+    l_nm = conv2(l_nm, "mW/cm**2/sr/nm", Iunit)
 
     return l_nm
 
@@ -413,8 +336,8 @@ def convert_universal(
     from_unit,
     to_unit,
     spec=None,
-    per_nm_is_like="mW/sr/cm2/nm",
-    per_cm_is_like="mW/sr/cm2/cm_1",
+    per_nm_is_like="mW/sr/cm**2/nm",
+    per_cm_is_like="mW/sr/cm**2/cm-1",
 ):
     """ Return variable var in whatever unit, and converts to to_unit
     Also deal with cases where var is in ~1/nm (per_nm_is_like) or ~1/cm-1
@@ -463,8 +386,8 @@ def convert_universal(
             # raise here if the input was non-sense.
         else:  # general case: just convert
             I = conv2(I, Iunit0, Iunit)
-    except DimensionalityError:
-        raise DimensionalityError(Iunit0, Iunit)
+    except u.UnitConversionError:
+        raise TypeError(Iunit0, Iunit)
 
     return I
 

--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -991,7 +991,6 @@ def plot_diff(
     if title:
         fig.suptitle(title)
     # Fix format
-    # print("ax0=", ax0)
     fix_style("origin", ax=ax0)
     for ax1i in ax1:
         fix_style("origin", ax=ax1i)

--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -776,6 +776,7 @@ def plot_diff(
     if Iunit == "default":
         try:
             Iunit = s1.units[var]
+            # print("-----> IUNIT = ", Iunit)
         except KeyError:  # unit not defined in dictionary
             raise KeyError(
                 "Iunit not defined in spectrum for variable {0}. ".format(var)
@@ -907,6 +908,9 @@ def plot_diff(
             label=label2
         )
 
+    if var in ["transmittance", "transmittance_noslit"] and wunit == "1":
+        Iunit = "I/I0"  # more explicit for the user
+
     Iunit = make_up(Iunit)  # cosmetic changes
 
     ax0.tick_params(labelbottom=False)
@@ -983,8 +987,9 @@ def plot_diff(
 
     if title:
         fig.suptitle(title)
-
+    # print("CALLED PLOT DIFF FUNCTION///...........")
     # Fix format
+    # print("ax0=", ax0)
     fix_style("origin", ax=ax0)
     for ax1i in ax1:
         fix_style("origin", ax=ax1i)

--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -910,6 +910,10 @@ def plot_diff(
 
     if var in ["transmittance", "transmittance_noslit"] and wunit == "1":
         Iunit = "1"  # more explicit for the user
+    elif var == 'abscoeff' and wunits == "1":
+        Iunit = "-ln(I/I0)" # more explicit for the user
+    elif var in ["emissivity_no_slit", "emissivity"] and wunits == "1":
+        Iunit = "eps"  # more explicit for the user
 
     Iunit = make_up(Iunit)  # cosmetic changes
 
@@ -987,7 +991,6 @@ def plot_diff(
 
     if title:
         fig.suptitle(title)
-    # print("CALLED PLOT DIFF FUNCTION///...........")
     # Fix format
     # print("ax0=", ax0)
     fix_style("origin", ax=ax0)

--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -907,14 +907,16 @@ def plot_diff(
             label=label2
         )
 
-    if var in ["transmittance", "transmittance_noslit"] and wunit == "":
-        Iunit = "1"  # more explicit for the user
-    elif var == "abscoeff" and wunit == "":
-        Iunit = "-ln(I/I0)"  # more explicit for the user
-    elif var in ["emissivity_no_slit", "emissivity"] and wunit == "":
-        Iunit = "eps"  # more explicit for the user
-
-    Iunit = make_up(Iunit)  # cosmetic changes
+    # cosmetic changes
+    if Iunit == "":
+        # give more explicit unit for the user:
+        if var in ["transmittance", "transmittance_noslit"]:
+            Iunit = r"I/I0"
+        elif var == "absorbance":
+            Iunit = r"-ln(I/I0)"
+        elif var in ["emissivity_no_slit", "emissivity"]:
+            Iunit = r"$\mathregular{\epsilon}$"
+    Iunit = make_up(Iunit)
 
     ax0.tick_params(labelbottom=False)
     if label1 is not None or label2 is not None:

--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -909,7 +909,7 @@ def plot_diff(
         )
 
     if var in ["transmittance", "transmittance_noslit"] and wunit == "1":
-        Iunit = "I/I0"  # more explicit for the user
+        Iunit = "1"  # more explicit for the user
 
     Iunit = make_up(Iunit)  # cosmetic changes
 

--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -907,11 +907,11 @@ def plot_diff(
             label=label2
         )
 
-    if var in ["transmittance", "transmittance_noslit"] and wunit == "1":
+    if var in ["transmittance", "transmittance_noslit"] and wunit == "":
         Iunit = "1"  # more explicit for the user
-    elif var == "abscoeff" and wunit == "1":
+    elif var == "abscoeff" and wunit == "":
         Iunit = "-ln(I/I0)"  # more explicit for the user
-    elif var in ["emissivity_no_slit", "emissivity"] and wunit == "1":
+    elif var in ["emissivity_no_slit", "emissivity"] and wunit == "":
         Iunit = "eps"  # more explicit for the user
 
     Iunit = make_up(Iunit)  # cosmetic changes

--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -776,7 +776,6 @@ def plot_diff(
     if Iunit == "default":
         try:
             Iunit = s1.units[var]
-            # print("-----> IUNIT = ", Iunit)
         except KeyError:  # unit not defined in dictionary
             raise KeyError(
                 "Iunit not defined in spectrum for variable {0}. ".format(var)
@@ -910,9 +909,9 @@ def plot_diff(
 
     if var in ["transmittance", "transmittance_noslit"] and wunit == "1":
         Iunit = "1"  # more explicit for the user
-    elif var == 'abscoeff' and wunits == "1":
-        Iunit = "-ln(I/I0)" # more explicit for the user
-    elif var in ["emissivity_no_slit", "emissivity"] and wunits == "1":
+    elif var == "abscoeff" and wunit == "1":
+        Iunit = "-ln(I/I0)"  # more explicit for the user
+    elif var in ["emissivity_no_slit", "emissivity"] and wunit == "1":
         Iunit = "eps"  # more explicit for the user
 
     Iunit = make_up(Iunit)  # cosmetic changes

--- a/radis/spectrum/models.py
+++ b/radis/spectrum/models.py
@@ -113,7 +113,7 @@ def calculated_spectrum(
 
 
 def transmittance_spectrum(
-    w, T, wunit="nm", Tunit="I/I0", conditions=None, cond_units=None, name=None
+    w, T, wunit="nm", Tunit="1", conditions=None, cond_units=None, name=None
 ):  # -> Spectrum:
     """ Convert ``(w, I)`` into a :py:class:`~radis.spectrum.spectrum.Spectrum`  
     object that has unit conversion, plotting and slit convolution capabilities
@@ -133,7 +133,7 @@ def transmittance_spectrum(
         (``'cm-1'``), or wavelength in vacuum (``'nm_vac'``). Default ``'nm'``. 
 
     Iunit: str
-        intensity unit. Default ``'I/I0'``
+        intensity unit. Default ``'1'``
 
 
     Other Parameters

--- a/radis/spectrum/models.py
+++ b/radis/spectrum/models.py
@@ -113,7 +113,7 @@ def calculated_spectrum(
 
 
 def transmittance_spectrum(
-    w, T, wunit="nm", Tunit="1", conditions=None, cond_units=None, name=None
+    w, T, wunit="nm", Tunit="", conditions=None, cond_units=None, name=None
 ):  # -> Spectrum:
     """ Convert ``(w, I)`` into a :py:class:`~radis.spectrum.spectrum.Spectrum`  
     object that has unit conversion, plotting and slit convolution capabilities
@@ -133,7 +133,7 @@ def transmittance_spectrum(
         (``'cm-1'``), or wavelength in vacuum (``'nm_vac'``). Default ``'nm'``. 
 
     Iunit: str
-        intensity unit. Default ``'1'``
+        intensity unit. Default ``""`` (adimensionned)
 
 
     Other Parameters

--- a/radis/spectrum/rescale.py
+++ b/radis/spectrum/rescale.py
@@ -740,7 +740,7 @@ def _recompute_all_at_equilibrium(
     rescaled["radiance_noslit"] = radiance_noslit
     rescaled["emisscoeff"] = emisscoeff
 
-    units["abscoeff"] = "cm_1"
+    units["abscoeff"] = "cm-1"
     units["absorbance"] = "-ln(I/I0)"
     units["transmittance_noslit"] = "I/I0"
     units["emissivity_noslit"] = "eps"

--- a/radis/spectrum/rescale.py
+++ b/radis/spectrum/rescale.py
@@ -741,9 +741,9 @@ def _recompute_all_at_equilibrium(
     rescaled["emisscoeff"] = emisscoeff
 
     units["abscoeff"] = "cm-1"
-    units["absorbance"] = "-ln(I/I0)"
-    units["transmittance_noslit"] = "I/I0"
-    units["emissivity_noslit"] = "eps"
+    units["absorbance"] = "1"
+    units["transmittance_noslit"] = "1"
+    units["emissivity_noslit"] = "1"
     units["radiance_noslit"] = get_unit_radiance()
     units["emisscoeff"] = get_unit_emisscoeff(units["radiance_noslit"])
 
@@ -955,13 +955,13 @@ def rescale_absorbance(
         )
         absorbance *= new_mole_fraction / old_mole_fraction  # rescale x
         absorbance *= new_path_length / old_path_length  # rescale L
-        unit = "-ln(I/I0)"
+        unit = "1"
     elif "abscoeff" in rescaled and true_path_length:
         if __debug__:
             printdbg("... rescale: absorbance A2 = j2*L2")
         abscoeff = rescaled["abscoeff"]  # x already scaled
         absorbance = abscoeff * new_path_length  # calculate L
-        unit = "-ln(I/I0)"
+        unit = "1"
     elif "transmittance_noslit" in initial and true_path_length:
         if __debug__:
             printdbg("... rescale: absorbance A2 = -ln(T1)*N2/N1*L2/L1")
@@ -983,7 +983,7 @@ def rescale_absorbance(
         absorbance = -ln(T1)
         absorbance *= new_mole_fraction / old_mole_fraction  # rescale x
         absorbance *= new_path_length / old_path_length  # rescale L
-        unit = "-ln(I/I0)"
+        unit = "1"
     else:
         msg = (
             "Cant recalculate absorbance if scaled absoeff "
@@ -1035,7 +1035,7 @@ def rescale_transmittance_noslit(
     unit = None
 
     def get_unit():
-        return "I/I0"
+        return "1"
 
     # case where we recomputed it already (somehow... ex: no_change signaled)
     if "transmittance_noslit" in rescaled:
@@ -1136,7 +1136,7 @@ def rescale_transmittance(
     #    unit = None
     apply_slit = False
     #    def get_unit():
-    #        return 'I/I0'
+    #        return '1'
 
     # case where we recomputed it already (somehow... ex: no_change signaled)
     if "transmittance" in rescaled:
@@ -1382,7 +1382,7 @@ def rescale_emissivity_noslit(spec, rescaled, units, extra, true_path_length):
     # Export rescaled value
     if emissivity_noslit is not None:
         rescaled["emissivity_noslit"] = emissivity_noslit
-        units["emissivity_noslit"] = "eps"
+        units["emissivity_noslit"] = "1"
 
     return rescaled, units
 

--- a/radis/spectrum/rescale.py
+++ b/radis/spectrum/rescale.py
@@ -741,9 +741,9 @@ def _recompute_all_at_equilibrium(
     rescaled["emisscoeff"] = emisscoeff
 
     units["abscoeff"] = "cm-1"
-    units["absorbance"] = "1"
-    units["transmittance_noslit"] = "1"
-    units["emissivity_noslit"] = "1"
+    units["absorbance"] = ""
+    units["transmittance_noslit"] = ""
+    units["emissivity_noslit"] = ""
     units["radiance_noslit"] = get_unit_radiance()
     units["emisscoeff"] = get_unit_emisscoeff(units["radiance_noslit"])
 
@@ -955,13 +955,13 @@ def rescale_absorbance(
         )
         absorbance *= new_mole_fraction / old_mole_fraction  # rescale x
         absorbance *= new_path_length / old_path_length  # rescale L
-        unit = "1"
+        unit = ""
     elif "abscoeff" in rescaled and true_path_length:
         if __debug__:
             printdbg("... rescale: absorbance A2 = j2*L2")
         abscoeff = rescaled["abscoeff"]  # x already scaled
         absorbance = abscoeff * new_path_length  # calculate L
-        unit = "1"
+        unit = ""
     elif "transmittance_noslit" in initial and true_path_length:
         if __debug__:
             printdbg("... rescale: absorbance A2 = -ln(T1)*N2/N1*L2/L1")
@@ -983,7 +983,7 @@ def rescale_absorbance(
         absorbance = -ln(T1)
         absorbance *= new_mole_fraction / old_mole_fraction  # rescale x
         absorbance *= new_path_length / old_path_length  # rescale L
-        unit = "1"
+        unit = ""
     else:
         msg = (
             "Cant recalculate absorbance if scaled absoeff "
@@ -1035,7 +1035,7 @@ def rescale_transmittance_noslit(
     unit = None
 
     def get_unit():
-        return "1"
+        return ""
 
     # case where we recomputed it already (somehow... ex: no_change signaled)
     if "transmittance_noslit" in rescaled:
@@ -1382,7 +1382,7 @@ def rescale_emissivity_noslit(spec, rescaled, units, extra, true_path_length):
     # Export rescaled value
     if emissivity_noslit is not None:
         rescaled["emissivity_noslit"] = emissivity_noslit
-        units["emissivity_noslit"] = "1"
+        units["emissivity_noslit"] = ""
 
     return rescaled, units
 

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -166,7 +166,7 @@ class Spectrum(object):
         s.print_conditions()
         s.plot('absorbance')
         s.line_survey(overlay='absorbance')
-        s.plot('radiance_noslit', wunits='cm-1', Iunits='W/m2/sr/cm_1')
+        s.plot('radiance_noslit', wunits='cm-1', Iunits='W/m2/sr/cm-1')
         s.apply_slit(5)
         s.plot('radiance')
         w, t = s.get('transmittance_noslit')  # for use in multi-slabs configs
@@ -428,7 +428,7 @@ class Spectrum(object):
             
             from radis import Spectrum
             s = Spectrum({'abscoeff': (w, A), 'emisscoeff': (w, E)},
-                         units={'abscoeff': 'cm_1', 'emisscoeff':'W/cm2/sr/nm'},
+                         units={'abscoeff': 'cm-1', 'emisscoeff':'W/cm2/sr/nm'},
                          waveunit='nm')
 
 
@@ -550,7 +550,7 @@ class Spectrum(object):
             
             from radis import Spectrum
             s = Spectrum({'abscoeff': (w, A), 'emisscoeff': (w, E)},
-                         units={'abscoeff': 'cm_1', 'emisscoeff':'W/cm2/sr/nm'},
+                         units={'abscoeff': 'cm-1', 'emisscoeff':'W/cm2/sr/nm'},
                          waveunit='nm')
 
         Notes
@@ -629,7 +629,7 @@ class Spectrum(object):
         Iunit: unit for variable ``var``
             if 'default', default unit for quantity `var` is used. See Spectrum.units
             to get the units. for radiance, one can use per wavelength (~ 'W/m2/sr/nm')
-            or per wavenumber (~ 'W/m2/sr/cm_1') units
+            or per wavenumber (~ 'W/m2/sr/cm-1') units
 
         Other Parameters
         ----------------
@@ -714,7 +714,7 @@ class Spectrum(object):
         if Iunit != "default" and Iunit != Iunit0:
             if var in ["radiance", "radiance_noslit"]:
                 # deal with the case where we want to get a radiance in per
-                # wavelength unit (~ W/sr/cm2/nm) in wavenumber units (~ W/sr/cm2/cm_1),
+                # wavelength unit (~ W/sr/cm2/nm) in wavenumber units (~ W/sr/cm2/cm-1),
                 # or the other way round
                 I = convert_universal(
                     I,
@@ -722,17 +722,17 @@ class Spectrum(object):
                     Iunit,
                     self,
                     per_nm_is_like="mW/sr/cm2/nm",
-                    per_cm_is_like="mW/sr/cm2/cm_1",
+                    per_cm_is_like="mW/sr/cm2/cm-1",
                 )
             elif var in ["emisscoeff"]:
-                # idem for emisscoeff in (~ W/sr/cm3/nm) or (~ /sr/cm3/cm_1)
+                # idem for emisscoeff in (~ W/sr/cm3/nm) or (~ /sr/cm3/cm-1)
                 I = convert_universal(
                     I,
                     Iunit0,
                     Iunit,
                     self,
                     per_nm_is_like="mW/sr/cm3/nm",
-                    per_cm_is_like="mW/sr/cm3/cm_1",
+                    per_cm_is_like="mW/sr/cm3/cm-1",
                 )
             elif var in ["absorbance"]:  # no unit
                 assert Iunit in ["", "-ln(I/I0)"]
@@ -1477,7 +1477,7 @@ class Spectrum(object):
         Iunit: unit for variable
             if `default`, default unit for quantity `var` is used.
             for radiance, one can use per wavelength (~ `W/m2/sr/nm`) or
-            per wavenumber (~ `W/m2/sr/cm_1`) units
+            per wavenumber (~ `W/m2/sr/cm-1`) units
 
 
         Other Parameters
@@ -1529,7 +1529,7 @@ class Spectrum(object):
         arbitrary units::
             
             s = experimental_spectrum(..., Iunit='mW/cm2/sr/nm')
-            s.plot(Iunit='W/cm2/sr/cm_1')
+            s.plot(Iunit='W/cm2/sr/cm-1')
             
         See more examples in :ref:`the plot Spectral quantities page <label_spectrum_plot>`. 
             
@@ -1544,6 +1544,7 @@ class Spectrum(object):
         # Check inputs, get defaults
         # ------
 
+        # print("PLOT SPECTRUM CALLED...")
         if var in ["intensity", "intensity_noslit"]:
             raise ValueError("`intensity` not defined. Use `radiance` instead")
 
@@ -1563,10 +1564,13 @@ class Spectrum(object):
                 if var.replace("_noslit", "") in params:  # favour convolved quantities
                     var = var.replace("_noslit", "")
 
+        # print("TILL LINE 1567..")
         if wunit == "default":
             wunit = self.get_waveunit()
         wunit = cast_waveunit(wunit)
 
+        # print("WAVEUNIT = ", wunit)
+        # print("TILL 1573...")
         # Get variable
         x, y = self.get(var, wunit=wunit, Iunit=Iunit)
 
@@ -1580,10 +1584,16 @@ class Spectrum(object):
                 Iunit0 = "a.u"
             Iunit = Iunit0
 
+        # rint("TILL 1587...")
+
+        if var in ["transmittance", "transmittance_noslit"] and wunit == "1":
+            Iunit = "I/I0"  # more explicit for the user
         # cosmetic changes
         Iunit = make_up(Iunit)
+        # print("IUNIT = ", Iunit)
         ylabel = make_up("{0} ({1})".format(var, Iunit))
 
+        # print("TILL 1593....")
         # Plot
         # -------
         if normalize:
@@ -1597,7 +1607,8 @@ class Spectrum(object):
                 y /= np.nanmax(y)
             Iunit = "norm"
 
-        set_style("origin")
+        # print("TILL 1607...")
+        # set_style("origin")
         if nfig == "same":
             nfig = plt.gcf().number
         fig = plt.figure(nfig)
@@ -1608,11 +1619,13 @@ class Spectrum(object):
         # they cannot be differenced. But at least this allows user to plot
         # both on the same figure if they want to compare
 
+        # print("TILL 1619...")
         def clean_error_msg(string):
             string = string.replace(r"$^\mathregular{", "^")
             string = string.replace(r"}$", "")
             return string
 
+        # print("TILL 1625...")
         if not force and (fig.gca().get_xlabel().lower() not in ["", xlabel.lower()]):
             raise ValueError(
                 "Error while plotting {0}. Cannot plot ".format(var)
@@ -1632,6 +1645,7 @@ class Spectrum(object):
                 + "\nUse force=True if you really want to plot"
             )
 
+        # print("TILL 1645...")
         # Add extra plotting parameters
         if "lw" not in kwargs and "linewidth" not in kwargs:
             kwargs["lw"] = 0.5
@@ -1646,15 +1660,16 @@ class Spectrum(object):
         plt.xlabel(xlabel)
         plt.ylabel(ylabel)
 
+        # print("TILL 1660...")
         plt.yscale(yscale)
 
         if "label" in kwargs:
             plt.legend()
-
-        fix_style(str("origin"))
-
+        # print("TILL 1665,...")
+        # fix_style(str("origin"))
+        # print("TILL 1667...")
         plt.show()
-
+        # print('TILL 1669...')
         return line
 
     def get_populations(self, molecule=None, isotope=None, electronic_state=None):
@@ -2390,7 +2405,7 @@ class Spectrum(object):
                 self.units[q] = self.units[qns]
             elif norm_by == "max":
                 new_unit = "{0}*{1}".format(
-                    self.units[qns], unit.replace("cm-1", "cm_1")
+                    self.units[qns], unit.replace("cm-1", "cm-1")
                 )
                 # because it's like if we multiplied
                 # by slit FWHM in the wavespace it was

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -1579,11 +1579,11 @@ class Spectrum(object):
                 Iunit0 = "a.u"
             Iunit = Iunit0
 
-        if var in ["transmittance", "transmittance_noslit"] and wunit == "1":
+        if var in ["transmittance", "transmittance_noslit"] and wunit == "":
             Iunit = "1"  # more explicit for the user
-        elif var == "abscoeff" and wunit == "1":
+        elif var == "abscoeff" and wunit == "":
             Iunit = "-ln(I/I0)"  # more explicit for the user
-        elif var in ["emissivity_no_slit", "emissivity"] and wunit == "1":
+        elif var in ["emissivity_no_slit", "emissivity"] and wunit == "":
             Iunit = "eps"  # more explicit for the user
         # cosmetic changes
         Iunit = make_up(Iunit)
@@ -2391,10 +2391,7 @@ class Spectrum(object):
             if norm_by == "area":
                 self.units[q] = self.units[qns]
             elif norm_by == "max":
-                if self.units[qns] == "1":
-                    new_unit = unit
-                else:
-                    new_unit = "{0} * {1}".format(unit, self.units[qns])
+                new_unit = (u.Unit(unit) * u.Unit(self.units[qns])).to_string()
                 # because it's like if we multiplied
                 # by slit FWHM in the wavespace it was
                 # generated
@@ -2511,7 +2508,7 @@ class Spectrum(object):
         if norm_by == "area":
             Iunit = "1/{0}".format(waveunit)
         elif norm_by == "max":  # set maximum to 1
-            Iunit = "1"
+            Iunit = ""
         elif norm_by is None:
             Iunit = None
         else:

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -1603,7 +1603,7 @@ class Spectrum(object):
                 y /= np.nanmax(y)
             Iunit = "norm"
 
-        # set_style("origin")
+        set_style("origin")
         if nfig == "same":
             nfig = plt.gcf().number
         fig = plt.figure(nfig)

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -1587,7 +1587,7 @@ class Spectrum(object):
         # rint("TILL 1587...")
 
         if var in ["transmittance", "transmittance_noslit"] and wunit == "1":
-            Iunit = "1"  # more explicit for the user
+            Iunit = "I/IO"  # more explicit for the user
         # cosmetic changes
         Iunit = make_up(Iunit)
         # print("IUNIT = ", Iunit)

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -46,7 +46,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from publib import set_style, fix_style
 from radis.phys.convert import conv2, cm2nm, nm2cm
-from radis.phys.units import Q_, convert_universal
+from radis.phys.units import Unit, convert_universal
 from radis.phys.air import vacuum2air, air2vacuum
 from radis.spectrum.utils import (
     CONVOLUTED_QUANTITIES,
@@ -1578,16 +1578,15 @@ class Spectrum(object):
                 Iunit0 = "a.u"
             Iunit = Iunit0
 
-        if var in ["transmittance", "transmittance_noslit"] and wunit == "":
-            Iunit = "1"  # more explicit for the user
-        elif var == "abscoeff" and wunit == "":
-            Iunit = "-ln(I/I0)"  # more explicit for the user
-        elif var in ["emissivity_no_slit", "emissivity"] and wunit == "":
-            Iunit = "eps"  # more explicit for the user
-
-        if Iunit == "":
-            Iunit = "1"
         # cosmetic changes
+        if Iunit == "":
+            # give more explicit unit for the user:
+            if var in ["transmittance", "transmittance_noslit"]:
+                Iunit = r"I/I0"
+            elif var == "absorbance":
+                Iunit = r"-ln(I/I0)"
+            elif var in ["emissivity_no_slit", "emissivity"]:
+                Iunit = r"$\mathregular{\epsilon}$"
         Iunit = make_up(Iunit)
         ylabel = make_up("{0} ({1})".format(var, Iunit))
         # Plot
@@ -2392,15 +2391,9 @@ class Spectrum(object):
             if norm_by == "area":
                 self.units[q] = self.units[qns]
             elif norm_by == "max":
-                new_unit = (u.Unit(unit) * u.Unit(self.units[qns])).to_string()
-                # because it's like if we multiplied
-                # by slit FWHM in the wavespace it was
-                # generated
-                # simplify unit:
-                try:
-                    new_unit = str(Q_(new_unit))
-                except UndefinedUnitError:
-                    pass
+                new_unit = (Unit(unit) * Unit(self.units[qns])).to_string()
+                # because it's like if we multiplied by slit FWHM in the wavespace
+                # it was generated
                 self.units[q] = new_unit
             # Note: there was another mode called 'max2' where, unlike 'max',
             # unit was multiplied by [unit] not [return_unit]

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -2393,13 +2393,9 @@ class Spectrum(object):
                 self.units[q] = self.units[qns]
             elif norm_by == "max":
                 if self.units[qns] == "1":
-                    new_unit = "{0}*{1}".format(
-                        self.units[qns], unit.replace("cm-1", "cm-1")
-                    )
+                    new_unit = unit
                 else:
-                    new_unit = "{0}*{1}".format(
-                        unit.replace("cm-1", "cm-1"), self.units[qns]
-                    )
+                    new_unit = "{0} * {1}".format(unit, self.units[qns])
                 # because it's like if we multiplied
                 # by slit FWHM in the wavespace it was
                 # generated

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -74,6 +74,7 @@ from copy import deepcopy
 from six import string_types
 from os.path import basename
 from six.moves import zip
+from astropy import units as u
 
 
 # %% Spectrum class to hold results )
@@ -1565,13 +1566,11 @@ class Spectrum(object):
         if wunit == "default":
             wunit = self.get_waveunit()
         wunit = cast_waveunit(wunit)
-
         # Get variable
         x, y = self.get(var, wunit=wunit, Iunit=Iunit)
 
         # Get labels
         xlabel = format_xlabel(wunit, plot_medium)
-
         if Iunit == "default":
             try:
                 Iunit0 = self.units[var]
@@ -1585,10 +1584,12 @@ class Spectrum(object):
             Iunit = "-ln(I/I0)"  # more explicit for the user
         elif var in ["emissivity_no_slit", "emissivity"] and wunit == "":
             Iunit = "eps"  # more explicit for the user
+
+        if Iunit == "":
+            Iunit = "1"
         # cosmetic changes
         Iunit = make_up(Iunit)
         ylabel = make_up("{0} ({1})".format(var, Iunit))
-
         # Plot
         # -------
         if normalize:

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -735,10 +735,10 @@ class Spectrum(object):
                     per_cm_is_like="mW/sr/cm3/cm-1",
                 )
             elif var in ["absorbance"]:  # no unit
-                assert Iunit in ["", "-ln(I/I0)"]
+                assert Iunit in ["", "1"]
                 # dont change the variable: I has no dimension
             elif var in ["transmittance"]:  # no unit
-                assert Iunit in ["", "I/I0"]
+                assert Iunit in ["", "1"]
                 # dont change the variable: I has no dimension
             else:
                 I = conv2(I, Iunit0, Iunit)
@@ -1587,7 +1587,7 @@ class Spectrum(object):
         # rint("TILL 1587...")
 
         if var in ["transmittance", "transmittance_noslit"] and wunit == "1":
-            Iunit = "I/I0"  # more explicit for the user
+            Iunit = "1"  # more explicit for the user
         # cosmetic changes
         Iunit = make_up(Iunit)
         # print("IUNIT = ", Iunit)
@@ -2404,15 +2404,20 @@ class Spectrum(object):
             if norm_by == "area":
                 self.units[q] = self.units[qns]
             elif norm_by == "max":
-                new_unit = "{0}*{1}".format(
-                    self.units[qns], unit.replace("cm-1", "cm-1")
-                )
+                if self.units[qns] == "1":
+                    new_unit = "{0}*{1}".format(
+                        self.units[qns], unit.replace("cm-1", "cm-1")
+                    )
+                else:
+                    new_unit = "{0}*{1}".format(
+                        unit.replace("cm-1", "cm-1"), self.units[qns]
+                    )
                 # because it's like if we multiplied
                 # by slit FWHM in the wavespace it was
                 # generated
                 # simplify unit:
                 try:
-                    new_unit = "{:~P}".format(Q_(new_unit).units)
+                    new_unit = str(Q_(new_unit))
                 except UndefinedUnitError:
                     pass
                 self.units[q] = new_unit

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -1544,7 +1544,6 @@ class Spectrum(object):
         # Check inputs, get defaults
         # ------
 
-        # print("PLOT SPECTRUM CALLED...")
         if var in ["intensity", "intensity_noslit"]:
             raise ValueError("`intensity` not defined. Use `radiance` instead")
 
@@ -1564,13 +1563,10 @@ class Spectrum(object):
                 if var.replace("_noslit", "") in params:  # favour convolved quantities
                     var = var.replace("_noslit", "")
 
-        # print("TILL LINE 1567..")
         if wunit == "default":
             wunit = self.get_waveunit()
         wunit = cast_waveunit(wunit)
 
-        # print("WAVEUNIT = ", wunit)
-        # print("TILL 1573...")
         # Get variable
         x, y = self.get(var, wunit=wunit, Iunit=Iunit)
 
@@ -1584,16 +1580,16 @@ class Spectrum(object):
                 Iunit0 = "a.u"
             Iunit = Iunit0
 
-        # rint("TILL 1587...")
-
         if var in ["transmittance", "transmittance_noslit"] and wunit == "1":
-            Iunit = "I/IO"  # more explicit for the user
+            Iunit = "1"  # more explicit for the user
+        elif var == "abscoeff" and wunit == "1":
+            Iunit = "-ln(I/I0)"  # more explicit for the user
+        elif var in ["emissivity_no_slit", "emissivity"] and wunit == "1":
+            Iunit = "eps"  # more explicit for the user
         # cosmetic changes
         Iunit = make_up(Iunit)
-        # print("IUNIT = ", Iunit)
         ylabel = make_up("{0} ({1})".format(var, Iunit))
 
-        # print("TILL 1593....")
         # Plot
         # -------
         if normalize:
@@ -1607,7 +1603,6 @@ class Spectrum(object):
                 y /= np.nanmax(y)
             Iunit = "norm"
 
-        # print("TILL 1607...")
         # set_style("origin")
         if nfig == "same":
             nfig = plt.gcf().number
@@ -1619,13 +1614,11 @@ class Spectrum(object):
         # they cannot be differenced. But at least this allows user to plot
         # both on the same figure if they want to compare
 
-        # print("TILL 1619...")
         def clean_error_msg(string):
             string = string.replace(r"$^\mathregular{", "^")
             string = string.replace(r"}$", "")
             return string
 
-        # print("TILL 1625...")
         if not force and (fig.gca().get_xlabel().lower() not in ["", xlabel.lower()]):
             raise ValueError(
                 "Error while plotting {0}. Cannot plot ".format(var)
@@ -1645,7 +1638,6 @@ class Spectrum(object):
                 + "\nUse force=True if you really want to plot"
             )
 
-        # print("TILL 1645...")
         # Add extra plotting parameters
         if "lw" not in kwargs and "linewidth" not in kwargs:
             kwargs["lw"] = 0.5
@@ -1660,16 +1652,12 @@ class Spectrum(object):
         plt.xlabel(xlabel)
         plt.ylabel(ylabel)
 
-        # print("TILL 1660...")
         plt.yscale(yscale)
 
         if "label" in kwargs:
             plt.legend()
-        # print("TILL 1665,...")
-        # fix_style(str("origin"))
-        # print("TILL 1667...")
+        fix_style(str("origin"))
         plt.show()
-        # print('TILL 1669...')
         return line
 
     def get_populations(self, molecule=None, isotope=None, electronic_state=None):

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -68,7 +68,6 @@ from radis.misc.arrays import (
 )
 from radis.misc.debug import printdbg
 from radis.misc.signal import resample
-from pint import UndefinedUnitError
 from warnings import warn
 from numpy import abs, diff
 from copy import deepcopy

--- a/radis/spectrum/utils.py
+++ b/radis/spectrum/utils.py
@@ -153,7 +153,7 @@ def make_up(label):
     """
 
     # Improve units
-    label = label.replace(r"cm-1", r"cm-1")
+    label = label.replace(r"um", r"µm")
     label = label.replace(r"cm-1", r"cm$^\mathregular{-1}$")
     label = label.replace(r"m^-1", r"m$^\mathregular{-1}$")
     label = label.replace(r"m2", r"m$^\mathregular{2}$")

--- a/radis/spectrum/utils.py
+++ b/radis/spectrum/utils.py
@@ -15,7 +15,7 @@ from radis.misc.basics import partition
 
 # Waverange, wavespaces
 # ... aliases:
-WAVENUM_UNITS = ["cm", "cm-1", "cm_1", "wavenumber"]
+WAVENUM_UNITS = ["cm", "cm-1", "cm-1", "wavenumber"]
 WAVELEN_UNITS = ["nm", "wavelength"]
 WAVELENVAC_UNITS = ["nm_vac", "nm_vacuum"]
 # ... internal names
@@ -153,7 +153,7 @@ def make_up(label):
     """
 
     # Improve units
-    label = label.replace(r"cm_1", r"cm-1")
+    label = label.replace(r"cm-1", r"cm-1")
     label = label.replace(r"cm-1", r"cm$^\mathregular{-1}$")
     label = label.replace(r"m^-1", r"m$^\mathregular{-1}$")
     label = label.replace(r"m2", r"m$^\mathregular{2}$")

--- a/radis/spectrum/utils.py
+++ b/radis/spectrum/utils.py
@@ -15,7 +15,7 @@ from radis.misc.basics import partition
 
 # Waverange, wavespaces
 # ... aliases:
-WAVENUM_UNITS = ["cm", "cm-1", "cm-1", "wavenumber"]
+WAVENUM_UNITS = ["cm", "cm-1", "wavenumber"]
 WAVELEN_UNITS = ["nm", "wavelength"]
 WAVELENVAC_UNITS = ["nm_vac", "nm_vacuum"]
 # ... internal names

--- a/radis/test/files/N2C_specair_380nm.spec
+++ b/radis/test/files/N2C_specair_380nm.spec
@@ -7528,7 +7528,7 @@
     "_q_conv": {},
     "units": {
         "radiance_noslit": "mW/cm2/sr/um",
-        "transmittance_noslit": "I/I0"
+        "transmittance_noslit": "1"
     },
     "conditions": {
         "idatabase": 1,

--- a/radis/test/lbl/test_broadening.py
+++ b/radis/test/lbl/test_broadening.py
@@ -65,7 +65,7 @@ def test_broadening_vs_hapi(rtol=1e-2, verbose=True, plot=False, *args, **kwargs
     )
 
     s_hapi = Spectrum.from_array(
-        nu, coef, "abscoeff", "cm-1", "cm_1", conditions={"Tgas": T}, name="HAPI"
+        nu, coef, "abscoeff", "cm-1", "cm-1", conditions={"Tgas": T}, name="HAPI"
     )
 
     # %% Calculate with RADIS

--- a/radis/test/lbl/test_calc.py
+++ b/radis/test/lbl/test_calc.py
@@ -43,12 +43,12 @@ def test_sPlanck_conversions(verbose=True, *args, **kwargs):
         printm("Testing sPlanck conversions: ")
 
     s_cm = sPlanck(1000, 10000, T=1500, eps=0.3)
-    I_cm2cm = s_cm.get("radiance_noslit", Iunit="mW/cm2/sr/cm_1")[1]
+    I_cm2cm = s_cm.get("radiance_noslit", Iunit="mW/cm2/sr/cm-1")[1]
     I_cm2nm = s_cm.get("radiance_noslit", Iunit="mW/cm2/sr/nm")[1]
 
     s_nm = sPlanck(1000, 10000, T=1500, eps=0.3)
     I_nm2nm = s_nm.get("radiance_noslit", Iunit="mW/cm2/sr/nm")[1]
-    I_nm2cm = s_nm.get("radiance_noslit", Iunit="mW/cm2/sr/cm_1")[1]
+    I_nm2cm = s_nm.get("radiance_noslit", Iunit="mW/cm2/sr/cm-1")[1]
 
     assert np.allclose(I_cm2cm, I_nm2cm)
     assert np.allclose(I_nm2nm, I_cm2nm)

--- a/radis/test/phys/test_blackbody.py
+++ b/radis/test/phys/test_blackbody.py
@@ -64,7 +64,7 @@ def test_planck_nm(verbose=True, plot=True, *args, **kwargs):
     w_cm = s.get_wavenumber()
 
     Iunit_per_nm = "W/sr/nm/m2"
-    Iunit_per_cm = "W/sr/cm_1/m2"
+    Iunit_per_cm = "W/sr/cm-1/m2"
 
     if plot:
         s.plot("radiance_noslit", Iunit=Iunit_per_nm)
@@ -137,7 +137,7 @@ def test_planck_cm(verbose=True, plot=True, *args, **kwargs):
     w_cm = s.get_wavenumber()
 
     I_nm = s.get_radiance_noslit(Iunit="mW/sr/m2/nm")
-    I_cm = s.get_radiance_noslit(Iunit="mW/sr/m2/cm_1")
+    I_cm = s.get_radiance_noslit(Iunit="mW/sr/m2/cm-1")
     I_cm *= 2 * pi  # mW/m2/cm-1
 
     # Check Wien's law

--- a/radis/test/spectrum/test_spectrum.py
+++ b/radis/test/spectrum/test_spectrum.py
@@ -216,7 +216,6 @@ def test_intensity_conversion(verbose=True, *args, **kwargs):
     I_nm = planck(w_nm, T=6000, unit="mW/sr/cm2/nm")
 
     s = calculated_spectrum(w_nm, I_nm, wunit="nm_vac", Iunit="mW/sr/cm2/nm",)
-    # print("INTENSITY CONVERSION SPECTRUM: s = ", s)
     # mW/sr/cm2/nm -> mW/sr/cm2/cm-1
     w, I = s.get("radiance_noslit", Iunit="mW/sr/cm2/cm-1")
     I_cm = planck_wn(w_cm, T=6000, unit="mW/sr/cm2/cm-1")
@@ -402,18 +401,17 @@ def _run_testcases(
     # Test conversion of intensity cm-1 works
     # -------------
     test_intensity_conversion(debug=debug, verbose=verbose, *args, **kwargs)
-    print("LINE 405 done...")
+
     # Test updating / rescaling functions (no self absorption)
     # ---------
     test_rescaling_function(debug=debug, *args, **kwargs)
-    print("LINE 409 done...")
+
     test_resampling_function(
         debug=debug, plot=plot, close_plots=close_plots, *args, **kwargs
     )
-    print("LINE 413 done....")
+
     # Test plot firewalls:
     test_noplot_different_quantities(*args, **kwargs)
-    print("LINE 416 done....")
     return True
 
 

--- a/radis/test/spectrum/test_spectrum.py
+++ b/radis/test/spectrum/test_spectrum.py
@@ -60,7 +60,7 @@ def test_spectrum_get_methods(
         == s.get("radiance_noslit", Iunit="W/m2/sr/nm")[1]
     )
     assert all(nm2cm(s.get_wavelength(medium="vacuum")) == s.get_wavenumber())
-    assert s.get_power(unit="W/cm2/sr") == 2631.6288408588148
+    assert np.isclose(s.get_power(unit="W/cm2/sr"), 2631.6288408588148)
     assert s.get_waveunit() == "nm"
     assert np.isclose(
         s.get_power(unit="W/cm2/sr"),
@@ -216,10 +216,10 @@ def test_intensity_conversion(verbose=True, *args, **kwargs):
     I_nm = planck(w_nm, T=6000, unit="mW/sr/cm2/nm")
 
     s = calculated_spectrum(w_nm, I_nm, wunit="nm_vac", Iunit="mW/sr/cm2/nm",)
-
+    # print("INTENSITY CONVERSION SPECTRUM: s = ", s)
     # mW/sr/cm2/nm -> mW/sr/cm2/cm-1
-    w, I = s.get("radiance_noslit", Iunit="mW/sr/cm2/cm_1")
-    I_cm = planck_wn(w_cm, T=6000, unit="mW/sr/cm2/cm_1")
+    w, I = s.get("radiance_noslit", Iunit="mW/sr/cm2/cm-1")
+    I_cm = planck_wn(w_cm, T=6000, unit="mW/sr/cm2/cm-1")
     assert allclose(I_cm, I, rtol=1e-3)
 
 
@@ -239,8 +239,8 @@ def test_intensity_conversion(verbose=True, *args, **kwargs):
 #
 #    # mW/sr/cm3/nm -> mW/sr/cm3/cm-1
 #
-#    w, I = s.get('emissivity_noslit', Iunit='mW/sr/cm3/cm_1')
-#    I_cm = convert_emi2nm(I, 'mW/sr/cm3/cm_1', 'mW/sr/m3/µm')
+#    w, I = s.get('emissivity_noslit', Iunit='mW/sr/cm3/cm-1')
+#    I_cm = convert_emi2nm(I, 'mW/sr/cm3/cm-1', 'mW/sr/m3/µm')
 #
 
 # TODO: finish implementing emissivity_conversino above
@@ -402,17 +402,18 @@ def _run_testcases(
     # Test conversion of intensity cm-1 works
     # -------------
     test_intensity_conversion(debug=debug, verbose=verbose, *args, **kwargs)
-
+    print("LINE 405 done...")
     # Test updating / rescaling functions (no self absorption)
     # ---------
     test_rescaling_function(debug=debug, *args, **kwargs)
+    print("LINE 409 done...")
     test_resampling_function(
         debug=debug, plot=plot, close_plots=close_plots, *args, **kwargs
     )
-
+    print("LINE 413 done....")
     # Test plot firewalls:
     test_noplot_different_quantities(*args, **kwargs)
-
+    print("LINE 416 done....")
     return True
 
 

--- a/radis/test/tools/test_slit.py
+++ b/radis/test/tools/test_slit.py
@@ -256,17 +256,17 @@ def test_convoluted_quantities_units(*args, **kwargs):
     s.update(verbose=False)
 
     assert s.units["radiance_noslit"] == "mW/cm2/sr/nm"
-    assert s.units["transmittance_noslit"] == "I/I0"
+    assert s.units["transmittance_noslit"] == "1"
 
     s.apply_slit(0.5, norm_by="area", verbose=False)
 
     assert s.units["radiance"] == "mW/cm2/sr/nm"
-    assert s.units["transmittance"] == "I/I0"
+    assert s.units["transmittance"] == "1"
 
     s.apply_slit(0.5, norm_by="max", verbose=False)
 
-    assert s.units["radiance"] == "mW/cm2/sr"
-    assert s.units["transmittance"] == "I/I0*nm"  # whatever that means
+    assert is_homogeneous(s.units["radiance"], "mW/cm2/sr")
+    assert s.units["transmittance"] == "nm"  # whatever that means
 
 
 @pytest.mark.fast
@@ -383,6 +383,8 @@ def test_normalisation_mode(plot=True, close_plots=True, verbose=True, *args, **
     s = calculated_spectrum(
         w, I, conditions={"Tvib": 3000, "Trot": 1200}, Iunit="mW/cm2/sr/µm"
     )
+
+    print("still in test file, s.units = ", s.units)
 
     FWHM = 2
 

--- a/radis/test/tools/test_slit.py
+++ b/radis/test/tools/test_slit.py
@@ -256,12 +256,12 @@ def test_convoluted_quantities_units(*args, **kwargs):
     s.update(verbose=False)
 
     assert s.units["radiance_noslit"] == "mW/cm2/sr/nm"
-    assert s.units["transmittance_noslit"] == "1"
+    assert s.units["transmittance_noslit"] == ""
 
     s.apply_slit(0.5, norm_by="area", verbose=False)
 
     assert s.units["radiance"] == "mW/cm2/sr/nm"
-    assert s.units["transmittance"] == "1"
+    assert s.units["transmittance"] == ""
 
     s.apply_slit(0.5, norm_by="max", verbose=False)
 

--- a/radis/test/tools/test_slit.py
+++ b/radis/test/tools/test_slit.py
@@ -384,8 +384,6 @@ def test_normalisation_mode(plot=True, close_plots=True, verbose=True, *args, **
         w, I, conditions={"Tvib": 3000, "Trot": 1200}, Iunit="mW/cm2/sr/µm"
     )
 
-    print("still in test file, s.units = ", s.units)
-
     FWHM = 2
 
     s.apply_slit(FWHM, norm_by="area")  # spectrum convolved with area=1

--- a/radis/test/validation/test_CO2_3Tvib_vs_klarenaar.py
+++ b/radis/test/validation/test_CO2_3Tvib_vs_klarenaar.py
@@ -64,7 +64,7 @@ def test_klarenaar_validation_case(
         ),
         "transmittance_noslit",
         waveunit="cm-1",
-        unit="I/I0",
+        unit="1",
         delimiter=",",
         name="Klarenaar 2017",
     )

--- a/radis/test/validation/test_CO2_3Tvib_vs_klarenaar.py
+++ b/radis/test/validation/test_CO2_3Tvib_vs_klarenaar.py
@@ -64,7 +64,7 @@ def test_klarenaar_validation_case(
         ),
         "transmittance_noslit",
         waveunit="cm-1",
-        unit="1",
+        unit="",
         delimiter=",",
         name="Klarenaar 2017",
     )

--- a/radis/test/validation/test_RADIS_vs_HAPI_line_broadening.py
+++ b/radis/test/validation/test_RADIS_vs_HAPI_line_broadening.py
@@ -101,7 +101,7 @@ def test_line_broadening(rtol=1e-3, verbose=True, plot=False, *args, **kwargs):
                 trans,
                 "transmittance_noslit",
                 "cm-1",
-                "I/I0",
+                "1",
                 conditions={"Tgas": T},
                 name="HAPI",
             )

--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -504,7 +504,7 @@ def load_spec(file, binary=False):  # , return_binary_status=False):
 
     for unit in s.units:
         if s.units[unit] in ["I/I0", "-ln(I/I0)", "eps"]:
-            s.units[unit] = "1"
+            s.units[unit] = ""
     # Auto-update RADIS .spec format
     # ... experimental feature...
     if fixed:

--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -502,9 +502,6 @@ def load_spec(file, binary=False):  # , return_binary_status=False):
     # Generate Spectrum
     s = _json_to_spec(sload, file)
 
-    for unit in s.units:
-        if s.units[unit] in ["I/I0", "-ln(I/I0)", "eps"]:
-            s.units[unit] = ""
     # Auto-update RADIS .spec format
     # ... experimental feature...
     if fixed:
@@ -833,6 +830,21 @@ def _fix_format(file, sload):
             )
             # Fix it:
             lines.rename(columns={"v1u": "vu", "v1l": "vl"}, inplace=True)
+
+    # Fix syntax of RAdis <= 0.9.26
+    # -----------------------------
+
+    # Fix adimensioned units
+    if "units" in sload:
+        for var, unit in sload["units"].items():
+            if unit in ["I/I0", "-ln(I/I0)", "eps"]:
+                printr(
+                    "File {0}".format(basename(file))
+                    + " has a deprecrated structure "
+                    + "(adimensioned units are now stored as ''). Fixed this time, but regenerate "
+                    + "database ASAP."
+                )
+                sload["units"][var] = ""
 
     return sload, fixed
 
@@ -2351,6 +2363,6 @@ def in_database(smatch, db=".", filt=".spec"):
 # %% Test
 if __name__ == "__main__":
 
-    from radis.test.tools.test_database import _run_testcases
+    import pytest
 
-    print("Testing database.py: ", _run_testcases())
+    pytest.main(["../test/tools/test_database.py", "-s"])

--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -464,7 +464,6 @@ def load_spec(file, binary=False):  # , return_binary_status=False):
 
 
     """
-    # print("LOAD SPEC CALLED")
 
     def _load(binary):
         if not binary:
@@ -501,14 +500,11 @@ def load_spec(file, binary=False):  # , return_binary_status=False):
     sload, fixed = _fix_format(file, sload)
 
     # Generate Spectrum
-    # print("CALLING jsontospec function")
     s = _json_to_spec(sload, file)
 
-    # print("BACK FROM jsontospec")
     for unit in s.units:
         if s.units[unit] in ["I/I0", "-ln(I/I0)", "eps"]:
             s.units[unit] = "1"
-    # print("INSIDE THE LOAD FUNCTION, s.units = ", s.units)
     # Auto-update RADIS .spec format
     # ... experimental feature...
     if fixed:
@@ -535,7 +531,6 @@ def _json_to_spec(sload, file=""):
     """
 
     conditions = sload["conditions"]
-    # print("TILL LINE 535")
     # Get quantities
     if "quantities" in sload:
         # old format -saved with tuples (w,I) under 'quantities'): heavier, but
@@ -566,7 +561,6 @@ def _json_to_spec(sload, file=""):
 
     # Generate spectrum:
     waveunit = sload["conditions"]["waveunit"]
-    # print("WAVEUNIT == ", waveunit)
     # Only `quantities` and `conditions` is required. The rest is just extra
     # details
     kwargs = {}
@@ -577,8 +571,6 @@ def _json_to_spec(sload, file=""):
     else:
         slit = {}
 
-    # print("TILL 579...")
-
     # ... load lines if exist
     if "lines" in sload:
         df = sload["lines"]
@@ -586,7 +578,6 @@ def _json_to_spec(sload, file=""):
     else:
         kwargs["lines"] = None
 
-    # print("TILL 588...")
     # ... load populations if exist
     if "populations" in sload:
 
@@ -605,7 +596,6 @@ def _json_to_spec(sload, file=""):
     else:
         kwargs["populations"] = None
 
-    # print("TILL 607...")
     # ... load other properties if exist
     for attr in ["units", "cond_units", "name"]:
         try:
@@ -613,16 +603,13 @@ def _json_to_spec(sload, file=""):
         except KeyError:
             kwargs[attr] = None
 
-    # print("TILL 615...")
     s = Spectrum(
         quantities=quantities, conditions=conditions, waveunit=waveunit, **kwargs
     )
 
-    # print("TILL 620...")
     # ... add file
     s.file = basename(file)
 
-    # print("TILL 624...")
     # ... add slit
     s._slit = slit
 

--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -464,6 +464,7 @@ def load_spec(file, binary=False):  # , return_binary_status=False):
 
 
     """
+    # print("LOAD SPEC CALLED")
 
     def _load(binary):
         if not binary:
@@ -500,8 +501,14 @@ def load_spec(file, binary=False):  # , return_binary_status=False):
     sload, fixed = _fix_format(file, sload)
 
     # Generate Spectrum
+    # print("CALLING jsontospec function")
     s = _json_to_spec(sload, file)
 
+    # print("BACK FROM jsontospec")
+    for unit in s.units:
+        if s.units[unit] in ["I/I0", "-ln(I/I0)", "eps"]:
+            s.units[unit] = "1"
+    # print("INSIDE THE LOAD FUNCTION, s.units = ", s.units)
     # Auto-update RADIS .spec format
     # ... experimental feature...
     if fixed:
@@ -528,7 +535,7 @@ def _json_to_spec(sload, file=""):
     """
 
     conditions = sload["conditions"]
-
+    # print("TILL LINE 535")
     # Get quantities
     if "quantities" in sload:
         # old format -saved with tuples (w,I) under 'quantities'): heavier, but
@@ -559,7 +566,7 @@ def _json_to_spec(sload, file=""):
 
     # Generate spectrum:
     waveunit = sload["conditions"]["waveunit"]
-
+    # print("WAVEUNIT == ", waveunit)
     # Only `quantities` and `conditions` is required. The rest is just extra
     # details
     kwargs = {}
@@ -570,6 +577,8 @@ def _json_to_spec(sload, file=""):
     else:
         slit = {}
 
+    # print("TILL 579...")
+
     # ... load lines if exist
     if "lines" in sload:
         df = sload["lines"]
@@ -577,6 +586,7 @@ def _json_to_spec(sload, file=""):
     else:
         kwargs["lines"] = None
 
+    # print("TILL 588...")
     # ... load populations if exist
     if "populations" in sload:
 
@@ -595,6 +605,7 @@ def _json_to_spec(sload, file=""):
     else:
         kwargs["populations"] = None
 
+    # print("TILL 607...")
     # ... load other properties if exist
     for attr in ["units", "cond_units", "name"]:
         try:
@@ -602,13 +613,16 @@ def _json_to_spec(sload, file=""):
         except KeyError:
             kwargs[attr] = None
 
+    # print("TILL 615...")
     s = Spectrum(
         quantities=quantities, conditions=conditions, waveunit=waveunit, **kwargs
     )
 
+    # print("TILL 620...")
     # ... add file
     s.file = basename(file)
 
+    # print("TILL 624...")
     # ... add slit
     s._slit = slit
 

--- a/radis/tools/slit.py
+++ b/radis/tools/slit.py
@@ -101,11 +101,16 @@ def get_slit_function(
     unit: 'nm' or 'cm-1'
         unit of slit_function FWHM, or unit of imported file
 
-    norm_by: ``'area'``, ``'max'``, or None
-        how to normalize. `area` conserves energy. With `max` the slit is normalized
-        so that its maximum is one (that is what is done in Specair: it changes
-        the outptut spectrum unit, e.g. from 'mW/cm2/sr/µm' to 'mW/cm2/sr')
-        None doesnt normalize. Default ``'area'``
+    norm_by: ``'area'``, ``'max'``, or ``None``
+        how to normalize. ``'area'`` conserves energy. With ``'max'`` the slit is normalized
+        at peak so that the maximum is one.
+        
+        .. note:: 
+            
+            ``'max'`` changes the unit of the spectral array, e.g. from 
+            ``'mW/cm2/sr/µm'`` to ``'mW/cm2/sr')``
+        
+        ``None`` doesnt normalize. Default ``'area'``
 
     shape: ``'triangular'``, ``'trapezoidal'``, ``'gaussian'``
         which shape to use when generating a slit. Default ``'triangular'``. 
@@ -521,8 +526,14 @@ def convolve_with_slit(
             Both wavespaces have to be the same!
 
     norm_by: ``'area'``, ``'max'``, or ``None``
-        how to normalize. ``'area'`` conserves energy. ``'max'`` is what is done in
-        Specair and changes spectrum units, e.g. from ``'mW/cm2/sr/µm'`` to ``'mW/cm2/sr'``
+        how to normalize. ``'area'`` conserves energy. With ``'max'`` the slit is normalized
+        at peak so that the maximum is one.
+        
+        .. note:: 
+            
+            ``'max'`` changes the unit of the spectral array, e.g. from 
+            ``'mW/cm2/sr/µm'`` to ``'mW/cm2/sr')``
+        
         ``None`` doesnt normalize. Default ``'area'``
 
     mode: ``'valid'``, ``'same'``
@@ -925,8 +936,14 @@ def normalize_slit(w_slit, I_slit, norm_by="area"):
         wavelength and slit intensity
         
     norm_by: ``'area'``, ``'max'``, or ``None``
-        renormalize after slit dilatation. ``'area'`` conserves energy. ``'max'`` is what is done in
-        Specair and changes spectrum units, e.g. from ``'mW/cm2/sr/µm'`` to ``'mW/cm2/sr'``
+        how to normalize. ``'area'`` conserves energy. With ``'max'`` the slit is normalized
+        at peak so that the maximum is one.
+        
+        .. note:: 
+            
+            ``'max'`` changes the unit of the spectral array, e.g. from 
+            ``'mW/cm2/sr/µm'`` to ``'mW/cm2/sr')``
+        
         ``None`` doesnt normalize. Default ``'area'``
 
     Returns

--- a/radis/tools/slit.py
+++ b/radis/tools/slit.py
@@ -388,7 +388,7 @@ def get_slit_function(
             #        I_slit /= np.trapz(I_slit, x=w_slit)
             Iunit = "1/{0}".format(unit)
         elif norm_by == "max":  # set maximum to 1
-            Iunit = "1"
+            Iunit = ""
         elif norm_by is None:
             Iunit = None
         else:
@@ -443,7 +443,7 @@ def get_slit_function(
             elif norm_by == "max":  # set maximum to 1
                 Islit /= abs(np.max(Islit))
                 Islit *= scale_slit
-                Iunit = "1"
+                Iunit = ""
                 if scale_slit != 1:
                     Iunit += "x{0}".format(scale_slit)
             elif norm_by is None:
@@ -1396,7 +1396,7 @@ def import_experimental_slit(
         Iunit = "1/{0}".format(waveunit)
     elif norm_by == "max":  # set maximum to 1
         I_slit /= abs(np.max(I_slit))
-        Iunit = "1"
+        Iunit = ""
     elif norm_by is None:
         Iunit = None
     else:
@@ -1511,7 +1511,7 @@ def triangular_slit(
         Iunit = "1/{0}".format(waveunit)
     elif norm_by == "max":  # set maximum to 1
         I /= np.max(I)
-        Iunit = "1"
+        Iunit = ""
     elif norm_by is None:
         Iunit = None
     else:
@@ -1652,7 +1652,7 @@ def trapezoidal_slit(
         Iunit = "1/{0}".format(waveunit)
     elif norm_by == "max":  # set maximum to 1
         I /= np.max(I)
-        Iunit = "1"
+        Iunit = ""
     elif norm_by is None:
         Iunit = None
     else:
@@ -1772,7 +1772,7 @@ def gaussian_slit(
         Iunit = "1/{0}".format(waveunit)
     elif norm_by == "max":  # set maximum to 1
         I /= np.max(I)
-        Iunit = "1"
+        Iunit = ""
     elif norm_by is None:
         Iunit = None
     else:

--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,6 @@ setup(
         "numba",
         "mpldatacursor",
         "astropy",  # Unit aware calculations
-        "pint>=0.7.2",  # Unit aware calculations
         "publib>=0.3.2",  # Plotting styles for Matplotlib
         "plotly>=2.5.1",  # for line survey HTML output
         "termcolor",  # terminal colors


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

- This PR replaces `pint` with `astropy.units` in the `phys/units.py` file.
- The import has been removed from the file and replaced with astropy units everywhere. 
- The `DimensionalityError` offered by `pint` has been replaced with astropy's `UnitConversionError` everywhere.

A few tests were breaking as they depended on pint's `UnitRegistry` which was imported as `Q_` earlier to convert the strings to units. The same task (and name) has now been given to astropy's `units.Unit` class which acts as the equivalent.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### TODO: 
- [x]  clean the code and remove old comments after review
- [x] search for other methods using `pint` and replace them with `astropy.units`
- [x] remove `pint` from dependencies

Will fix #104 