### PR TITLE
Fixes Rendering of Radis Flow Chart Image in LBL and cdsd4000_vs_hitemp_3409K Image in Use Case Section of Features (radis.readthedocs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,8 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 docs/source/
+docs/auto_examples
+docs/gen_modules
 
 # PyBuilder
 target/

--- a/.gitignore
+++ b/.gitignore
@@ -78,8 +78,8 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 docs/source/
-docs/auto_examples
-docs/gen_modules
+docs/auto_examples/
+docs/gen_modules/
 
 # PyBuilder
 target/

--- a/docs/features/features.rst
+++ b/docs/features/features.rst
@@ -63,8 +63,9 @@ Use RADIS to:
   See the comparison of two CO2 spectra calculated with [HITEMP-2010]_ and [CDSD-4000]_
   below:
 
-  .. image:: spectrum/cdsd4000_vs_hitemp_3409K.*
+  .. image:: https://radis.readthedocs.io/en/latest/_images/cdsd4000_vs_hitemp_3409K.svg
       :alt: https://radis.readthedocs.io/en/latest/_images/cdsd4000_vs_hitemp_3409K.svg
+      :scale: 100 %
 
 
 - Use the RADIS post-processing methods with the calculation results of another spectral code. For instance,

--- a/docs/lbl/lbl.rst
+++ b/docs/lbl/lbl.rst
@@ -144,7 +144,7 @@ various strategies to improve :ref:`Performances <label_lbl_performance>`,
 and produce a :ref:`Spectrum object <label_spectrum>`. These steps can be summarized in
 the flow chart below:
 
-.. image:: RADIS_flow_chart.*
+.. image:: https://radis.readthedocs.io/en/latest/_images/RADIS_flow_chart.svg
     :alt: https://radis.readthedocs.io/en/latest/_images/RADIS_flow_chart.svg
     :scale: 100 %
 


### PR DESCRIPTION
Fixes the following issue -
- The `cdsd4000_vs_hitemp_3409K` image didn't render before [here](https://radis.readthedocs.io/en/latest/features/features.html#use-cases)

Before 
![Before1](https://user-images.githubusercontent.com/44584067/112768161-39f72a80-9038-11eb-97e4-840f7290c72d.png)

After
![After1](https://user-images.githubusercontent.com/44584067/112768168-4085a200-9038-11eb-99e7-b5c4369c2493.png)



- The Radis-Flow-Chart didn't render [here](https://radis.readthedocs.io/en/latest/lbl/lbl.html#flow-chart)

Before
![Before2](https://user-images.githubusercontent.com/44584067/112768188-6317bb00-9038-11eb-99b4-061845044384.png)

After
![After2](https://user-images.githubusercontent.com/44584067/112768194-6ad75f80-9038-11eb-8a7e-52dee4c04879.png)

- Added  `docs/auto_examples/` ,`docs/gen_modules/ `in .gitignore so that anyone can work on modifying the docs without worrying about deleting the cache files.
