### PR TITLE
dimensionned units for multiply/division 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,6 @@
 from __future__ import absolute_import
 import sys
 import os
-import shlex
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -121,6 +120,7 @@ intersphinx_mapping = {
 }
 
 napoleon_google_docstring = False
+napoleon_use_param = False  # fixes https://github.com/sphinx-doc/sphinx/issues/2227
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -174,6 +174,7 @@ exclude_patterns = ["_build"]
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
 # default_role = None
+default_role = "py:obj"  # fixes https://github.com/spacetelescope/specviz/pull/77
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 # add_function_parentheses = True

--- a/docs/spectrum/spectrum.rst
+++ b/docs/spectrum/spectrum.rst
@@ -534,6 +534,11 @@ the spectral radiance of a spectrum with a low resolution::
 
     (10*Radiance(s.apply_slit(10, 'nm'))).plot()
 
+Algebraic operations also work with dimensioned `~astropy.units.quantity.Quantity`. 
+For instance, remove a constant baseline in a given unit::
+
+    s -= 0.1 * u.Unit('W/cm2/sr/nm')     
+
 
 .. _label_spectrum_offset_crop:
 

--- a/docs/spectrum/spectrum.rst
+++ b/docs/spectrum/spectrum.rst
@@ -539,6 +539,14 @@ For instance, remove a constant baseline in a given unit::
 
     s -= 0.1 * u.Unit('W/cm2/sr/nm')     
 
+Here, se normalize a spectrum manually, assuming the spectrum units is in "mW/cm2/sr/nm" :: 
+
+    s /= s.max() * u.Unit("mW/cm2/sr/nm")
+
+Or below, we calibrate a Spectrum, assuming the spectrum units is in "count" ::
+
+    s *= 100 * u.Unit("mW/cm2/sr/nm/count")
+
 
 .. _label_spectrum_offset_crop:
 
@@ -558,6 +566,28 @@ so they can be used directly with::
 By default, using methods will modify the object inplace, using the functions will 
 generate a new Spectrum. 
     
