### PR TITLE
(Fixes #76) Regenerate cache if line database file was edited.

### DIFF
--- a/radis/io/cdsd.py
+++ b/radis/io/cdsd.py
@@ -246,6 +246,8 @@ def cdsd2df(
     :func:`~radis.io.hitran.hit2df`
 
     """
+    metadata = {}
+    metadata["last_modification"] = time.ctime(getmtime(fname))
 
     if verbose >= 2:
         print(
@@ -253,6 +255,7 @@ def cdsd2df(
                 fname, version, cache
             )
         )
+        print("Last Modification time: {0}".format(metadata["last_modification"]))
 
     if version == "hitemp":
         columns = columns_hitemp
@@ -261,14 +264,13 @@ def cdsd2df(
     else:
         raise ValueError("Unknown CDSD version: {0}".format(version))
 
-    metadata = {}
-    metadata["last_modification"] = time.ctime(getmtime(fname))
-
-    if verbose >= 2:
-        print("Last Modification time: {0}".format(metadata["last_modification"]))
     # Use cache file if possible
     fcache = splitext(fname)[0] + ".h5"
     check_cache_file(fcache=fcache, use_cached=cache, verbose=verbose)
+
+    if verbose >= 2:
+        print(exists(fcache))
+
     if cache and exists(fcache):
         # return get_cache_file(fcache, verbose=verbose)
         return load_h5_cache_file(
@@ -295,7 +297,8 @@ def cdsd2df(
             save_to_hdf(
                 df,
                 fcache,
-                metadata={},
+                # metadata={},
+                metadata=metadata,
                 version=radis.__version__,
                 key="df",
                 overwrite=True,

--- a/radis/io/cdsd.py
+++ b/radis/io/cdsd.py
@@ -267,7 +267,6 @@ def cdsd2df(
     fcache = splitext(fname)[0] + ".h5"
     check_cache_file(fcache=fcache, use_cached=cache, verbose=verbose)
 
-
     if cache and exists(fcache):
         return load_h5_cache_file(
             fcache,

--- a/radis/io/cdsd.py
+++ b/radis/io/cdsd.py
@@ -32,7 +32,6 @@ from radis.io.tools import (
 from radis.misc.cache_files import (
     check_cache_file,
     save_to_hdf,
-    get_cache_file,
     load_h5_cache_file,
 )
 from os.path import getmtime
@@ -268,17 +267,15 @@ def cdsd2df(
     fcache = splitext(fname)[0] + ".h5"
     check_cache_file(fcache=fcache, use_cached=cache, verbose=verbose)
 
-    if verbose >= 2:
-        print(exists(fcache))
 
     if cache and exists(fcache):
-        # return get_cache_file(fcache, verbose=verbose)
         return load_h5_cache_file(
             fcache,
             cache,
             metadata=metadata,
             current_version=radis.__version__,
             last_compatible_version=OLDEST_COMPATIBLE_VERSION,
+            verbose=verbose,
         )
     # %% Start reading the full file
 
@@ -297,7 +294,6 @@ def cdsd2df(
             save_to_hdf(
                 df,
                 fcache,
-                # metadata={},
                 metadata=metadata,
                 version=radis.__version__,
                 key="df",

--- a/radis/io/hitran.py
+++ b/radis/io/hitran.py
@@ -36,7 +36,6 @@ from radis.io.tools import (
 from radis.misc.cache_files import (
     save_to_hdf,
     check_cache_file,
-    get_cache_file,
     load_h5_cache_file,
 )
 from os.path import getmtime
@@ -326,8 +325,6 @@ def hit2df(fname, count=-1, cache=False, verbose=True, drop_non_numeric=True):
     # Use cache file if possible
     fcache = splitext(fname)[0] + ".h5"
     check_cache_file(fcache=fcache, use_cached=cache, verbose=verbose)
-    if verbose >= 2:
-        print(exists(fcache))
     if cache and exists(fcache):
         # return get_cache_file(fcache, verbose=verbose)
         return load_h5_cache_file(
@@ -393,7 +390,6 @@ def hit2df(fname, count=-1, cache=False, verbose=True, drop_non_numeric=True):
             save_to_hdf(
                 df,
                 fcache,
-                # metadata={},
                 metadata=metadata,
                 version=radis.__version__,
                 key="df",

--- a/radis/io/hitran.py
+++ b/radis/io/hitran.py
@@ -326,8 +326,8 @@ def hit2df(fname, count=-1, cache=False, verbose=True, drop_non_numeric=True):
     # Use cache file if possible
     fcache = splitext(fname)[0] + ".h5"
     check_cache_file(fcache=fcache, use_cached=cache, verbose=verbose)
-    print(exists(fcache))
-    cache = True
+    if verbose >= 2:
+        print(exists(fcache))
     if cache and exists(fcache):
         # return get_cache_file(fcache, verbose=verbose)
         return load_h5_cache_file(

--- a/radis/io/query.py
+++ b/radis/io/query.py
@@ -105,7 +105,6 @@ def fetch_astroquery(
         metadata.update(
             {"molecule": molecule, "isotope": isotope, "wmin": wmin, "wmax": wmax}
         )
-
         fcache = join(
             Hitran.cache_location,
             CACHE_FILE_NAME.format(

--- a/radis/test/test_io.py
+++ b/radis/test/test_io.py
@@ -207,8 +207,6 @@ def run_example():
     )
     sf.warnings["MissingSelfBroadeningWarning"] = "ignore"
     sf.load_databank("HITRAN-CO2-TEST")  # this database must be defined in ~/.radis
-    s = sf.non_eq_spectrum(300, 300)
-    s.plot()
 
 
 def test_cache_regeneration(verbose=True, warnings=True, **kwargs):
@@ -252,6 +250,7 @@ def _run_testcases(verbose=True, *args, **kwargs):
     test_hitran_co2(verbose=verbose, *args, **kwargs)
     test_hitran_h2o(verbose=verbose, *args, **kwargs)
     test_hitemp(verbose=verbose, *args, **kwargs)
+
     test_cache_regeneration(verbose=verbose, *args, **kwargs)
     return True
 

--- a/radis/test/test_io.py
+++ b/radis/test/test_io.py
@@ -206,7 +206,9 @@ def run_example():
         broadening_max_width=10,  # cm-1
     )
     sf.warnings["MissingSelfBroadeningWarning"] = "ignore"
-    sf.load_databank("HITRAN-CO2-TEST")  # this database must be defined in ~/.radis
+    sf.load_databank(
+        name="HITRAN-CO2-TEST", db_use_cached=True
+    )  # this database must be defined in ~/.radis
 
 
 def test_cache_regeneration(verbose=True, warnings=True, **kwargs):

--- a/radis/test/test_io.py
+++ b/radis/test/test_io.py
@@ -206,9 +206,7 @@ def run_example():
         broadening_max_width=10,  # cm-1
     )
     sf.warnings["MissingSelfBroadeningWarning"] = "ignore"
-    sf.load_databank(
-        name="HITRAN-CO2-TEST", db_use_cached=True
-    )  # this database must be defined in ~/.radis
+    sf.load_databank("HITRAN-CO2-TEST")  # this database must be defined in ~/.radis
 
 
 def test_cache_regeneration(verbose=True, warnings=True, **kwargs):

--- a/radis/test/test_io.py
+++ b/radis/test/test_io.py
@@ -29,6 +29,11 @@ from radis.test.utils import getTestFile
 import pytest
 import numpy as np
 from warnings import warn
+from radis import SpectrumFactory
+from os.path import basename, exists, getmtime
+import os
+import time
+from radis.test.utils import setup_test_line_databases
 
 
 @pytest.mark.fast
@@ -183,6 +188,63 @@ def test_hitemp(verbose=True, warnings=True, **kwargs):
     return True
 
 
+def run_example():
+    import astropy.units as u
+    from radis import SpectrumFactory
+
+    setup_test_line_databases(
+        verbose=True
+    )  # add HITEMP-CO2-HAMIL-TEST in ~/.radis if not there
+    sf = SpectrumFactory(
+        wavelength_min=4165,
+        wavelength_max=4200,
+        path_length=0.1,
+        pressure=20,
+        molecule="CO2",
+        isotope="1,2",
+        cutoff=1e-25,  # cm/molecule
+        broadening_max_width=10,  # cm-1
+    )
+    sf.warnings["MissingSelfBroadeningWarning"] = "ignore"
+    sf.load_databank("HITRAN-CO2-TEST")  # this database must be defined in ~/.radis
+    s = sf.non_eq_spectrum(300, 300)
+    s.plot()
+
+
+def test_cache_regeneration(verbose=True, warnings=True, **kwargs):
+
+    run_example()
+    # get time when line database file was last modified
+    file_last_modification = getmtime(
+        getTestFile(r"hitran_co2_626_bandhead_4165_4200nm.par")
+    )
+    # get time when cache file was last modified
+    cache_last_modification = getmtime(
+        getTestFile(r"hitran_co2_626_bandhead_4165_4200nm.h5")
+    )
+    # change the time when line database was last modified
+    stinfo = os.stat(getTestFile(r"hitran_co2_626_bandhead_4165_4200nm.par"))
+    access_time = stinfo.st_atime
+    os.utime(
+        getTestFile(r"hitran_co2_626_bandhead_4165_4200nm.par"),
+        (file_last_modification + 1, access_time + 1),
+    )
+
+    file_last_modification_again = getmtime(
+        getTestFile(r"hitran_co2_626_bandhead_4165_4200nm.par")
+    )
+
+    assert file_last_modification_again > file_last_modification
+
+    run_example()
+
+    cache_last_modification_again = getmtime(
+        getTestFile(r"hitran_co2_626_bandhead_4165_4200nm.h5")
+    )
+
+    assert cache_last_modification_again > cache_last_modification
+
+
 def _run_testcases(verbose=True, *args, **kwargs):
 
     test_hitran_names_match(verbose=verbose, *args, **kwargs)
@@ -190,7 +252,7 @@ def _run_testcases(verbose=True, *args, **kwargs):
     test_hitran_co2(verbose=verbose, *args, **kwargs)
     test_hitran_h2o(verbose=verbose, *args, **kwargs)
     test_hitemp(verbose=verbose, *args, **kwargs)
-
+    test_cache_regeneration(verbose=verbose, *args, **kwargs)
     return True
 
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address ... the regeneration of cache file if their line database was edited. For this I changed the `get_cache_file` functions to `load_h5_cache_file`, since there's support for checking metadata differences in that function. I've also added a new key in the metadata for the cache file, called `last_modification`, which stores the last time a line database file was edited.

------------------
Everytime `SpectrumFactory.load_databank()` is called, last_modification keys are compared. If the file was recently modified, then the cache file is re-generated (discarding the old).

----------------------
Test case to test if it works with hitran format database has been added in `test/test_io.py` file. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #76 