### PR TITLE
fix: partfuncfmt error

### DIFF
--- a/docs/lbl/lbl.rst
+++ b/docs/lbl/lbl.rst
@@ -414,7 +414,8 @@ partition functions, for instance::
                                      # file. If `hapi`, then HAPI (HITRAN Python
                                      # interface) is used to retrieve them (valid if
                                      # your databank is HITRAN data). HAPI is embedded
-                                     # into RADIS. Check the version.
+                                     # into RADIS. Check the version. If not specified then 'hapi'
+                                     # is used as default
     parfunc = PATH/TO/cdsd_partition_functions.txt
                                      #  path to tabulated partition function to use.
                                      # If `parfuncfmt` is `hapi` then `parfunc`

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -694,7 +694,7 @@ class DatabankLoader(object):
             format to read tabulated partition function file. If ``hapi``, then
             HAPI (HITRAN Python interface) [1]_ is used to retrieve them (valid if
             your database is HITRAN data). HAPI is embedded into RADIS. Check the
-            version.
+            version. If partfuncfmt is None then ``hapi`` is used. Default ``hapi``.
         parfunc: filename or None
             path to tabulated partition function to use.
             If `parfuncfmt` is `hapi` then `parfunc` should be the link to the
@@ -706,7 +706,7 @@ class DatabankLoader(object):
             how to read the previous file. Known formats: (see :data:`~radis.lbl.loader.KNOWN_LVLFORMAT`).
             If ``radis``, energies are calculated using the diatomic constants in radis.db database
             if available for given molecule. Look up references there.
-            If None, non equilibrium calculations are not possible. Default ``None``.
+            If ``None``, non equilibrium calculations are not possible. Default ``'radis'``.
         db_use_cached: boolean, or ``None``
             if ``True``, a pandas-readable csv file is generated on first access,
             and later used. This saves on the datatype cast and conversion and
@@ -821,7 +821,7 @@ class DatabankLoader(object):
             format to read tabulated partition function file. If ``hapi``, then
             HAPI (HITRAN Python interface) [2]_ is used to retrieve them (valid if
             your database is HITRAN data). HAPI is embedded into RADIS. Check the
-            version.
+            version. If partfuncfmt is None then ``hapi`` is used. Default ``hapi``.
         parfunc: filename or None
             path to tabulated partition function to use.
             If `parfuncfmt` is `hapi` then `parfunc` should be the link to the
@@ -1073,7 +1073,7 @@ class DatabankLoader(object):
             format to read tabulated partition function file. If ``hapi``, then
             HAPI (HITRAN Python interface) [1]_ is used to retrieve them (valid if
             your database is HITRAN data). HAPI is embedded into RADIS. Check the
-            version.
+            version. If partfuncfmt is None then ``hapi`` is used. Default ``hapi``.
         parfunc: filename or None
             path to tabulated partition function to use.
             If `parfuncfmt` is `hapi` then `parfunc` should be the link to the
@@ -1085,7 +1085,7 @@ class DatabankLoader(object):
             how to read the previous file. Known formats: (see :data:`~radis.lbl.loader.KNOWN_LVLFORMAT`).
             If ``radis``, energies are calculated using the diatomic constants in radis.db database
             if available for given molecule. Look up references there.
-            If None, non equilibrium calculations are not possible. Default ``None``.
+            If ``None``, non equilibrium calculations are not possible. Default ``'radis'``.
         db_use_cached: boolean, or ``None``
             if ``True``, a pandas-readable csv file is generated on first access,
             and later used. This saves on the datatype cast and conversion and
@@ -1133,6 +1133,11 @@ class DatabankLoader(object):
         """
         # %% Check inputs
         # ---------
+        
+        # use radis default for calculations non equilibrium calculations 
+        # if the levelsfmt is not specified in the databank
+        if levelsfmt is None:
+            levelsfmt = 'radis'
 
         (
             name,

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -2044,17 +2044,15 @@ class DatabankLoader(object):
         isotope = int(isotope)
 
         # Use HAPI (HITRAN Python interface, integrated in RADIS)
-        if parfuncfmt == "hapi":
+        # no tabulated partition functions defined. Only non-eq spectra can
+        # be calculated if energies are also given
+        if parfuncfmt == "hapi" or parfuncfmt is None:
             parsum = PartFuncHAPI(
                 M=molecule, I=isotope, path=parfunc, verbose=self.verbose
             )
         elif parfuncfmt == "cdsd":  # Use tabulated CDSD partition functions
             assert molecule == "CO2"
             parsum = PartFuncCO2_CDSDtab(isotope, parfunc)
-        elif parfuncfmt is None:
-            # no tabulated partition functions defined. Only non-eq spectra can
-            # be calculated if energies are also given
-            parsum = None
         else:
             raise ValueError(
                 "Unknown format for partition function: {0}".format(parfuncfmt)

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -1133,11 +1133,11 @@ class DatabankLoader(object):
         """
         # %% Check inputs
         # ---------
-        
-        # use radis default for calculations non equilibrium calculations 
+
+        # use radis default for calculations non equilibrium calculations
         # if the levelsfmt is not specified in the databank
         if levelsfmt is None:
-            levelsfmt = 'radis'
+            levelsfmt = "radis"
 
         (
             name,


### PR DESCRIPTION
### Description
<!-- Provide a general description of what your pull request does. -->

Previously the program crashed with the following errors 

```
  File "/home/gaganaryan/Desktop/radis/radis/lbl/base.py", line 3157, in _get_parsum
    return self.get_partition_function_interpolator(molecule, iso, state)
  File "/home/gaganaryan/Desktop/radis/radis/lbl/loader.py", line 2233, in get_partition_function_interpolator
    assert isinstance(parsum, RovibParFuncTabulator)
AssertionError
```
when `parfuncfmt` wasn't passed into the databank. This pr addresses this issue and removes this behavior by using `hapi` as the default partition function.  

Fixes #78 