### PR TITLE
HITEMP-Hdf5 improvement

### DIFF
--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -177,22 +177,24 @@ def fetch_hitemp(
         if verbose:
             print("Created folder :", local_databases)
 
-    output = abspath(
+    local_file = abspath(
         join(local_databases, molecule + "-" + inputf.replace(".par.bz2", ".h5"))
     )
 
     if not cache or cache == "regen":
         # Delete existing HDF5 file
-        if exists(output):
+        if exists(local_file):
             if verbose:
-                print("Removing existing file ", output)
+                print("Removing existing file ", local_file)
                 # TODO: also clean the getDatabankList? Todo once it is in JSON format. https://github.com/radis/radis/issues/167
-            os.remove(output)
+            os.remove(local_file)
 
-    if exists(output):
+    if exists(local_file):
+        # Read and return from local file
+
         # check metadata :
         check_not_deprecated(
-            output,
+            local_file,
             metadata_is={},
             metadata_keys_contain=["wavenumber_min", "wavenumber_max"],
         )
@@ -200,7 +202,7 @@ def fetch_hitemp(
         if not databank_name in getDatabankList():
             # if not, check number of rows is correct :
             error_msg = ""
-            with pd.HDFStore(output, "r") as store:
+            with pd.HDFStore(local_file, "r") as store:
                 nrows = store.get_storer("df").nrows
                 if nrows != INFO_HITEMP_LINE_COUNT[molecule]:
                     error_msg += (
@@ -224,7 +226,7 @@ def fetch_hitemp(
             if error_msg:
                 raise ValueError(
                     f"{databank_name} not declared in your RADIS ~/.config file although "
-                    + f"{output} exists. {error_msg}\n"
+                    + f"{local_file} exists. {error_msg}\n"
                     + "If you know this file, add it to ~/.radisdb manually. "
                     + "Else regenerate the database with:\n\t"
                     + ">>> radis.SpectrumFactory().fetch_databank(..., use_cached='regen')"
@@ -232,19 +234,19 @@ def fetch_hitemp(
                     + ">>> radis.io.hitemp.fetch_hitemp({molecule}, cache='regen')"
                     + "\n\n⚠️ It will re-download & uncompress the whole database "
                     + "from HITEMP.\n\nList of declared databanks: {getDatabankList()}.\n"
-                    + f"{output} metadata: {file_metadata}"
+                    + f"{local_file} metadata: {file_metadata}"
                 )
 
             # Else database looks ok : register it
             if verbose:
                 print(
                     f"{databank_name} not declared in your RADIS ~/.config file although "
-                    + f"{output} exists. Registering the database automatically."
+                    + f"{local_file} exists. Registering the database automatically."
                 )
 
             register_database(
                 databank_name,
-                [output],
+                [local_file],
                 molecule=molecule,
                 wmin=file_metadata["wavenumber_min"],
                 wmax=file_metadata["wavenumber_max"],
@@ -256,13 +258,13 @@ def fetch_hitemp(
         if verbose:
             print(f"Using existing database {databank_name}")
         df = hdf2df(
-            output,
+            local_file,
             isotope=isotope,
             load_wavenum_min=load_wavenum_min,
             load_wavenum_max=load_wavenum_max,
             verbose=verbose,
         )
-        return df, output if return_local_path else df
+        return (df, local_file) if return_local_path else df
 
     # Doesnt exist : download
     ds = DataSource(join(local_databases, "downloads"))
@@ -291,9 +293,9 @@ def fetch_hitemp(
         wmin = np.inf
         wmax = 0
         if verbose:
-            print(f"Download complete. Building {molecule} database to {output}")
+            print(f"Download complete. Building {molecule} database to {local_file}")
 
-        with pd.HDFStore(output, mode="a", complib="blosc", complevel=9) as f:
+        with pd.HDFStore(local_file, mode="a", complib="blosc", complevel=9) as f:
             Nlines = 0
             Ntotal_lines_expected = INFO_HITEMP_LINE_COUNT[molecule]
             pb = ProgressBar(N=Ntotal_lines_expected, active=verbose)
@@ -318,7 +320,7 @@ def fetch_hitemp(
                     replace_PQR_with_m101(df)
 
                 # df.to_hdf(
-                #     output, "df", format="table", append=True, complib="blosc", complevel=9
+                #     local_file, "df", format="table", append=True, complib="blosc", complevel=9
                 # )
                 f.put(
                     key="df",
@@ -352,7 +354,7 @@ def fetch_hitemp(
 
     # Done: add final checks
     # ... check on the created file that all lines are there :
-    with pd.HDFStore(output, "r") as store:
+    with pd.HDFStore(local_file, "r") as store:
         nrows = store.get_storer("df").nrows
         assert nrows == Nlines
         if nrows != INFO_HITEMP_LINE_COUNT[molecule]:
@@ -366,11 +368,18 @@ def fetch_hitemp(
 
     # Add database to  ~/.radis
     register_database(
-        databank_name, [output], molecule, wmin, wmax, download_date, urlname, verbose
+        databank_name,
+        [local_file],
+        molecule,
+        wmin,
+        wmax,
+        download_date,
+        urlname,
+        verbose,
     )
 
     df = hdf2df(
-        output,
+        local_file,
         isotope=isotope,
         load_wavenum_min=load_wavenum_min,
         load_wavenum_max=load_wavenum_max,
@@ -385,7 +394,7 @@ def fetch_hitemp(
 
             printg("... removed downloaded cache file")
 
-    return df, output if return_local_path else df
+    return (df, local_file) if return_local_path else df
 
 
 def register_database(
@@ -449,9 +458,12 @@ def register_database(
             # TODO @dev : replace once we have configfile as JSON (https://github.com/radis/radis/issues/167)
         except AssertionError:
             raise DatabaseAlreadyExists(
-                f"{databank_name} already exists in your ~/.radis config file. "
-                + "Remove it from your config file, or choose a different name "
-                + "for the downloaded database with `fetch_hitemp(databank_name=...)`"
+                f"{databank_name} already exists in your ~/.radis config file, "
+                + f"with different key `{k}` : `{v}` (~/.radis) ≠ `{dict_entries[k]}` (new). "
+                + "If you're sure of what you're doing, fix the registered database in ~/.radis. "
+                + "Else, remove it from your config file, or choose a different name "
+                + "for the downloaded database with `fetch_hitemp(databank_name=...)`, "
+                + "and restart."
             ) from err
         else:  # no other error raised
             if verbose:

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -85,6 +85,7 @@ def fetch_hitemp(
     verbose=True,
     chunksize=100000,
     clean_cache_files=True,
+    return_local_path=False,
 ):
     """Stream HITEMP file from HITRAN website. Unzip and build a HDF5 file directly.
 
@@ -115,6 +116,8 @@ def fetch_hitemp(
         but can create Memory problems and keep the user uninformed of the progress.
     clean_cache_files: bool
         if ``True`` clean downloaded cache files after HDF5 are created.
+    return_local_path: bool
+        if ``True``, also returns the path of the local database file.
 
     Returns
     -------
@@ -123,6 +126,8 @@ def fetch_hitemp(
         A HDF5 file is also created in ``local_databases`` and referenced
         in the :ref:`RADIS config file <label_lbl_config_file>` with name
         ``databank_name``
+    local_path: str
+        path of local database file if ``return_local_path``
 
     Notes
     -----
@@ -245,13 +250,14 @@ def fetch_hitemp(
 
         if verbose:
             print(f"Using existing database {databank_name}")
-        return hdf2df(
+        df = hdf2df(
             output,
             isotope=isotope,
             load_wavenum_min=load_wavenum_min,
             load_wavenum_max=load_wavenum_max,
             verbose=verbose,
         )
+        return df, output if return_local_path else df
 
     # Doesnt exist : download
     ds = DataSource(join(local_databases, "downloads"))
@@ -355,13 +361,14 @@ def fetch_hitemp(
 
             printg("... removed downloaded cache file")
 
-    return hdf2df(
+    df = hdf2df(
         output,
         isotope=isotope,
         load_wavenum_min=load_wavenum_min,
         load_wavenum_max=load_wavenum_max,
         verbose=verbose,
     )
+    return df, output if return_local_path else df
 
 
 def register_database(
@@ -386,7 +393,7 @@ def register_database(
         adds to :ref:`~/.radis <label_lbl_config_file>` with all the input
         parameters. Also adds ::
 
-            format : "hdf5"
+            format : "hitemp-radisdb"
             parfuncfmt : "hapi"   # TIPS-2017 for equilibrium partition functions
 
         And if the molecule is in :py:attr:`~radis.db.MOLECULES_LIST_NONEQUILIBRIUM`::
@@ -397,7 +404,7 @@ def register_database(
     dict_entries = {
         "info": f"HITEMP {molecule} lines ({wmin:.1f}-{wmax:.1f} cm-1) with TIPS-2017 (through HAPI) for partition functions",
         "path": path_list,
-        "format": "hdf5",
+        "format": "hitemp-radisdb",
         "parfuncfmt": "hapi",
         "wavenumber_min": f"{wmin}",
         "wavenumber_max": f"{wmax}",

--- a/radis/io/hitran.py
+++ b/radis/io/hitran.py
@@ -215,7 +215,7 @@ def hit2df(
             + "below: \n{0}".format(secondline)
         )
 
-    # dd local quanta attributes, based on the HITRAN group
+    # Add local quanta attributes, based on the HITRAN group
     df = parse_local_quanta(df, mol)
 
     # Add global quanta attributes, based on the HITRAN class

--- a/radis/lbl/bands.py
+++ b/radis/lbl/bands.py
@@ -1146,7 +1146,13 @@ def add_bands(df, dbformat, lvlformat, verbose=True):
         if lvlformat in ["cdsd-pc", "cdsd-pcN", "cdsd-hamil"]:
 
             # ensures that vib_lvl_name functions wont crash
-            if dbformat not in ["cdsd-hitemp", "cdsd-4000", "hitran"]:
+            if dbformat not in [
+                "cdsd-hitemp",
+                "cdsd-4000",
+                "hitran",
+                "hitemp",
+                "hitemp-radisdb",
+            ]:
                 raise NotImplementedError(
                     "lvlformat {0} not supported with dbformat {1}".format(
                         lvlformat, dbformat
@@ -1198,7 +1204,13 @@ def add_bands(df, dbformat, lvlformat, verbose=True):
         # 'radis' uses Dunham development based on v1v2l2v3 HITRAN convention
         elif lvlformat in ["radis"]:
 
-            if dbformat not in ["hitran", "cdsd-hitemp", "cdsd-4000"]:
+            if dbformat not in [
+                "hitran",
+                "hitemp",
+                "cdsd-hitemp",
+                "cdsd-4000",
+                "hitemp-radisdb",
+            ]:
                 raise NotImplementedError(
                     "lvlformat `{0}` not supported with dbformat `{1}`".format(
                         lvlformat, dbformat
@@ -1226,7 +1238,7 @@ def add_bands(df, dbformat, lvlformat, verbose=True):
         if lvlformat in ["radis"]:
 
             # ensures that vib_lvl_name functions wont crash
-            if dbformat not in ["hitran"]:
+            if dbformat not in ["hitran", "hitemp", "hitemp-radisdb"]:
                 raise NotImplementedError(
                     "lvlformat {0} not supported with dbformat {1}".format(
                         lvlformat, dbformat

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -1433,13 +1433,11 @@ class BaseFactory(DatabankLoader):
 
         Returns
         -------
-
-        None
+        None:
             df is updated automatically with column ``'ju'``
 
         Notes
         -----
-
         Reminder::
 
             P branch: J' - J'' = -1
@@ -1476,7 +1474,6 @@ class BaseFactory(DatabankLoader):
 
         Returns
         -------
-
         None:
             df is updated automatically with new column ``'Eu'``
         """
@@ -1503,12 +1500,22 @@ class BaseFactory(DatabankLoader):
         if len(df) == 0:
             return  # no lines
 
+        # Check spectroscopic parameters required for non-equilibrium (to identify lines)
+        for k in ["branch"]:
+            if k not in df:
+                error_details = ""
+                if "globu" in df:
+                    error_details = ". However, it looks like `globu` is defined. Maybe HITRAN-like database wasn't fully parsed? See radis.io.hitran.hit2df"
+                raise KeyError(
+                    f"`{k}` not defined in database ({list(df.columns)})"
+                    + error_details
+                )
+
         # Make sure database has pre-computed non equilibrium quantities
         # (Evib, Erot, etc.)
         # This may be a bottleneck for a first calculation (has to calculate
         # the nonequilibrium energies)
         calc_Evib_harmonic_anharmonic = vib_distribution in ["treanor"]
-
         if singleTvibmode:
             if (
                 not "Evib" in df

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -1702,7 +1702,13 @@ class BaseFactory(DatabankLoader):
 
         # %%
 
-        if dbformat in ["hitran", "cdsd-hitemp", "cdsd-4000"]:
+        if dbformat in [
+            "hitran",
+            "hitemp",
+            "hitemp-radisdb",
+            "cdsd-hitemp",
+            "cdsd-4000",
+        ]:
             # In HITRAN, AFAIK all molecules have a complete assignment of rovibrational
             # levels hence gvib=1 for all vibrational levels.
             #
@@ -3117,7 +3123,7 @@ class BaseFactory(DatabankLoader):
             self.warn("mole_fraction is > 1", "InputConditionsWarning")
 
         # Check temperature range
-        if Tmax > 700 and self.params.dbformat in ["hitran", "hitran_tab"]:
+        if Tmax > 700 and self.params.dbformat in ["hitran"]:
             self.warn(
                 "HITRAN is valid for low temperatures (typically < 700 K). "
                 + "For higher temperatures you may need HITEMP or CDSD. See the "

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -1453,6 +1453,7 @@ class BaseFactory(DatabankLoader):
                 + "format for (P, Q, R) branch is now required. "
                 + "If using cache files, regenerate them?"
             )
+        # TODO @dev : switch to CategorialGroup ? (less memory)
 
         #        df['ju'] = df.jl
         #        df.loc[df.branch==-1,'ju'] -= 1    # branch P

--- a/radis/lbl/calc.py
+++ b/radis/lbl/calc.py
@@ -580,8 +580,14 @@ def _calc_spectrum(
                 # constants (not all molecules are supported!)
                 conditions["levelsfmt"] = "radis"
                 conditions["lvl_use_cached"] = use_cached
-        elif databank.endswith(".h5"):
-            conditions["format"] = "hdf5"
+        elif databank.endswith(".h5") or databank.endswith(".hdf5"):
+            if verbose:
+                print(
+                    "Infered {0} is a HDF5 file with RADISDB columns format".format(
+                        databank
+                    )
+                )
+            conditions["format"] = "hdf5-radisdb"
             if not _equilibrium:
                 conditions["levelsfmt"] = "radis"
         else:

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -973,9 +973,10 @@ class DatabankLoader(object):
                 + "{0:.2f}-{1:.2f} cm-1".format(wavenum_min, wavenum_max)
             )
 
-        # Post-processing of the line database :
+        # Post-processing of the line database
+        # (note : this is now done in 'fetch_hitemp' before saving to the disk)
         if (
-            levelsfmt != None
+            levelsfmt != None and "locu" in df and "globu" in df
         ):  # spectroscopic quantum numbers will be needed for nonequilibrium calculations :
             df = parse_local_quanta(df, molecule)
             df = parse_global_quanta(df, molecule)

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -101,14 +101,22 @@ from radis.misc.warning import (
 from radis.phys.convert import cm2nm
 from radis.tools.database import SpecDatabase
 
-KNOWN_DBFORMAT = ["hitran", "hitemp", "cdsd-hitemp", "cdsd-4000", "hdf5"]
+KNOWN_DBFORMAT = [
+    "hitran",
+    "hitemp",
+    "cdsd-hitemp",
+    "cdsd-4000",
+    "hitemp-radisdb",
+    "hdf5-radisdb",
+]
 """list: Known formats for Line Databases:
 
-- ``'hitran'`` : HITRAN original .par format
-- ``'hitemp'`` : HITEMP-2010 original format (same format as 'hitran')
-- ``'cdsd-hitemp'`` : CDSD-HITEMP (CO2 only, same lines as HITEMP-2010)
-- ``'cdsd-4000'`` : CDSD-4000 original format (CO2 only)
-- ``'hdf5'`` : HDF5 file with RADIS column names.
+- ``'hitran'`` : [HITRAN-2016]_ original .par format
+- ``'hitemp'`` : [HITEMP-2010]_ original format (same format as 'hitran')
+- ``'cdsd-hitemp'`` : CDSD-HITEMP original format (CO2 only, same lines as HITEMP-2010)
+- ``'cdsd-4000'`` : [CDSD-4000]_ original format (CO2 only)
+- ``'hitemp-radisdb'`` : HITEMP under RADISDB format (pytables-HDF5 with RADIS column names).
+- ``'hdf5-radisdb'`` : arbitrary HDF5 file with RADIS column names.
 
 To install all databases manually see the :ref:`Configuration file <label_lbl_config_file>`
 and the :ref:`list of databases <label_line_databases>` .
@@ -156,7 +164,8 @@ drop_auto_columns_for_dbformat = {
     "hitemp": ["ierr", "iref", "lmix", "gp", "gpp"],
     "cdsd-4000": ["wang2"],
     "cdsd-hitemp": ["wang2", "lsrc"],
-    "hdf5": [],
+    "hdf5-radisdb": [],
+    "hitemp-radisdb": [],
 }
 """ dict: drop these columns if using ``drop_columns='auto'`` in load_databank
 Based on the value of ``dbformat=``, some of these columns won't be used.
@@ -214,7 +223,7 @@ See Also
 
 """
 
-# Sanity checks
+# @dev: Sanity checks
 # (make sure all variables are defined everywhere)
 assert compare_lists(drop_auto_columns_for_dbformat, KNOWN_DBFORMAT) == 1
 assert compare_lists(drop_auto_columns_for_levelsfmt, KNOWN_LVLFORMAT) == 1
@@ -875,7 +884,9 @@ class DatabankLoader(object):
         if source == "hitran":
             dbformat = "hitran"
         elif source == "hitemp":
-            dbformat = "hdf5"  # downloaded in RADIS local databases ~/.radisdb
+            dbformat = (
+                "hitemp-radisdb"  # downloaded in RADIS local databases ~/.radisdb
+            )
 
         # Get inputs
         molecule = self.input.molecule
@@ -892,7 +903,6 @@ class DatabankLoader(object):
 
         # Let's store all params so they can be parsed by "get_conditions()"
         # and saved in output spectra information
-        self.params.dbpath = "fetched from " + source
         self.params.dbformat = dbformat
         if levels is not None:
             self.levelspath = ",".join([format_paths(lvl) for lvl in levels.values()])
@@ -928,6 +938,7 @@ class DatabankLoader(object):
             else:
                 df = pd.concat(frames, ignore_index=True)  # reindex
 
+            self.params.dbpath = "fetched from hitran"
         elif source == "hitemp":
             # Download, setup local databases, and fetch (use existing if possible)
 
@@ -936,14 +947,16 @@ class DatabankLoader(object):
             else:
                 isotope_list = ",".join([str(k) for k in self._get_isotope_list()])
 
-            df = fetch_hitemp(
+            df, local_path = fetch_hitemp(
                 molecule,
                 isotope=isotope_list,
                 load_wavenum_min=wavenum_min,
                 load_wavenum_max=wavenum_max,
                 cache=db_use_cached,
                 verbose=self.verbose,
+                return_local_path=True,
             )
+            self.params.dbpath = local_path
 
             # ... explicitely write all isotopes based on isotopes found in the database
             if isotope == "all":
@@ -1728,7 +1741,7 @@ class DatabankLoader(object):
                             load_wavenum_min=wavenum_min,
                             load_wavenum_max=wavenum_max,
                         )
-                    elif dbformat == "hdf5":
+                    elif dbformat in ["hdf5-radisdb", "hitemp-radisdb"]:
                         df = hdf2df(
                             filename,
                             # cache=db_use_cached,

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -197,6 +197,9 @@ See Also
 - 'cdsd-hamil': :data:`~radis.io.cdsd.columns_4000`,
 
 """
+# TODO @dev : switch from a model where we drop certain useless columns (RADIS==0.9.28)
+# to a model where we only-load the required ones initially (if possible with lazy-loading,
+# i.e. only load them on demand. See https://github.com/radis/radis/issues/118 )
 drop_all_but_these = [
     "id",
     "iso",

--- a/radis/test/io/test_hitemp.py
+++ b/radis/test/io/test_hitemp.py
@@ -124,6 +124,48 @@ def test_calc_hitemp_spectrum(*args, **kwargs):
     return
 
 
+@pytest.mark.needs_connection
+def test_calc_hitemp_CO_noneq(verbose=True, *args, **kwargs):
+    """Test proper download of HITEMP CO database.
+
+    Good to test noneq calculations with direct-download of HITEMP.
+
+    ``05_HITEMP2020.par.bz2`` is about 14 Mb. We still download it
+    (once per machine) because it allows to compute & test noneq spectra,
+    which failed with direct HITEMP download in RADIS 0.9.28.
+
+    Approximate cost for the planet 🌳 :  ~ 14 gr CO2
+    (hard to evaluate !).
+
+
+    """
+
+    from astropy import units as u
+
+    from radis import calc_spectrum
+
+    calc_spectrum(
+        wavenum_min=2000 / u.cm,
+        wavenum_max=2300 / u.cm,
+        molecule="CO",
+        isotope="1,2",
+        Tvib=1500,
+        Trot=300,
+        databank="hitemp",  # test by fetching directly
+    )
+
+    # Recompute with (now) locally downloaded database [note : this failed on 0.9.28]
+    calc_spectrum(
+        wavenum_min=2000 / u.cm,
+        wavenum_max=2300 / u.cm,
+        molecule="CO",
+        isotope="1,2",
+        Tvib=1500,
+        Trot=300,
+        databank="HITEMP-CO",  # registered in ~/.radis
+    )
+
+
 if __name__ == "__main__":
     test_fetch_hitemp_OH()
     test_partial_loading()
@@ -132,3 +174,4 @@ if __name__ == "__main__":
     test_fetch_hitemp_all_molecules("CO")
     test_fetch_hitemp_all_molecules("N2O", verbose=3)
     test_fetch_hitemp_all_molecules("NO", verbose=3)
+    test_calc_hitemp_CO_noneq()


### PR DESCRIPTION
- renamed "hdf5" dbformat (a fileformat not giving any idea about the line database used) to "hitemp-radisdb"
- fix nonequilibrium calculations that were blocked on "hitemp-radisdb" for CO
(misc)
- add local files in Spectrum output
- improved error message when missing 'branch' (not fully parsed HITRAN file)
- add non-eq calculation with direct-HITEMP download [fails with 0.9.28]
- auto-download HITEMP CO database for noneq tests (14 Mb ~ 14 gr CO2 🌳 ).
- parse HITEMP local/global quanta before storing the fetched file to disk. Fixes previous test.
