### PR TITLE
Ensure load_databank() does not read cached files

### DIFF
--- a/radis/io/cdsd.py
+++ b/radis/io/cdsd.py
@@ -23,13 +23,13 @@ from __future__ import print_function, absolute_import, division, unicode_litera
 
 from collections import OrderedDict
 import radis
-from os.path import exists, splitext
+from os.path import exists
 from radis.io.tools import (
     parse_hitran_file,
     drop_object_format_columns,
     replace_PQR_with_m101,
 )
-from radis.misc.cache_files import save_to_hdf, load_h5_cache_file
+from radis.misc.cache_files import save_to_hdf, load_h5_cache_file, cache_file_name
 from os.path import getmtime
 import time
 from radis import OLDEST_COMPATIBLE_VERSION
@@ -260,7 +260,7 @@ def cdsd2df(
         raise ValueError("Unknown CDSD version: {0}".format(version))
 
     # Use cache file if possible
-    fcache = splitext(fname)[0] + ".h5"
+    fcache = cache_file_name(fname)
     if cache and exists(fcache):
         df = load_h5_cache_file(
             fcache,

--- a/radis/io/hitran.py
+++ b/radis/io/hitran.py
@@ -26,14 +26,14 @@ from __future__ import print_function, absolute_import, division, unicode_litera
 import sys
 import pandas as pd
 from collections import OrderedDict
-from os.path import exists, splitext
+from os.path import exists
 import radis
 from radis.io.tools import (
     parse_hitran_file,
     drop_object_format_columns,
     replace_PQR_with_m101,
 )
-from radis.misc.cache_files import load_h5_cache_file, save_to_hdf
+from radis.misc.cache_files import load_h5_cache_file, save_to_hdf, cache_file_name
 from os.path import getmtime
 
 # from radis.test.utils import getTestFile
@@ -319,7 +319,7 @@ def hit2df(fname, count=-1, cache=False, verbose=True, drop_non_numeric=True):
     columns = columns_2004
 
     # Use cache file if possible
-    fcache = splitext(fname)[0] + ".h5"
+    fcache = cache_file_name(fname)
     if cache and exists(fcache):
         df = load_h5_cache_file(
             fcache,

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -73,6 +73,7 @@ from radis.io.hitran import (
 )
 
 # from radis.io.hitran import hit2dfTAB
+from radis.misc.cache_files import cache_file_name
 from radis.misc.warning import EmptyDatabaseError
 from radis.io.query import fetch_astroquery
 from radis.io.tools import drop_object_format_columns, replace_PQR_with_m101
@@ -1288,9 +1289,11 @@ class DatabankLoader(object):
         # Check input types are correct
         if isinstance(path, string_types):  # make it a list
             path = get_files_from_regex(path)
-            path = [
-                p for p in path if not (p.endswith(".h5") and p[:-3] in path)
-            ]  # ignore the cached h5 files when the main dataset files are present
+            filtered_path = [fname for fname in path]
+            for fname in path:
+                if cache_file_name(fname) in path and cache_file_name(fname) != fname:
+                    filtered_path.remove(cache_file_name(fname))
+            path = filtered_path
 
         if dbformat not in KNOWN_DBFORMAT:
             # >>>>>>>>>>>

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -1288,9 +1288,6 @@ class DatabankLoader(object):
         # Check input types are correct
         if isinstance(path, string_types):  # make it a list
             path = get_files_from_regex(path)
-            path = [
-                p for p in path if not (p.endswith(".h5") and p[:-3] in path)
-            ]  # ignore cached files in the directory if the original dataset is present
 
         if dbformat not in KNOWN_DBFORMAT:
             # >>>>>>>>>>>

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -104,7 +104,6 @@ from time import time
 import gc
 from uuid import uuid1
 from six.moves import range
-import fnmatch
 from radis.misc.utils import get_files_from_regex
 
 KNOWN_DBFORMAT = ["hitran", "cdsd-hitemp", "cdsd-4000"]
@@ -1289,6 +1288,9 @@ class DatabankLoader(object):
         # Check input types are correct
         if isinstance(path, string_types):  # make it a list
             path = get_files_from_regex(path)
+            path = [
+                p for p in path if not (p.endswith(".h5") and p[:-3] in path)
+            ]  # ignore cached files in the directory if the original dataset is present
 
         if dbformat not in KNOWN_DBFORMAT:
             # >>>>>>>>>>>

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -1289,6 +1289,14 @@ class DatabankLoader(object):
         # Check input types are correct
         if isinstance(path, string_types):  # make it a list
             path = get_files_from_regex(path)
+
+            # Ensure that `path` does not contain the cached dataset files in
+            # case a wildcard input is given by the user. For instance, if the
+            # given input is "cdsd_hitemp_09_frag*", path should not contain both
+            # "cdsd_hitemp_09_fragment.txt" and "cdsd_hitemp_09_fragment.h5".
+
+            # Reference: https://github.com/radis/radis/issues/121
+
             filtered_path = [fname for fname in path]
             for fname in path:
                 if cache_file_name(fname) in path and cache_file_name(fname) != fname:

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -1288,6 +1288,9 @@ class DatabankLoader(object):
         # Check input types are correct
         if isinstance(path, string_types):  # make it a list
             path = get_files_from_regex(path)
+            path = [
+                p for p in path if not (p.endswith(".h5") and p[:-3] in path)
+            ]  # ignore the cached h5 files when the main dataset files are present
 
         if dbformat not in KNOWN_DBFORMAT:
             # >>>>>>>>>>>

--- a/radis/misc/cache_files.py
+++ b/radis/misc/cache_files.py
@@ -36,7 +36,7 @@ import os
 import h5py
 import radis
 from warnings import warn
-from os.path import exists
+from os.path import exists, splitext
 from radis import OLDEST_COMPATIBLE_VERSION
 from radis.misc.basics import compare_dict, is_float
 from radis.misc.printer import printr, printm
@@ -551,3 +551,8 @@ def filter_metadata(arguments, discard_variables=["self", "verbose"]):
     metadata = {k: v for (k, v) in metadata.items() if v is not None}
 
     return metadata
+
+
+def cache_file_name(fname):
+    """ Returns the corresponding cache file name for fname """
+    return splitext(fname)[0] + ".h5"

--- a/radis/test/lbl/test_loader.py
+++ b/radis/test/lbl/test_loader.py
@@ -87,6 +87,16 @@ def test_retrieve_from_database(
 
 
 def test_ignore_cached_files():
+    """
+        Previous implementation of RADIS saved the cached h5 files generated while reading the
+        dataset in the same directory from where the data was being read. Using a wildcard input
+        such as `path = "cdsd_hitemp_09_frag*"` in such case led to the cached files present
+        in directory to also being loaded and treated as the dataset files. This resulted in
+        an error due to the differences in the way data is stored in h5 files versus in dataset
+        files such as par, txt, etc.
+
+        Reference: `https://github.com/radis/radis/issues/121`
+    """
 
     sf = SpectrumFactory(wavenum_min=2000, wavenum_max=3000, pressure=1)
 

--- a/radis/test/lbl/test_loader.py
+++ b/radis/test/lbl/test_loader.py
@@ -8,7 +8,7 @@ Created on Mon May  7 17:34:52 2018
 from __future__ import absolute_import, unicode_literals, division, print_function
 from radis.lbl import SpectrumFactory
 from radis.misc.printer import printm
-from radis.test.utils import setup_test_line_databases
+from radis.test.utils import setup_test_line_databases, getTestFile
 import matplotlib.pyplot as plt
 from os.path import exists
 from shutil import rmtree
@@ -86,9 +86,27 @@ def test_retrieve_from_database(
         rmtree(temp_database_name)
 
 
+def test_ignore_cached_files():
+
+    sf = SpectrumFactory(wavenum_min=2000, wavenum_max=3000, pressure=1,)
+
+    loaded_files = True
+    file_dir = getTestFile("cdsd_hitemp_09_fragment.txt")
+    test_file = file_dir[:-8] + "*"
+    sf.load_databank(path=test_file, format="cdsd-hitemp", parfuncfmt="hapi")
+
+    try:
+        sf.load_databank(path=test_file, format="cdsd-hitemp", parfuncfmt="hapi")
+    except UnicodeDecodeError:
+        loaded_files = False
+
+    assert loaded_files
+
+
 def _run_testcases(verbose=True, plot=True):
 
     test_retrieve_from_database(plot=plot, verbose=verbose)
+    test_ignore_cached_files()
 
 
 if __name__ == "__main__":

--- a/radis/test/lbl/test_loader.py
+++ b/radis/test/lbl/test_loader.py
@@ -88,25 +88,24 @@ def test_retrieve_from_database(
 
 def test_ignore_cached_files():
 
-    sf = SpectrumFactory(wavenum_min=2000, wavenum_max=3000, pressure=1,)
+    sf = SpectrumFactory(wavenum_min=2000, wavenum_max=3000, pressure=1)
 
-    loaded_files = True
     file_dir = getTestFile("cdsd_hitemp_09_fragment.txt")
     test_file = file_dir[:-8] + "*"
     sf.load_databank(path=test_file, format="cdsd-hitemp", parfuncfmt="hapi")
 
     try:
         sf.load_databank(path=test_file, format="cdsd-hitemp", parfuncfmt="hapi")
-    except UnicodeDecodeError:
-        loaded_files = False
-
-    assert loaded_files
+    except UnicodeDecodeError as err:
+        raise UnicodeDecodeError(
+            "Couldn't load database the 2nd time. This may be due to cache files trying to be read as normal files"
+        ) from err
 
 
 def _run_testcases(verbose=True, plot=True):
 
-    test_retrieve_from_database(plot=plot, verbose=verbose)
     test_ignore_cached_files()
+    test_retrieve_from_database(plot=plot, verbose=verbose)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/blob/develop/CONTRIBUTING.md . -->

<!-- Provide a general description of what your pull request does. -->

Ensure that `SpectrumFactory.load_databank()` does not read .h5 cached files written in the same directory where the main dataset files are presented.
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #121 