### PR TITLE
fix "cm_1" in units of Spectrum generated before 0.9.26

### DIFF
--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -838,6 +838,14 @@ def _fix_format(file, sload):
                     + "database ASAP."
                 )
                 sload["units"][var] = ""
+            if "cm_1" in unit:
+                printr(
+                    "File {0}".format(basename(file))
+                    + " has a deprecrated structure "
+                    + "(cm_1 is now written cm-1''). Fixed this time, but regenerate "
+                    + "database ASAP."
+                )
+                sload["units"][var] = sload["units"][var].replace("cm_1", "cm-1")
 
     return sload, fixed
 


### PR DESCRIPTION
Fixes loading of old .spec files