### PR TITLE
Fix issue #218 (Slit dispersion bug over large spectral range)

### DIFF
--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -2055,7 +2055,6 @@ class Spectrum(object):
             get_slit_function,
             normalize_slit,
             offset_dilate_slit_function,
-            remove_boundary,
         )
 
         # Check inputs
@@ -2129,19 +2128,8 @@ class Spectrum(object):
         else:
             w_nm = cm2nm(w)
             wslit0_nm = cm2nm(wslit0)
-        if slit_dispersion is not None and mode != 'valid':
-            # add space (wings) on the side of each slice. This space is cut
-            # after convolution, removing side effects. Too much space and we'll
-            # overlap too much and loose performance. Not enough and we'll have
-            # artifacts on the jonction. We use the slit width to be conservative.
-            wings = len(wslit0)
-            # correct if the slit is to be interpolated (because wstep is different):
-            wings *= max(1, abs(int(np.diff(wslit0).mean() / wstep)))
-            slice_windows, wings_min, wings_max = _cut_slices(
-                w_nm, slit_dispersion, wings=wings
-            )
-        else:
-            slice_windows = [np.ones_like(w, dtype=np.bool)]
+
+        slice_windows = [np.ones_like(w, dtype=np.bool)]
 
         # Create dictionary to store convolved
         I_conv_slices = {}
@@ -2203,14 +2191,6 @@ class Spectrum(object):
                 )
 
                 # Crop wings to remove overlaps (before merging)
-                if slit_dispersion is not None and mode != 'valid':
-                    w_conv_window, I_conv_window = remove_boundary(
-                        w_conv_window,
-                        I_conv_window,
-                        "crop",
-                        crop_left=wings_min[islice],
-                        crop_right=wings_max[islice],
-                    )
 
                 if i == 0:
                     w_conv_slices.append(w_conv_window)
@@ -2220,27 +2200,11 @@ class Spectrum(object):
         # ---------
         for q in I_conv_slices.keys():
             qns = q + "_noslit"
-            I_not_conv = self._q[qns]
 
             # Merge all slices
             w_conv = np.hstack(w_conv_slices)
             I_conv = np.hstack(I_conv_slices[q])
 
-            #            assert all(sorted(w_conv) == w_conv)
-
-            # Crop to remove boundary effects (after merging)
-            # this uses the mode='valid', 'same' attribute
-            # ... if slit was imported, it has been interpolated on the Spectrum
-            # ... grid and its initial length has changed: get the scaling factor
-            # ... to remove the correct number of non valid points on the side
-            scale_factor = abs((wslit0_nm[1] - wslit0_nm[0]) / (w_nm[1] - w_nm[0]))
-            w_conv, I_conv = remove_boundary(
-                w_conv,
-                I_conv,
-                mode,
-                len_I=len(I_not_conv),
-                len_I_slit_interp=int(len(Islit0) * scale_factor) + 1,
-            )
             # Store
             self._q_conv["wavespace"] = w_conv
             self._q_conv[q] = I_conv

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -2129,7 +2129,7 @@ class Spectrum(object):
         else:
             w_nm = cm2nm(w)
             wslit0_nm = cm2nm(wslit0)
-        if slit_dispersion is not None:
+        if slit_dispersion is not None and mode != 'valid':
             # add space (wings) on the side of each slice. This space is cut
             # after convolution, removing side effects. Too much space and we'll
             # overlap too much and loose performance. Not enough and we'll have
@@ -2194,7 +2194,7 @@ class Spectrum(object):
                     wslit,
                     Islit,
                     norm_by=None,  # already norm.
-                    mode="same",  # dont loose information yet
+                    mode=mode,
                     waveunit=waveunit,
                     verbose=verbose,
                     assert_evenly_spaced=False,
@@ -2203,7 +2203,7 @@ class Spectrum(object):
                 )
 
                 # Crop wings to remove overlaps (before merging)
-                if slit_dispersion is not None:
+                if slit_dispersion is not None and mode != 'valid':
                     w_conv_window, I_conv_window = remove_boundary(
                         w_conv_window,
                         I_conv_window,
@@ -4017,7 +4017,7 @@ def _cut_slices(w_nm, dispersion, threshold=0.01, wings=0):
         slice_w[imin:imax:increment] = 1
         slices.append(slice_w)
 
-    ##    # make sure we didnt miss anyone
+    # make sure we didnt miss anyone
     #    assert len(w_nm) == sum([slice_w.sum() for slice_w in slices])
 
     return slices[::increment], wings_min[::increment], wings_max[::increment]

--- a/radis/tools/slit.py
+++ b/radis/tools/slit.py
@@ -723,12 +723,14 @@ def convolve_with_slit(
     if bplot:
         plot_slit(w_slit, I_slit, waveunit="")
 
-    # 7. Convolve!
+    # 6. Convolve!
     # --------------
 
+    # We actually do not use mode valid in np.convolve,
+    # instead we use mode=same and remove the same boundaries from I and W in remove_boundary()
     I_conv = np.convolve(I, I_slit_interp, mode="same") * wstep
 
-    # 6. Remove boundary effects
+    # 7. Remove boundary effects
     # --------------
 
     w_conv, I_conv = remove_boundary(


### PR DESCRIPTION
By transmitting the mode to the convolve function (default is valid) and removing boundaries only if the mode is different than valid.

<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>