### PR TITLE
fix: wavelength range mismatch

### DIFF
--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -3228,7 +3228,7 @@ class BaseFactory(DatabankLoader):
 def get_waverange(
     wmin=None,
     wmax=None,
-    wunit=None,
+    wunit=Default('cm-1'),
     wavenum_min=None,
     wavenum_max=None,
     wavelength_min=None,

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -3228,7 +3228,7 @@ class BaseFactory(DatabankLoader):
 def get_waverange(
     wmin=None,
     wmax=None,
-    wunit=Default('cm-1'),
+    wunit=Default("cm-1"),
     wavenum_min=None,
     wavenum_max=None,
     wavelength_min=None,

--- a/radis/lbl/calc.py
+++ b/radis/lbl/calc.py
@@ -22,8 +22,8 @@ from os.path import exists
 
 from radis.lbl.factory import SpectrumFactory
 from radis.misc.basics import all_in
-from radis.phys.convert import nm2cm
 from radis.phys.air import air2vacuum
+from radis.phys.convert import nm2cm
 
 
 # %%

--- a/radis/lbl/calc.py
+++ b/radis/lbl/calc.py
@@ -23,6 +23,7 @@ from os.path import exists
 from radis.lbl.factory import SpectrumFactory
 from radis.misc.basics import all_in
 from radis.phys.convert import nm2cm
+from radis.phys.air import air2vacuum
 
 
 # %%
@@ -485,11 +486,18 @@ def _calc_spectrum(
     ):
         raise ValueError("Wavenumber and Wavelength both given... it's time to choose!")
 
+    if not medium in ["air", "vacuum"]:
+        raise NotImplementedError("Unknown propagating medium: {0}".format(medium))
+
     if wavenum_min is None and wavenum_max is None:
         assert wavelength_max is not None
         assert wavelength_min is not None
-        wavenum_min = nm2cm(wavelength_max)
-        wavenum_max = nm2cm(wavelength_min)
+        if medium == "vacuum":
+            wavenum_min = nm2cm(wavelength_max)
+            wavenum_max = nm2cm(wavelength_min)
+        else:
+            wavenum_min = nm2cm(air2vacuum(wavelength_max))
+            wavenum_max = nm2cm(air2vacuum(wavelength_min))
     else:
         assert wavenum_min is not None
         assert wavenum_max is not None

--- a/radis/lbl/py_cuffs/py_cuffs.pyx
+++ b/radis/lbl/py_cuffs/py_cuffs.pyx
@@ -1,21 +1,28 @@
 # distutils: language=c++
 
 import pickle
+
 from cpython cimport array
-import numpy as np
+
 import cupy as cp
+import numpy as np
+
 cimport numpy as np
+
 import sys
-from libcpp.vector cimport vector
+
+from libcpp.map cimport map as mapcpp
 from libcpp.set cimport set
 from libcpp.utility cimport pair
-from libcpp.map cimport map as mapcpp
-from cython.operator import dereference, postincrement
+from libcpp.vector cimport vector
+
 import ctypes
-from matplotlib import pyplot as plt
+
 import cupyx
 import cupyx.scipy.fftpack
 import cython
+from cython.operator import dereference, postincrement
+from matplotlib import pyplot as plt
 
 
 cdef float epsilon   = <float> 0.0001

--- a/radis/test/lbl/test_calc.py
+++ b/radis/test/lbl/test_calc.py
@@ -731,6 +731,30 @@ def _run_testcases(plot=True, verbose=True, warnings=True, *args, **kwargs):
     return True
 
 
+def check_wavelength_range(verbose=True, warnings=True, *args, **kwargs):
+
+    if verbose:
+        printm("Testing calc_spectrum wavelength range")
+
+    s = calc_spectrum(
+        wavelength_min=4348,  # nm
+        wavelength_max=5000,
+        molecule="CO",
+        isotope="1,2,3",
+        pressure=1.01325,  # bar
+        Tvib=1700,  # K
+        Trot=1700,  # K
+        databank="HITRAN-CO-TEST",
+        wstep=0.01,
+    )
+    w, I = s.get("radiance_noslit", wunit="nm", Iunit="mW/sr/cm2/nm")
+
+    assert np.isclose(w.min(), 4348, atol=0.01)
+    assert np.isclose(w.max(), 5000, atol=0.01)
+
+    return True
+
+
 # --------------------------
 if __name__ == "__main__":
 

--- a/radis/test/lbl/test_calc.py
+++ b/radis/test/lbl/test_calc.py
@@ -732,9 +732,13 @@ def _run_testcases(plot=True, verbose=True, warnings=True, *args, **kwargs):
 
 
 def check_wavelength_range(verbose=True, warnings=True, *args, **kwargs):
-
+    """Check that input wavelength is correctly taken into account.
+    See https://github.com/radis/radis/issues/214
+    """
     if verbose:
         printm("Testing calc_spectrum wavelength range")
+
+    wstep = 0.01
 
     s = calc_spectrum(
         wavelength_min=4348,  # nm
@@ -745,12 +749,12 @@ def check_wavelength_range(verbose=True, warnings=True, *args, **kwargs):
         Tvib=1700,  # K
         Trot=1700,  # K
         databank="HITRAN-CO-TEST",
-        wstep=0.01,
+        wstep=wstep,
     )
     w, I = s.get("radiance_noslit", wunit="nm", Iunit="mW/sr/cm2/nm")
 
-    assert np.isclose(w.min(), 4348, atol=0.01)
-    assert np.isclose(w.max(), 5000, atol=0.01)
+    assert np.isclose(w.min(), 4348, atol=wstep)
+    assert np.isclose(w.max(), 5000, atol=wstep)
 
     return True
 


### PR DESCRIPTION
### Description
<!-- Provide a general description of what your pull request does. -->

This pull request addresses lower output wavelengths compared to the boundaries provided in `calc_spectrum` due to conversions from wavenumber to wavelengths and vice-versa during calculations. 

Following up on the discussion in #214, [fetch_databank](https://github.com/radis/radis/blob/c421c67444d45f1d95062dd0a1e2201524965c8a/radis/lbl/loader.py#L796) is called upon Spectrum factory, and it seems to be expecting the values in wavenumbers. So, we do need to convert the wavelengths to wavenumbers taking into account the medium (?) 

There still seems to be a slight shift though, since the example below 

```
s = calc_spectrum( wavelength_min=5200, # nm
                   wavelength_max=5250, 
                   molecule='CO',
                   isotope='1,2,3',
                   pressure=1.01325,   # bar
                   Tgas=300,           # K
                   mole_fraction=0.1,
                   path_length=1,      # cm
                   verbose=False
                  )
w, I = s.get('radiance_noslit', wunit="nm", Iunit="mW/sr/cm2/nm")
print(w.min(), w.max())
```
prints `5199.973016620518 5250.00000015924`

Partially Fixes #214 