### PR TITLE
Fix get residual

### DIFF
--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -334,21 +334,22 @@ def get_residual(
         s2 = s2.copy()
         w1, I1 = s1.get(var, wunit=wunit, copy=False)
         w2, I2 = s2.get(var, wunit=wunit, copy=False)
-
         if normalize_how == "max":
-            ratio = np.nanmax(I1) / np.nanmax(I2)
+            norm1 = np.nanmax(I1) 
+            norm2 = np.nanmax(I2)
         elif normalize_how == "mean":
-            ratio = np.nanmean(I1) / np.nanmean(I2)
+            norm1 = np.nanmean(I1) 
+            norm2 = np.nanmean(I2)
         elif normalize_how == "area":
             norm1 = np.abs(nantrapz(I1, w1))
             norm2 = np.abs(nantrapz(I2, w2))
-            ratio = norm1 / norm2
         else:
             raise ValueError("Unexpected `normalize_how`: {0}".format(normalize_how))
-        I1 /= np.nanmax(I1)
-        I2 /= np.nanmax(I2)
+        I1 /= norm1
+        I2 /= norm2
 
         if verbose:
+            ratio = norm1 / norm2
             print(("Rescale factor: " + str(ratio)))
 
     _, Idiffs = get_wdiff_Idiff(
@@ -361,6 +362,12 @@ def get_residual(
     if not ignore_nan and b.any():
         warningText = (
             'NaN output in residual. You should use "ignore_nan=True". Read the help.'
+        )
+        warn(warningText, UserWarning)
+        
+    if b.any() and normalize_how == "mean":
+        warningText = (
+            "The 'normalize_how=mean' method seams to be not adapted for spectra with NaN. Consider using 'normalize_how=mean' "
         )
         warn(warningText, UserWarning)
     if ignore_nan:

--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -256,185 +256,6 @@ def get_distance(s1, s2, var, wunit="default", Iunit="default", resample=True):
     # euclidian distance from w1, I1
     return curve_distance(w1, I1, w2, I2, discard_out_of_bounds=True)
 
-
-# def get_residual(
-#     s1,
-#     s2,
-#     var,
-#     norm="L2",
-#     ignore_nan=False,
-#     diff_window=0,
-#     normalize=False,
-#     normalize_how="max",
-# ):
-#     # type: (Spectrum, Spectrum, str, bool, int) -> np.array, np.array
-#     """ Returns L2 norm of ``s1`` and ``s2``
-
-#     For ``I1``, ``I2``, the values of variable ``var`` in ``s1`` and ``s2``, 
-#     respectively, residual is calculated as:
-        
-#     For ``L2`` norm:
-
-#         .. math::
-    
-#             res = \\frac{\\sqrt{\\sum_i {(s_1[i]-s_2[i])^2}}}{N}.
-
-#     For ``L1`` norm:
-            
-#         .. math::
-    
-#             res = \\frac{\\sqrt{\\sum_i {|s_1[i]-s_2[i]|}}}{N}.
-
-
-#     Parameters    
-#     ----------
-
-#     s1, s2: :class:`~radis.spectrum.spectrum.Spectrum` objects
-#         if not on the same range, ``s2`` is resampled on ``s1``.
-
-#     var: str
-#         spectral quantity
-
-#     norm: 'L2', 'L1'
-#         which norm to use 
-
-#     Other Parameters
-#     ----------------
-
-#     ignore_nan: boolean
-#         if ``True``, ignore nan in the difference between s1 and s2 (ex: out of bound)
-#         when calculating residual. Default ``False``. Note: ``get_residual`` will still 
-#         fail if there are nan in initial Spectrum. 
-
-#     normalize: bool, or tuple
-#         if ``True``, normalize the two spectra before calculating the residual. 
-#         If a tuple (ex: ``(4168, 4180)``), normalize on this range only. The unit
-#         is that of the first Spectrum. Ex::
-            
-#             s_exp   # in 'nm'
-#             s_calc  # in 'cm-1'
-#             get_residual(s_exp, s_calc, normalize=(4178, 4180))  # interpreted as 'nm'
-
-#     normalize_how: ``'max'``, ``'area'``, ``'mean'``
-#         how to normalize. ``'max'`` is the default but may not be suited for very
-#         noisy experimental spectra. ``'area'`` will normalize the integral to 1.
-#         ``'mean'`` will normalize by the mean amplitude value
-
-#     Notes
-#     -----
-
-#     0 values for I1 yield nans except if I2 = I1 = 0
-
-#     when s1 and s2 dont have the size wavespace range, they are automatically
-#     resampled through get_diff on 's1' range 
-
-#     Implementation of ``L2`` norm::
-
-#         np.sqrt((dI**2).sum())/len(dI)
-    
-#     Implementation of ``L1`` norm::
-        
-#         np.abs(dI).sum()/len(dI)
-
-#     See Also
-#     --------
-
-#     :func:`~radis.spectrum.compare.get_diff`, 
-#     :func:`~radis.spectrum.compare.get_ratio`, 
-#     :func:`~radis.spectrum.compare.get_distance`, 
-#     :func:`~radis.spectrum.compare.plot_diff`, 
-#     :func:`~radis.spectrum.compare.get_residual_integral`, 
-#     :meth:`~radis.spectrum.spectrum.compare_with` 
-#     """
-
-    if normalize:
-        from radis.spectrum.operations import multiply
-
-        if isinstance(normalize, tuple):
-            wmin, wmax = normalize
-            w1, I1 = s1.get(
-                var, copy=False, wunit=s1.get_waveunit(), Iunit=s1.units[var],
-            )  # (faster not to copy)
-            b = (w1 > wmin) & (w1 < wmax)
-            if normalize_how == "max":
-                norm1 = np.nanmax(I1[b])
-            elif normalize_how == "mean":
-                norm1 = np.nanmean(I1[b])
-            elif normalize_how == "area":
-                norm1 = np.abs(nantrapz(I1[b], w1[b]))
-            else:
-                raise ValueError(
-                    "Unexpected `normalize_how`: {0}".format(normalize_how)
-                )
-            # now normalize s2. Ensure we use the same unit system!
-            w2, I2 = s2.get(
-                var, copy=False, wunit=s1.get_waveunit(), Iunit=s1.units[var]
-            )
-            b = (w2 > wmin) & (w2 < wmax)
-            if normalize_how == "max":
-                norm2 = np.nanmax(I2[b])
-            elif normalize_how == "mean":
-                norm2 = np.nanmean(I2[b])
-            elif normalize_how == "area":
-                norm2 = np.abs(nantrapz(I2[b], w2[b]))
-            else:
-                raise ValueError(
-                    "Unexpected `normalize_how`: {0}".format(normalize_how)
-                )
-            s1 = multiply(s1, 1 / norm1, var=var)
-            s2 = multiply(s2, 1 / norm2, var=var)
-        else:
-            if normalize_how == "max":
-                norm1 = np.nanmax(s1.get(var, copy=False)[1])
-                norm2 = np.nanmax(s2.get(var)[1])
-
-            elif normalize_how == "mean":
-                norm1 = np.nanmean(s1.get(var, copy=False)[1])
-                norm2 = np.nanmean(s2.get(var)[1])
-
-            elif normalize_how == "area":
-                # norm1 = s1.get_integral(var)
-                # norm2 = s2.get_integral(
-                #    var, wunit=s1.get_waveunit(), Iunit=s1.units[var]
-                # )
-                w1, I1 = s1.get(var, copy=False)
-                norm1 = nantrapz(I1, w1)
-                w2, I2 = s2.get(var, Iunit=s1.units[var], wunit=s1.get_waveunit())
-                norm2 = nantrapz(I2, w2)
-
-            else:
-                raise ValueError(
-                    "Unexpected `normalize_how`: {0}".format(normalize_how)
-                )
-            # Ensure we use the same unit system!
-            s1 = multiply(s1, 1 / norm1, var=var, Iunit=s1.units[var])
-            s2 = multiply(s2, 1 / norm2, var=var, Iunit=s1.units[var])
-            # s1 = multiply(s1, 1 / norm1, var=var)
-            # s2 = multiply(s2, 1 / norm2, var=var)
-
-#     # mask for 0
-#     wdiff, dI = get_diff(
-#         s1, s2, var, resample=True, diff_window=diff_window, Iunit=s1.units[var]
-#     )
-#     if ignore_nan:
-#         b = np.isnan(dI)
-#         wdiff, dI = wdiff[~b], dI[~b]
-#     warningText = (
-#         'NaN output in residual. You should use "ignore_nan=True". Read the help.'
-#     )
-#     if norm == "L2":
-#         output = np.sqrt((dI ** 2).sum()) / len(dI)
-#         if np.isnan(output):
-#             warn(warningText, UserWarning)
-#         return output
-#     elif norm == "L1":
-#         output = (np.abs(dI)).sum() / len(dI)
-#         if np.isnan(output):
-#             warn.warning(warningText, UserWarning)
-#         return output
-#     else:
-#         raise ValueError("unexpected value for norm")
-
 def get_residual(s1, s2, var, 
                  Iunit='default', wunit='default', 
                  normalize=False,
@@ -443,7 +264,16 @@ def get_residual(s1, s2, var,
                  ignore_nan=False,
                  normalize_how="max"):
     """ 
+    Returns L2 norm of ``s1 - s2``
 
+    The values of variable ``var`` in ``s1`` and ``s2``, 
+    respectively, residual is calculated as:
+        
+    ``L2`` norm:
+
+        .. math::
+    
+            res = \\frac{\\sqrt{\\sum_i {(s_1[i]-s_2[i])^2}}}{N}.
 
     Parameters    
     ----------
@@ -463,7 +293,25 @@ def get_residual(s1, s2, var,
     diff_window: int
         If non 0, calculates diff by offsetting s1 by ``diff_window`` number of
         units on either side, and returns the minimum. Compensates for experimental
-        errors on the w axis. Default 0. 
+        errors on the w axis. Default 0.       
+       
+    ignore_nan: boolean
+        if ``True``, ignore nan in the difference between s1 and s2 (ex: out of bound)
+        when calculating residual. Default ``False``. Note: ``get_residual`` will still 
+        fail if there are nan in initial Spectrum. 
+
+    normalize: bool
+        if ``True``, normalize the two spectra before calculating the residual. 
+        The unit is that of the first Spectrum. Ex::
+            
+            s_exp   # in 'nm'
+            s_calc  # in 'cm-1'
+            get_residual(s_exp, s_calc, normalize=(4178, 4180))  # interpreted as 'nm'
+
+    normalize_how: ``'max'``, ``'area'``, ``'mean'``
+        how to normalize. ``'max'`` is the default but may not be suited for very
+        noisy experimental spectra. ``'area'`` will normalize the integral to 1.
+        ``'mean'`` will normalize by the mean amplitude value
     """
     from numpy.linalg import norm
     if Iunit == 'default':

--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -256,13 +256,19 @@ def get_distance(s1, s2, var, wunit="default", Iunit="default", resample=True):
     # euclidian distance from w1, I1
     return curve_distance(w1, I1, w2, I2, discard_out_of_bounds=True)
 
-def get_residual(s1, s2, var, 
-                 Iunit='default', wunit='default', 
-                 normalize=False,
-                 verbose=False,
-                 diff_window=0,
-                 ignore_nan=False,
-                 normalize_how="max"):
+
+def get_residual(
+    s1,
+    s2,
+    var,
+    Iunit="default",
+    wunit="default",
+    normalize=False,
+    verbose=False,
+    diff_window=0,
+    ignore_nan=False,
+    normalize_how="max",
+):
     """ 
     Returns L2 norm of ``s1 - s2``
 
@@ -314,11 +320,12 @@ def get_residual(s1, s2, var,
         ``'mean'`` will normalize by the mean amplitude value
     """
     from numpy.linalg import norm
-    if Iunit == 'default':
+
+    if Iunit == "default":
         Iunit = s1.units[var]
-    if wunit == 'default':
+    if wunit == "default":
         wunit = s1.get_waveunit()
-    
+
     # Get data
     # ----
     if normalize:
@@ -327,7 +334,7 @@ def get_residual(s1, s2, var,
         s2 = s2.copy()
         w1, I1 = s1.get(var, wunit=wunit, copy=False)
         w2, I2 = s2.get(var, wunit=wunit, copy=False)
-                
+
         if normalize_how == "max":
             ratio = np.nanmax(I1) / np.nanmax(I2)
         elif normalize_how == "mean":
@@ -337,22 +344,19 @@ def get_residual(s1, s2, var,
             norm2 = np.abs(nantrapz(I2, w2))
             ratio = norm1 / norm2
         else:
-            raise ValueError(
-                "Unexpected `normalize_how`: {0}".format(normalize_how)
-            )
+            raise ValueError("Unexpected `normalize_how`: {0}".format(normalize_how))
         I1 /= np.nanmax(I1)
         I2 /= np.nanmax(I2)
 
         if verbose:
             print(("Rescale factor: " + str(ratio)))
-            
-    _, Idiffs = get_wdiff_Idiff(s1, s2, var, wunit, Iunit, 
-                                      diff_window, 
-                                      normalize=normalize, 
-                                      method = 'diff')
+
+    _, Idiffs = get_wdiff_Idiff(
+        s1, s2, var, wunit, Iunit, diff_window, normalize=normalize, method="diff"
+    )
     Idiffs = np.array(Idiffs)
-    
-    #Nan handeling
+
+    # Nan handeling
     b = np.isnan(Idiffs)
     if not ignore_nan and b.any():
         warningText = (
@@ -362,6 +366,7 @@ def get_residual(s1, s2, var,
     if ignore_nan:
         Idiffs = Idiffs[~b]
     return norm(Idiffs, ord=2)
+
 
 def get_residual_integral(s1, s2, var, ignore_nan=False):
     # type: (Spectrum, Spectrum, str, bool) -> float
@@ -486,16 +491,17 @@ def _get_defaults(
 
     return w1, I1, w2, I2
 
-def get_wdiff_Idiff(s1, s2, var, wunit, Iunit, diff_window, 
-                    normalize=False, 
-                    method = 'diff'):
+
+def get_wdiff_Idiff(
+    s1, s2, var, wunit, Iunit, diff_window, normalize=False, method="diff"
+):
     """    
     diff_window: int
         If non 0, calculates diff by offsetting s1 by ``diff_window`` number of
         units on either side, and returns the minimum. Compensates for experimental
         errors on the w axis. Default 0. (look up code for more details...)
     """
-    
+
     if isinstance(method, list):
         methods = method
     else:
@@ -504,17 +510,10 @@ def get_wdiff_Idiff(s1, s2, var, wunit, Iunit, diff_window,
     for method in methods:
         if not normalize:
             if method == "distance":
-                wdiff, Idiff = get_distance(
-                    s1, s2, var=var, wunit=wunit, Iunit=Iunit
-                )
+                wdiff, Idiff = get_distance(s1, s2, var=var, wunit=wunit, Iunit=Iunit)
             elif method == "diff":
                 wdiff, Idiff = get_diff(
-                    s1,
-                    s2,
-                    var=var,
-                    wunit=wunit,
-                    Iunit=Iunit,
-                    diff_window=diff_window,
+                    s1, s2, var=var, wunit=wunit, Iunit=Iunit, diff_window=diff_window
                 )
             elif method == "ratio":
                 wdiff, Idiff = get_ratio(s1, s2, var=var, wunit=wunit, Iunit=Iunit)
@@ -525,12 +524,10 @@ def get_wdiff_Idiff(s1, s2, var, wunit, Iunit, diff_window,
         else:
             if method == "distance":
                 raise ValueError(
-                    "{0} was not implemented yet for normalized spectra".format(
-                        method
-                    )
+                    "{0} was not implemented yet for normalized spectra".format(method)
                 )
             elif method == "diff":
-                #we already multiplied the values of I1 and I2 by ratio
+                # we already multiplied the values of I1 and I2 by ratio
                 w1, I1 = s1.get(var, wunit=wunit, copy=False)
                 w2, I2 = s2.get(var, wunit=wunit, copy=False)
                 wdiff, Idiff = curve_substract(w1, I1, w2, I2)
@@ -541,6 +538,7 @@ def get_wdiff_Idiff(s1, s2, var, wunit, Iunit, diff_window,
             wdiffs.append(wdiff)
             Idiffs.append(Idiff)
     return wdiffs, Idiffs
+
 
 def plot_diff(
     s1,
@@ -791,12 +789,9 @@ def plot_diff(
         if verbose:
             print(("Rescale factor: " + str(ratio)))
 
-    
-
-    wdiffs, Idiffs = get_wdiff_Idiff(s1, s2, var, wunit, Iunit, 
-                                     diff_window, 
-                                     normalize=False, 
-                                     method = 'diff')
+    wdiffs, Idiffs = get_wdiff_Idiff(
+        s1, s2, var, wunit, Iunit, diff_window, normalize=False, method="diff"
+    )
 
     # Plot
     # ----

--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -347,70 +347,70 @@ def get_distance(s1, s2, var, wunit="default", Iunit="default", resample=True):
 #     :meth:`~radis.spectrum.spectrum.compare_with` 
 #     """
 
-#     if normalize:
-#         from radis.spectrum.operations import multiply
+    if normalize:
+        from radis.spectrum.operations import multiply
 
-#         if isinstance(normalize, tuple):
-#             wmin, wmax = normalize
-#             w1, I1 = s1.get(
-#                 var, copy=False, wunit=s1.get_waveunit(), Iunit=s1.units[var],
-#             )  # (faster not to copy)
-#             b = (w1 > wmin) & (w1 < wmax)
-#             if normalize_how == "max":
-#                 norm1 = np.nanmax(I1[b])
-#             elif normalize_how == "mean":
-#                 norm1 = np.nanmean(I1[b])
-#             elif normalize_how == "area":
-#                 norm1 = np.abs(nantrapz(I1[b], w1[b]))
-#             else:
-#                 raise ValueError(
-#                     "Unexpected `normalize_how`: {0}".format(normalize_how)
-#                 )
-#             # now normalize s2. Ensure we use the same unit system!
-#             w2, I2 = s2.get(
-#                 var, copy=False, wunit=s1.get_waveunit(), Iunit=s1.units[var]
-#             )
-#             b = (w2 > wmin) & (w2 < wmax)
-#             if normalize_how == "max":
-#                 norm2 = np.nanmax(I2[b])
-#             elif normalize_how == "mean":
-#                 norm2 = np.nanmean(I2[b])
-#             elif normalize_how == "area":
-#                 norm2 = np.abs(nantrapz(I2[b], w2[b]))
-#             else:
-#                 raise ValueError(
-#                     "Unexpected `normalize_how`: {0}".format(normalize_how)
-#                 )
-#             s1 = multiply(s1, 1 / norm1, var=var)
-#             s2 = multiply(s2, 1 / norm2, var=var)
-#         else:
-#             if normalize_how == "max":
-#                 norm1 = np.nanmax(s1.get(var, copy=False)[1])
-#                 norm2 = np.nanmax(s2.get(var)[1])
+        if isinstance(normalize, tuple):
+            wmin, wmax = normalize
+            w1, I1 = s1.get(
+                var, copy=False, wunit=s1.get_waveunit(), Iunit=s1.units[var],
+            )  # (faster not to copy)
+            b = (w1 > wmin) & (w1 < wmax)
+            if normalize_how == "max":
+                norm1 = np.nanmax(I1[b])
+            elif normalize_how == "mean":
+                norm1 = np.nanmean(I1[b])
+            elif normalize_how == "area":
+                norm1 = np.abs(nantrapz(I1[b], w1[b]))
+            else:
+                raise ValueError(
+                    "Unexpected `normalize_how`: {0}".format(normalize_how)
+                )
+            # now normalize s2. Ensure we use the same unit system!
+            w2, I2 = s2.get(
+                var, copy=False, wunit=s1.get_waveunit(), Iunit=s1.units[var]
+            )
+            b = (w2 > wmin) & (w2 < wmax)
+            if normalize_how == "max":
+                norm2 = np.nanmax(I2[b])
+            elif normalize_how == "mean":
+                norm2 = np.nanmean(I2[b])
+            elif normalize_how == "area":
+                norm2 = np.abs(nantrapz(I2[b], w2[b]))
+            else:
+                raise ValueError(
+                    "Unexpected `normalize_how`: {0}".format(normalize_how)
+                )
+            s1 = multiply(s1, 1 / norm1, var=var)
+            s2 = multiply(s2, 1 / norm2, var=var)
+        else:
+            if normalize_how == "max":
+                norm1 = np.nanmax(s1.get(var, copy=False)[1])
+                norm2 = np.nanmax(s2.get(var)[1])
 
-#             elif normalize_how == "mean":
-#                 norm1 = np.nanmean(s1.get(var, copy=False)[1])
-#                 norm2 = np.nanmean(s2.get(var)[1])
+            elif normalize_how == "mean":
+                norm1 = np.nanmean(s1.get(var, copy=False)[1])
+                norm2 = np.nanmean(s2.get(var)[1])
 
-#             elif normalize_how == "area":
-#                 # norm1 = s1.get_integral(var)
-#                 # norm2 = s2.get_integral(
-#                 #    var, wunit=s1.get_waveunit(), Iunit=s1.units[var]
-#                 # )
-#                 w1, I1 = s1.get(var, copy=False)
-#                 norm1 = nantrapz(I1, w1)
-#                 w2, I2 = s2.get(var, Iunit=s1.units[var], wunit=s1.get_waveunit())
-#                 norm2 = nantrapz(I2, w2)
+            elif normalize_how == "area":
+                # norm1 = s1.get_integral(var)
+                # norm2 = s2.get_integral(
+                #    var, wunit=s1.get_waveunit(), Iunit=s1.units[var]
+                # )
+                w1, I1 = s1.get(var, copy=False)
+                norm1 = nantrapz(I1, w1)
+                w2, I2 = s2.get(var, Iunit=s1.units[var], wunit=s1.get_waveunit())
+                norm2 = nantrapz(I2, w2)
 
-#             else:
-#                 raise ValueError(
-#                     "Unexpected `normalize_how`: {0}".format(normalize_how)
-#                 )
-#             # Ensure we use the same unit system!
-#             s1 = multiply(s1, 1 / norm1, var=var, Iunit=s1.units[var])
-#             s2 = multiply(s2, 1 / norm2, var=var, Iunit=s1.units[var])
-#             # s1 = multiply(s1, 1 / norm1, var=var)
-#             # s2 = multiply(s2, 1 / norm2, var=var)
+            else:
+                raise ValueError(
+                    "Unexpected `normalize_how`: {0}".format(normalize_how)
+                )
+            # Ensure we use the same unit system!
+            s1 = multiply(s1, 1 / norm1, var=var, Iunit=s1.units[var])
+            s2 = multiply(s2, 1 / norm2, var=var, Iunit=s1.units[var])
+            # s1 = multiply(s1, 1 / norm1, var=var)
+            # s2 = multiply(s2, 1 / norm2, var=var)
 
 #     # mask for 0
 #     wdiff, dI = get_diff(
@@ -440,7 +440,8 @@ def get_residual(s1, s2, var,
                  normalize=False,
                  verbose=False,
                  diff_window=0,
-                 ignore_nan=False):
+                 ignore_nan=False,
+                 normalize_how="max"):
     """ 
 
 
@@ -478,7 +479,19 @@ def get_residual(s1, s2, var,
         s2 = s2.copy()
         w1, I1 = s1.get(var, wunit=wunit, copy=False)
         w2, I2 = s2.get(var, wunit=wunit, copy=False)
-        ratio = np.nanmax(I1) / np.nanmax(I2)
+                
+        if normalize_how == "max":
+            ratio = np.nanmax(I1) / np.nanmax(I2)
+        elif normalize_how == "mean":
+            ratio = np.nanmean(I1) / np.nanmean(I2)
+        elif normalize_how == "area":
+            norm1 = np.abs(nantrapz(I1, w1))
+            norm2 = np.abs(nantrapz(I2, w2))
+            ratio = norm1 / norm2
+        else:
+            raise ValueError(
+                "Unexpected `normalize_how`: {0}".format(normalize_how)
+            )
         I1 /= np.nanmax(I1)
         I2 /= np.nanmax(I2)
 

--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -312,12 +312,23 @@ def get_residual(
             
             s_exp   # in 'nm'
             s_calc  # in 'cm-1'
-            get_residual(s_exp, s_calc, normalize=(4178, 4180))  # interpreted as 'nm'
+            get_residual(s_exp, s_calc, normalize=True)  
 
     normalize_how: ``'max'``, ``'area'``, ``'mean'``
         how to normalize. ``'max'`` is the default but may not be suited for very
         noisy experimental spectra. ``'area'`` will normalize the integral to 1.
-        ``'mean'`` will normalize by the mean amplitude value
+        ``'mean'`` will normalize by the mean amplitude value. Ex::
+        
+            get_residual(s_exp, s_calc, normalize=True, normalize_how == "area") 
+        
+    See Also
+    --------
+    :func:`~radis.spectrum.compare.get_diff`, 
+    :func:`~radis.spectrum.compare.get_ratio`, 
+    :func:`~radis.spectrum.compare.get_distance`, 
+    :func:`~radis.spectrum.compare.plot_diff`, 
+    :func:`~radis.spectrum.compare.get_residual_integral`, 
+    :meth:`~radis.spectrum.spectrum.compare_with` 
     """
     from numpy.linalg import norm
 

--- a/radis/spectrum/operations.py
+++ b/radis/spectrum/operations.py
@@ -429,7 +429,7 @@ def _get_unique_var(s, var, inplace):
     return var
 
 
-def multiply(s, coef, var=None, inplace=False):
+def multiply(s, coef, Iunit=None, var=None, inplace=False):
     """Multiply s[var] by the float 'coef'
 
     Parameters
@@ -454,6 +454,8 @@ def multiply(s, coef, var=None, inplace=False):
     """
     # Check input
     var = _get_unique_var(s, var, inplace)
+    if Iunit == None:
+        Iunit = s.units[var]
 
     if not inplace:
         s = s.copy(quantity=var)
@@ -461,7 +463,7 @@ def multiply(s, coef, var=None, inplace=False):
     #            s.name = name
 
     # Multiply inplace       ( @dev: we have copied already if needed )
-    w, I = s.get(var, wunit=s.get_waveunit(), copy=False)
+    w, I = s.get(var, wunit=s.get_waveunit(), copy=False, Iunit=Iunit)
     I *= coef  # @dev: updates the Spectrum directly because of copy=False
 
     return s

--- a/radis/test/lbl/test_base.py
+++ b/radis/test/lbl/test_base.py
@@ -398,7 +398,7 @@ def test_optically_thick_limit_2iso(verbose=True, plot=True, *args, **kwargs):
 
     finally:
         # Reset DEBUG_MODE
-        radis.DEBUG_MODE = DEBUG_MODE
+        radis.DEBUG_MODE = DEBUG_MODE  
 
 
 def _run_testcases(verbose=True, plot=True):
@@ -408,57 +408,5 @@ def _run_testcases(verbose=True, plot=True):
     test_optically_thick_limit_1iso(plot=plot, verbose=verbose)
     test_optically_thick_limit_2iso(plot=plot, verbose=verbose)
 
-
 if __name__ == "__main__":
-    # _run_testcases()
-    
-    from radis import calc_spectrum, get_residual, experimental_spectrum, plot_diff
-    s1 = calc_spectrum(1900, 2300,
-                      molecule='CO',
-                      isotope='1,2,3',
-                      pressure=1.01325,
-                      Tgas=1000,
-                      mole_fraction=0.1,
-                      )
-    s1.apply_slit(1, 'nm')
-    
-    #s2 is like s1 but at 1001 K - to have an order of magnitude for residual
-    s2 = calc_spectrum(1900, 2300,         
-                      molecule='CO',
-                      isotope='1,2,3',
-                      pressure=1.01325,
-                      Tgas=1001, #HERE IS THE DIFFERENCE
-                      mole_fraction=0.1,
-                      )
-    s2.apply_slit(1, 'nm')
-    residual_ref = get_residual(s1, s2, 'radiance', 
-                                # ignore_nan=False, 
-                                normalize=True)
-    
-    w1, I1 = s1.get('radiance', copy=False, wunit=s1.get_waveunit())
-    
-    #Fake experimental spectrum (identical)
-    s_expe_1 = experimental_spectrum(w1, I1, Iunit="mW/cm2/sr/nm", wunit="cm-1") 
-    
-    #Fake experimental spectrum with a new unit (but identical)
-    I2 = I1*1e-3
-    s_expe_2 = experimental_spectrum(w1, I2, Iunit="W/cm2/sr/nm", wunit="cm-1") 
-    
-    #Fake experimental spectrum with a nan
-    I3 = I1.copy()
-    I3[0] = np.nan
-    s_expe_3 = experimental_spectrum(w1, I3, Iunit="W/cm2/sr/nm", wunit="cm-1") 
-    
-    
-    
-    residual1 = get_residual(s1, s_expe_1, 'radiance', 
-                             # ignore_nan=False, 
-                             normalize=True)
-    residual2 = get_residual(s1, s_expe_2, 'radiance', 
-                             # ignore_nan=False, 
-                             normalize=True)
-    residual3 = get_residual(s1, s_expe_2, 'radiance', 
-                              ignore_nan=True, 
-                             normalize=True)
-    
-    print(residual1, residual2, residual3, residual_ref)
+    _run_testcases()

--- a/radis/test/lbl/test_base.py
+++ b/radis/test/lbl/test_base.py
@@ -410,4 +410,55 @@ def _run_testcases(verbose=True, plot=True):
 
 
 if __name__ == "__main__":
-    _run_testcases()
+    # _run_testcases()
+    
+    from radis import calc_spectrum, get_residual, experimental_spectrum, plot_diff
+    s1 = calc_spectrum(1900, 2300,
+                      molecule='CO',
+                      isotope='1,2,3',
+                      pressure=1.01325,
+                      Tgas=1000,
+                      mole_fraction=0.1,
+                      )
+    s1.apply_slit(1, 'nm')
+    
+    #s2 is like s1 but at 1001 K - to have an order of magnitude for residual
+    s2 = calc_spectrum(1900, 2300,         
+                      molecule='CO',
+                      isotope='1,2,3',
+                      pressure=1.01325,
+                      Tgas=1001, #HERE IS THE DIFFERENCE
+                      mole_fraction=0.1,
+                      )
+    s2.apply_slit(1, 'nm')
+    residual_ref = get_residual(s1, s2, 'radiance', 
+                                # ignore_nan=False, 
+                                normalize=True)
+    
+    w1, I1 = s1.get('radiance', copy=False, wunit=s1.get_waveunit())
+    
+    #Fake experimental spectrum (identical)
+    s_expe_1 = experimental_spectrum(w1, I1, Iunit="mW/cm2/sr/nm", wunit="cm-1") 
+    
+    #Fake experimental spectrum with a new unit (but identical)
+    I2 = I1*1e-3
+    s_expe_2 = experimental_spectrum(w1, I2, Iunit="W/cm2/sr/nm", wunit="cm-1") 
+    
+    #Fake experimental spectrum with a nan
+    I3 = I1.copy()
+    I3[0] = np.nan
+    s_expe_3 = experimental_spectrum(w1, I3, Iunit="W/cm2/sr/nm", wunit="cm-1") 
+    
+    
+    
+    residual1 = get_residual(s1, s_expe_1, 'radiance', 
+                             # ignore_nan=False, 
+                             normalize=True)
+    residual2 = get_residual(s1, s_expe_2, 'radiance', 
+                             # ignore_nan=False, 
+                             normalize=True)
+    residual3 = get_residual(s1, s_expe_2, 'radiance', 
+                              ignore_nan=True, 
+                             normalize=True)
+    
+    print(residual1, residual2, residual3, residual_ref)

--- a/radis/test/spectrum/test_compare.py
+++ b/radis/test/spectrum/test_compare.py
@@ -91,25 +91,6 @@ def test_plot_compare_with_nan(
     s = Radiance_noslit(s)
     s._q["radiance_noslit"][0] = np.nan
 
-    # Test get_residual methods when there are nans in the spectra
-    diff1 = get_residual(
-        s,
-        s * 1.2,
-        var="radiance_noslit",
-        ignore_nan=True,
-        normalize=True,
-        normalize_how="mean",
-    )
-    diff2 = get_residual(
-        s,
-        s * 1.2,
-        var="radiance_noslit",
-        ignore_nan=True,
-        normalize=True,
-        normalize_how="area",
-    )
-    # TODO Write similar testcase for normalize_how="mean"
-
     # Test Plot function when there are Nans in the spectrum:
     if plot:
         s.plot(normalize=True)
@@ -121,6 +102,63 @@ def test_plot_compare_with_nan(
         plot_diff(s, s * 1.2, "radiance_noslit", normalize=(2000, 2100))
 
 
+def test_get_residual():
+    from radis import calc_spectrum, experimental_spectrum
+
+    s1 = calc_spectrum(
+        1900,
+        2300,
+        molecule="CO",
+        isotope="1,2,3",
+        pressure=1.01325,
+        Tgas=1000,
+        mole_fraction=0.1,
+    )
+    s1.apply_slit(1, "nm")
+    w1, I1 = s1.get("radiance", copy=False, wunit=s1.get_waveunit())
+
+    # Fake experimental spectrum (identical)
+    s_expe_1 = experimental_spectrum(w1, I1, Iunit="mW/cm2/sr/nm", wunit="cm-1")
+    residual1 = get_residual(
+        s1,
+        s_expe_1,
+        "radiance",
+        # ignore_nan=False,
+        normalize=True,
+    )
+    assert residual1 == 0
+
+    # Fake experimental spectrum with a new unit (but identical)
+    I2 = I1 * 1e-3
+    s_expe_2 = experimental_spectrum(w1, I2, Iunit="W/cm2/sr/nm", wunit="cm-1")
+
+    for bool_test in [True, False]:
+        residual2 = get_residual(
+            s1,
+            s_expe_2,
+            "radiance",
+            # ignore_nan=False,
+            normalize=bool_test,
+        )
+        assert residual2 < 1e-10
+
+    # Fake experimental spectrum with a nan
+    I3 = I1.copy()
+    I3[0] = np.nan
+    s_expe_3 = experimental_spectrum(w1, I3, Iunit="W/cm2/sr/nm", wunit="cm-1")
+
+    for bool_how in ["max", "area", "mean"]:
+        residual3 = get_residual(
+            s1,
+            s_expe_3,
+            "radiance",
+            ignore_nan=True,
+            normalize=True,
+            normalize_how=bool_how,
+        )
+        assert residual3 == 0
+
+
 def _run_testcases(plot=True, verbose=True, warnings=True, *args, **kwargs):
     """ Test procedures
     """
@@ -129,6 +167,7 @@ def _run_testcases(plot=True, verbose=True, warnings=True, *args, **kwargs):
     # ----------------------------------
     test_compare_methods(verbose=verbose, plot=plot, *args, **kwargs)
     test_plot_compare_with_nan(verbose=verbose, plot=True, *args, **kwargs)
+    test_get_residual()
     return True
 
 

--- a/radis/test/spectrum/test_compare.py
+++ b/radis/test/spectrum/test_compare.py
@@ -132,31 +132,45 @@ def test_get_residual():
     I2 = I1 * 1e-3
     s_expe_2 = experimental_spectrum(w1, I2, Iunit="W/cm2/sr/nm", wunit="cm-1")
 
-    for bool_test in [True, False]:
-        residual2 = get_residual(
+    
+    residual2 = get_residual(
+        s1,
+        s_expe_2,
+        "radiance",
+        normalize=False,
+    )
+    assert residual2 < 1e-10
+    for bool_how in ["max", "area", "mean"]:
+        residual2_bis = get_residual(
             s1,
             s_expe_2,
             "radiance",
-            # ignore_nan=False,
-            normalize=bool_test,
+            ignore_nan=False,
+            normalize=True,
+            normalize_how=bool_how
         )
-        assert residual2 < 1e-10
-
+        # print('residu2 ={}'.format(residual2))
+        assert residual2_bis < 1e-13
+        
+        
     # Fake experimental spectrum with a nan
     I3 = I1.copy()
     I3[0] = np.nan
     s_expe_3 = experimental_spectrum(w1, I3, Iunit="W/cm2/sr/nm", wunit="cm-1")
 
-    for bool_how in ["max", "area", "mean"]:
+    # Intrestingly, the "mean" method seams to be not adapted for spectra with nans
+    criterion = [1e-10, 2e-6, 2e-2]
+    for index, bool_how in enumerate(["max", "area", "mean"]):
         residual3 = get_residual(
             s1,
             s_expe_3,
             "radiance",
             ignore_nan=True,
             normalize=True,
-            normalize_how=bool_how,
+            normalize_how=bool_how
         )
-        assert residual3 == 0
+        # print('residu3 ={}'.format(residual3))
+        assert residual3 < criterion[index]
 
 
 def _run_testcases(plot=True, verbose=True, warnings=True, *args, **kwargs):
@@ -165,8 +179,8 @@ def _run_testcases(plot=True, verbose=True, warnings=True, *args, **kwargs):
 
     # Test all Spectrum compare methods
     # ----------------------------------
-    test_compare_methods(verbose=verbose, plot=plot, *args, **kwargs)
-    test_plot_compare_with_nan(verbose=verbose, plot=True, *args, **kwargs)
+    # test_compare_methods(verbose=verbose, plot=plot, *args, **kwargs)
+    # test_plot_compare_with_nan(verbose=verbose, plot=True, *args, **kwargs)
     test_get_residual()
     return True
 

--- a/radis/test/spectrum/test_spectrum.py
+++ b/radis/test/spectrum/test_spectrum.py
@@ -215,7 +215,7 @@ def test_intensity_conversion(verbose=True, *args, **kwargs):
     w_cm = nm2cm(w_nm)
     I_nm = planck(w_nm, T=6000, unit="mW/sr/cm2/nm")
 
-    s = calculated_spectrum(w_nm, I_nm, wunit="nm_vac", Iunit="mW/sr/cm2/nm",)
+    s = calculated_spectrum(w_nm, I_nm, wunit="nm_vac", Iunit="mW/sr/cm2/nm")
 
     # mW/sr/cm2/nm -> mW/sr/cm2/cm-1
     w, I = s.get("radiance_noslit", Iunit="mW/sr/cm2/cm_1")


### PR DESCRIPTION
Hi guys,

This is related to #102. I did what I wanted to do:
- [x] assert NANs are correctly handled in plot_diff and get_residual
- [x]  find the common functions in plot_diff and get_residual
- [x] write the functions of the previous point (copy-paste)
- [x] **quickly** implement the previous test

Please, tell me what you think of the output. I removed the option to normalize on a certain wave-range. I think it just complicates this function a bit too much. What is left:
- [x] write the help of each function
- [x] remove previous get_residual which is commented
- [x] **properly** implement the tests with nice functions
- [x] (you tell me)