+Normalize
+---------
+
+Use :py:meth:`~radis.spectrum.spectrum.normalize` directly, if your spectrum
+only has one spectral quantity ::
+
+    s.normalize()
+    s.normalize(normalize_how="max")
+    s.normalize(normalize_how="area")
+    
+You can also normalize only on limited range. Useful for noisy spectra ::
+
+    s.normalize(wrange=(2250, 2500), wunit="cm-1", normalize_how="mean")    
+
+This returns a new spectrum and does not modify the Spectrum itself. To do so use::
+
+    s.normalize(inplace=True)
+    
+You can chain the commands : 
+
+    s.normalize().plot()
+
 
 .. _label_spectrum_remove_baseline:
 

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -3256,15 +3256,15 @@ def get_waverange(
         ----------
         medium: ``'air'``, ``'vacuum'``
             propagation medium
-        wmin, wmax: float, or ~astropy.units.quantity.Quantity or ``None``
+        wmin, wmax: float, or `~astropy.units.quantity.Quantity` or ``None``
             hybrid parameters that can serve as both wavenumbers or wavelength depending on the unit accompanying them.
             If unitless, wunit is assumed as the accompanying unit.
         wunit: string
             The unit accompanying wmin and wmax. Cannot be passed without passing values for wmin and wmax.
             Default: cm-1
-        wavenum_min, wavenum_max: float, or ~astropy.units.quantity.Quantity or ``None``
+        wavenum_min, wavenum_max: float, or `~astropy.units.quantity.Quantity` or ``None``
             wavenumbers
-        wavelength_min, wavelength_max: float, or ~astropy.units.quantity.Quantity or ``None``
+        wavelength_min, wavelength_max: float, or `~astropy.units.quantity.Quantity` or ``None``
             wavelengths in given ``medium``
         Returns
         -------

--- a/radis/phys/units_astropy.py
+++ b/radis/phys/units_astropy.py
@@ -7,9 +7,9 @@ def convert_and_strip_units(quantity, output_unit=None, digit=10):
 
     Parameters
     ----------
-    quantity : int or float or list or None or ~astropy.units.quantity.Quantity
+    quantity : int or float or list or None or `~astropy.units.quantity.Quantity`
         Numerical quantity. Pass it without including units if default units are intended.
-    output_unit : ~astropy.units.core.UnitBase or ~astropy.units.quantity.Quantity
+    output_unit : `~astropy.units.core.UnitBase` or `~astropy.units.quantity.Quantity`
         The default units in which the quantity is to be converted before extracting the value.
 
     Other Parameters

--- a/radis/spectrum/operations.py
+++ b/radis/spectrum/operations.py
@@ -515,7 +515,7 @@ def multiply(s, coef, unit=None, var=None, inplace=False):
     # Convert Spectrum unit
     if unit is not None:
         Iunit = s.units[var]
-        s.units[var] = (Iunit * unit).to_string()
+        s.units[var] = (u.Unit(Iunit) * u.Unit(unit)).to_string()
 
     return s
 

--- a/radis/spectrum/operations.py
+++ b/radis/spectrum/operations.py
@@ -472,7 +472,7 @@ def multiply(s, coef, unit=None, var=None, inplace=False):
         The spectrum to multiply.
     coef: float
         Coefficient of the multiplication.
-    unit: str. 
+    unit: str, or `~astropy.units.core.Unit`
         unit for ``coef``. If ``None``, ``coef`` is considered to be 
         adimensioned. Else, the spectrum `~radis.spectrum.spectrum.Spectrum.units` is multiplied. 
     var: str, or ``None``

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -345,6 +345,8 @@ class Spectrum(object):
         self.populations = populations
         self.lines = lines
         self.units = units
+        """ dict: units for spectral quantities. 
+        """
         self.cond_units = cond_units
         self.name = name
         self.file = None  # used to store filename when loaded from a file
@@ -624,8 +626,9 @@ class Spectrum(object):
             Default ``nm`` (wavelength in air).
 
         Iunit: unit for variable ``var``
-            if 'default', default unit for quantity `var` is used. See Spectrum.units
-            to get the units. for radiance, one can use per wavelength (~ 'W/m2/sr/nm')
+            if ``"default"``, default unit for quantity `var` is used. See the 
+            :py:attr:`~radis.spectrum.spectrum.Spectrum.units` attribute. 
+            For ``var="radiance"``, one can use per wavelength (~ 'W/m2/sr/nm')
             or per wavenumber (~ 'W/m2/sr/cm-1') units
 
         Other Parameters
@@ -3345,9 +3348,9 @@ class Spectrum(object):
             if ``True``, use plot_diff to plot all quantities for the 2 spectra
             and the difference between them. Default ``True``.
 
-        wunit: 'nm', 'cm-1', 'default'
-            in which wavespace to compare (and plot). If default, natural wavespace
-            of first Spectrum is taken
+        wunit: ``"nm"``, ``"cm-1"``, ``"default"``
+            in which wavespace to compare (and plot). If ``"default"``, natural wavespace
+            of first Spectrum is taken.
 
         rtol: float
             relative difference to use for spectral quantities comparison

--- a/radis/spectrum/utils.py
+++ b/radis/spectrum/utils.py
@@ -197,6 +197,8 @@ def make_up_unit(Iunit, var):
             Iunit = r"-ln(I/I0)"
         elif var in ["emissivity_no_slit", "emissivity"]:
             Iunit = r"$\mathregular{\epsilon}$"
+    elif Iunit == "1.0":
+        Iunit = r"norm"
 
     return Iunit
 

--- a/radis/spectrum/utils.py
+++ b/radis/spectrum/utils.py
@@ -197,8 +197,8 @@ def make_up_unit(Iunit, var):
             Iunit = r"-ln(I/I0)"
         elif var in ["emissivity_no_slit", "emissivity"]:
             Iunit = r"$\mathregular{\epsilon}$"
-    elif Iunit == "1.0":
-        Iunit = r"norm"
+        elif var in ["radiance", "radiance_noslit"]:
+            Iunit = r"norm"
 
     return Iunit
 

--- a/radis/test/spectrum/test_operations.py
+++ b/radis/test/spectrum/test_operations.py
@@ -284,7 +284,7 @@ def test_dimensioned_operations(*args, **kwargs):
     # Example : a manual normalization
     s /= s.max() * u.Unit("mW/cm2/sr/nm")
 
-    assert s.units["radiance"] == "1.0"  # normalized
+    assert s.units["radiance"] == ""  # normalized
     assert s.max() == 1.0
 
     # Test Multiplication

--- a/radis/test/spectrum/test_operations.py
+++ b/radis/test/spectrum/test_operations.py
@@ -280,6 +280,23 @@ def test_dimensioned_operations(*args, **kwargs):
 
     assert np.isclose(s.get("radiance")[1].max(), Imax)
 
+    # Test division
+    # Example : a manual normalization
+    s /= s.max() * u.Unit("mW/cm2/sr/nm")
+
+    assert s.units["radiance"] == "1.0"  # normalized
+    assert s.max() == 1.0
+
+    # Test Multiplication
+    # example : a manual Calibration
+    s.units["radiance"] = "count"
+    s *= 100 * u.Unit("mW/cm2/sr/nm/count")
+
+    assert u.Unit(s.units["radiance"]) == u.Unit(
+        "mW/cm2/sr/nm"
+    )  # check units are valid
+    assert s.units["radiance"] == "mW / (cm2 nm sr)"  # check units have been simplified
+
 
 def _run_testcases(verbose=True, plot=False, *args, **kwargs):
     """ Test procedures


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/blob/develop/CONTRIBUTING.md . -->

### Description

- Add unit support for multiply / division. Fixes #109 
- Also add min(), max() methods for spectra with unique quantities 

Allows to use the following syntax : 
```
# add a baseline : 
s += 0.1 * u.Unit("W/cm2/sr/nm")   

# normalize manually : 
s /= s.max() * u.Unit("mW/cm2/sr/nm")   
assert s.units['radiance'] == "1.0" # normalized
assert s.max() == 1.0

# Calibrate :
s.units['radiance'] = 'count'
s *= 100 * u.Unit("mW/cm2/sr/nm/count")

```

Edit : 

also added a normalization method directly : 

```

    s.normalize()
    s.normalize(normalize_how="max")
    s.normalize(normalize_how="area")
    
You can also normalize only on limited range. Useful for noisy spectra ::

    s.normalize(wrange=(2250, 2500), wunit="cm-1", normalize_how="mean")    

This returns a new spectrum and does not modify the Spectrum itself. To do so use::

    s.normalize(inplace=True)
    
You can chain the commands :: 

    s.normalize().plot()
```