### PR TITLE
Add equations and references in documentation

### DIFF
--- a/docs/dev/architecture.rst
+++ b/docs/dev/architecture.rst
@@ -78,18 +78,18 @@ Methods from the Flow Chart: this methods are called successively from the
 
 - Populations: methods of :py:class:`~radis.lbl.base.BaseFactory` :
 
-    - :py:meth:`radis.lbl.base.BaseFactory._calc_populations_eq`
-    - :py:meth:`radis.lbl.base.BaseFactory._calc_populations_noneq`
+    - :py:meth:`radis.lbl.base.BaseFactory.calc_populations_eq`
+    - :py:meth:`radis.lbl.base.BaseFactory.calc_populations_noneq`
 
 - Line Intensities: methods of :py:class:`~radis.lbl.base.BaseFactory` :
 
-    - :py:meth:`radis.lbl.base.BaseFactory._calc_linestrength_eq`
+    - :py:meth:`radis.lbl.base.BaseFactory.calc_linestrength_eq`
     - :py:meth:`radis.lbl.base.BaseFactory._calc_linestrength_noneq`
     - :py:meth:`radis.lbl.base.BaseFactory._calc_emission_integral`
 
 - Line Positions:  methods of :py:class:`~radis.lbl.base.BaseFactory` :
 
-    - :py:meth:`radis.lbl.base.BaseFactory._calc_lineshift`
+    - :py:meth:`radis.lbl.base.BaseFactory.calc_lineshift`
 
 - Reduced line set: methods of :py:class:`~radis.lbl.base.BaseFactory` :
 

--- a/docs/features/features.rst
+++ b/docs/features/features.rst
@@ -33,7 +33,7 @@ RADIS does *not* include, so far:
 RADIS also features:
 
 - :ref:`High Performances <label_lbl_performance>`: spectra are calculated up to several orders of magnitude faster than equivalent line-by-line codes.
-- In-the-browser calculations (no install needed) : see :ref:`🌱 RADIS Online <label_radis_online>
+- In-the-browser calculations (no install needed) : see :ref:`🌱 RADIS Online <label_radis_online>`.
 - Automatic download of the latest HITRAN and HITEMP databases with :py:func:`~radis.lbl.calc.calc_spectrum`
 - Automatic testing and continuous integration tools for a reliable :ref:`Open-source Development <label_developer_guide>`.
 

--- a/docs/references/bibliography.rst
+++ b/docs/references/bibliography.rst
@@ -3,21 +3,31 @@ Bibliography
 
 List of bibliographic references used in this project:
 
-.. [CANTERA] D. G. Goodwin, H. K. Moffat, R. L. Speth, Cantera: An Object-oriented Software
-             Toolkit for Chemical Kinetics, Thermodynamics, and Transport Processes,
+.. [CANTERA] D. G. Goodwin, H. K. Moffat, R. L. Speth, "Cantera: An Object-oriented Software
+             Toolkit for Chemical Kinetics"", Thermodynamics, and Transport Processes,
              http://www.cantera.org, `doi:10.5281/zenodo.170284 <https://zenodo.org/record/170284#.XRIOno-xVEY>`__, 2017.
 
 .. [HAPI] `HAPI: The HITRAN Application Programming Interface <http://hitran.org/hapi>`_
-          R. Kochanov, I. Gordon, L. Rothman, P. Wcisło, C. Hill, J. Wilzewski, HITRAN Application Programming Interface (HAPI):
-          A comprehensive approach to working with spectroscopic data, Journal of Quantitative Spectroscopy
+          R. Kochanov, I. Gordon, L. Rothman, P. Wcisło, C. Hill, J. Wilzewski,
+          "HITRAN Application Programming Interface (HAPI):
+          A comprehensive approach to working with spectroscopic data", Journal of Quantitative Spectroscopy
           and Radiative Transfer 177 (2016) 15–30, ISSN 00224073, `doi:10.1016/j.jqsrt.2016.03.005 <https://www.researchgate.net/publication/297682202_HITRAN_Application_Programming_Interface_HAPI_A_comprehensive_approach_to_working_with_spectroscopic_data>`__.
 
-.. [RADIS-2018] E. Pannier, C. O. Laux, RADIS: A Nonequilibrium Line-by-Line Radiative Code for CO2 and
-                HITRAN-like database species, Journal of Quantitative Spectroscopy and Radiative Transfer
+.. [RADIS-2018] E. Pannier, C. O. Laux, "RADIS: A Nonequilibrium Line-by-Line Radiative Code for CO2 and
+                HITRAN-like database species", Journal of Quantitative Spectroscopy and Radiative Transfer
                 (2018) `doi:10.1016/j.jqsrt.2018.09.027 <https://www.sciencedirect.com/science/article/pii/S0022407318305867?via%3Dihub>`__
 
-.. [Spectral-Synthesis-Algorithm] D.C.M. van den Bekerom, E. Pannier, A Discrete Integral Transform for Rapid Spectral Synthesis,
+.. [Spectral-Synthesis-Algorithm] D.C.M. van den Bekerom, E. Pannier,
+                "A Discrete Integral Transform for Rapid Spectral Synthesis",
                 Journal of Quantitative Spectroscopy and Radiative Transfer (2021) `doi:10.1016/j.jqsrt.2020.107476 <https://www.sciencedirect.com/science/article/abs/pii/S0022407320310049>`__
+
+.. [Rothman-1998] L.S. Rothman, C.P. Rinsland, A. Goldman, S.T. Massie D.P. Edwards, J-M. Flaud,
+                 A. Perrin, C. Camy-Peyret, V. Dana, J.-Y. Mandin, J. Schroeder, A. McCann,
+                 R.R. Gamache, R.B. Wattson, K. Yoshino, K.V. Chance, K.W. Jucks, L.R. Brown,
+                 V. Nemtchinov, P. Varanasi "The Hitran Molecular Spectroscopic Database
+                 and Hawks (Hitran Atmospheric Workstation): 1996 Edition",
+                 Journal of Quantitative Spectroscopy and Radiative Transfer 60 (1998)
+                 665 - 710, `doi:10.1016/S0022-4073(98)00078-8 <https://www.sciencedirect.com/science/article/abs/pii/S0022407398000788?via%3Dihub>`__
 
 Line Databases
 --------------

--- a/docs/references/constants.rst
+++ b/docs/references/constants.rst
@@ -7,7 +7,8 @@ CO2
 ---
 
 Version 0.9 uses uses the CO2 spectrosopic coefficients of [Klarenaar2017]_ ,
-Table 2,3 and the references therein. /!\ These constants have been compiled for Treanor distributions.
+Table 2,3 and the references therein. ⚠️ These constants have been compiled for Treanor distributions
+and may not be suited for Boltzmann distributions.
 
 .. include:: ../../radis/db/CO2/molecules_data.json
     :literal:

--- a/docs/references/references.rst
+++ b/docs/references/references.rst
@@ -21,12 +21,12 @@ Cite
 ====
 
 RADIS is built on the shoulders of many state-of-the-art packages and databases. If using RADIS
-for your work, cite all of them that made it possible :
+for your work, **cite all of them that made it possible** :
 
 Line-by-line algorithm :
 
-- the line-by-line code as [RADIS-2018]_ |badge_article1|
-- the new spectral synthesis algorithm [Spectral-Synthesis-Algorithm]_ |badge_article2|
+- cite the line-by-line code as [RADIS-2018]_ |badge_article1|
+- if using the default optimization, cite the new spectral synthesis algorithm [Spectral-Synthesis-Algorithm]_ |badge_article2|
 - for reproducibility, mention the RADIS version number. Get your version with :py:func:`~radis.get_version`
   (latest version available is |badge_pypi|) ::
 
@@ -35,12 +35,23 @@ Line-by-line algorithm :
 
 Database and database retrieval algorithms :
 
-- the Line Databases used (for instance, [HITRAN-2016]_, [HITEMP-2010]_ or [CDSD-4000]_ ).
+- cite the Line Databases used (for instance, [HITRAN-2016]_, [HITEMP-2010]_ or [CDSD-4000]_ ).
 - if downloading [HITRAN-2016]_ directly with ``fetch('hitran')``, cite [HAPI]_ which is the underlying
   interface that makes it work !
 - if running nonequilibrium calculations, mention the reference of the spectroscopic constants used
   to calculate the energies (for instance, the
   :ref:`RADIS built-in constants <label_db_spectroscopic_constants>`)
+
+
+Research Work
+=============
+
+Research papers using RADIS and the associated algorithms :
+
+- Papers citing |badge_article1| : https://scholar.google.fr/scholar?cites=5826973099621508256
+
+- Papers citing |badge_article2| : https://scholar.google.fr/scholar?cites=17363432006874800849
+
 
 Useful Links
 ============
@@ -59,7 +70,7 @@ RADIS:
 
 - PyPi Repository: |badge_pypi|  |badge_pypistats|
 
-- Interactive Examples: `radis_examples <https://github.com/radis/radis-examples>`__ |badge_examples| |badge_binder|
+- Interactive Examples: |badge_examples| |badge_binder|
 
 - Try online : :ref:`🌱 RADIS Lab <label_radis_online>`
 
@@ -78,7 +89,7 @@ RADIS:
                    :target: https://linkinghub.elsevier.com/retrieve/pii/S0022407320310049
                    :alt: Spectral Synthesis Algorithm
 
-.. |badge_stars| image:: https://img.shields.io/github/stars/radis/radis.svg?style=social&label=Star
+.. |badge_stars| image:: https://img.shields.io/github/stars/radis/radis.svg?style=social&label=GitHub
                 :target: https://github.com/radis/radis/stargazers
                 :alt: GitHub
 
@@ -106,7 +117,7 @@ RADIS:
                      :target: https://pypistats.org/packages/radis
                      :alt: Downloads
 
-.. |badge_examples| image:: https://img.shields.io/github/stars/radis/radis-examples.svg?style=social&label=Star
+.. |badge_examples| image:: https://img.shields.io/github/stars/radis/radis-examples.svg?style=social&label=Examples
                 :target: https://github.com/radis/radis-examples
                 :alt: Examples
 

--- a/radis/db/molecules.py
+++ b/radis/db/molecules.py
@@ -18,7 +18,7 @@ from radis.phys.convert import eV2cm
 
 
 # CO
-# ----------
+# --
 
 # Define with default diatomic constants
 CO_X_iso1 = ElectronicState(
@@ -32,7 +32,7 @@ CO_X_iso1 = ElectronicState(
     vmax_morse=48,
     Ediss=eV2cm(11.16),
 )
-""":math:``^{16}O^{12}C`` electronic ground state"""
+"""CO first isotope (:math:`^{16}O^{12}C`), electronic ground state"""
 CO_X_iso2 = ElectronicState(
     "CO",
     isotope=2,
@@ -44,7 +44,7 @@ CO_X_iso2 = ElectronicState(
     vmax_morse=48,
     Ediss=eV2cm(11.16),
 )
-""":math:``^{16}O^{13}C`` electronic ground state"""
+"""CO 2nd isotope (:math:`^{16}O^{13}C`), electronic ground state"""
 CO_X_iso3 = ElectronicState(
     "CO",
     isotope=3,
@@ -56,10 +56,10 @@ CO_X_iso3 = ElectronicState(
     vmax_morse=48,
     Ediss=eV2cm(11.16),
 )
-""":math:``^{18}O^{12}C`` electronic ground state"""
+"""CO 3rd isotope (:math:`^{18}O^{12}C`) electronic ground state"""
 
 # CO2
-# ----------
+# ---
 
 CO2_X_626 = ElectronicState(
     "CO2",
@@ -70,7 +70,7 @@ CO2_X_626 = ElectronicState(
     spectroscopic_constants_type="herzberg",
     Ediss=44600,
 )
-""":math:``^{16}O^{12}C^{16}O`` electronic ground state"""
+"""CO2 1st isotope (:math:`^{16}O^{12}C^{16}O`), electronic ground state"""
 CO2_X_636 = ElectronicState(
     "CO2",
     isotope=2,
@@ -80,7 +80,7 @@ CO2_X_636 = ElectronicState(
     spectroscopic_constants_type="herzberg",
     Ediss=44600,
 )
-""":math:``^{16}O^{13}C^{16}O`` electronic ground state"""
+"""CO2 2nd isotope (:math:`^{16}O^{13}C^{16}O`), electronic ground state"""
 CO2_X_628 = ElectronicState(
     "CO2",
     isotope=3,
@@ -90,7 +90,7 @@ CO2_X_628 = ElectronicState(
     spectroscopic_constants_type="herzberg",
     Ediss=44600,
 )
-""":math:``^{16}O^{12}C^{18}O`` electronic ground state"""
+"""CO2 3rd isotope (:math:`^{16}O^{12}C^{18}O`), electronic ground state"""
 CO2_X_627 = ElectronicState(
     "CO2",
     isotope=4,
@@ -100,7 +100,7 @@ CO2_X_627 = ElectronicState(
     spectroscopic_constants_type="herzberg",
     Ediss=44600,
 )
-""":math:``^{16}O^{12}C^{17}O`` electronic ground state"""
+"""CO2 4th isotope (:math:`^{16}O^{12}C^{17}O`), electronic ground state"""
 
 
 # %% Dictionary of predefined molecules
@@ -153,30 +153,24 @@ def getMolecule(molecule, isotope=None, electronic_state=None, verbose=True):
 
     Parameters
     ----------
-
     molecule: str
         molecule name
-
     isotope: int, or ``None``
         isotope number. if None, only one isotope must exist in database. Else,
         an error is raised
-
     electronic_state: str
         if None, only one electronic state must exist in database. Else, an error
         is raised
-
     verbose: boolean
         if ``True``, print which electronic state we got
 
     Returns
     -------
-
-    state: ElectronicState
+    ElectronicState
         an :py:class:`~radis.db.classes.ElectronicState` object.
 
     See Also
     --------
-
     :py:data:`~radis.db.molecules.Molecules`
 
     """

--- a/radis/lbl/bands.py
+++ b/radis/lbl/bands.py
@@ -215,13 +215,13 @@ class BandFactory(BroadenFactory):
         # --------------------------------------------------------------------
 
         # First calculate the linestrength at given temperature
-        self._calc_linestrength_eq(Tgas)
+        self.calc_linestrength_eq(Tgas)
         self._cutoff_linestrength()
 
         # ----------------------------------------------------------------------
 
         # Calculate line shift
-        self._calc_lineshift()
+        self.calc_lineshift()
 
         # ----------------------------------------------------------------------
 
@@ -524,8 +524,8 @@ class BandFactory(BroadenFactory):
             self._calc_noneq_parameters()
 
         if not "Aul" in self.df0:
-            self._calc_weighted_trans_moment()
-            self._calc_einstein_coefficients()
+            self.calc_weighted_trans_moment()
+            self.calc_einstein_coefficients()
 
         if not "band" in self.df0:
             self._add_bands()
@@ -540,7 +540,7 @@ class BandFactory(BroadenFactory):
         # Calculate Populations, Linestrength and Emission Integral
         # (Note: Emission Integral is non canonical quantity, equivalent to
         #  Linestrength for absorption)
-        self._calc_populations_noneq(Tvib, Trot)
+        self.calc_populations_noneq(Tvib, Trot)
         self._calc_linestrength_noneq()
         self._calc_emission_integral()
 
@@ -551,7 +551,7 @@ class BandFactory(BroadenFactory):
         # ----------------------------------------------------------------------
 
         # Calculate lineshift
-        self._calc_lineshift()
+        self.calc_lineshift()
 
         # ----------------------------------------------------------------------
 

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -669,13 +669,13 @@ class SpectrumFactory(BandFactory):
         # --------------------------------------------------------------------
 
         # First calculate the linestrength at given temperature
-        self._calc_linestrength_eq(Tgas)  # scales S0 to S (equivalent to S0 in code)
+        self.calc_linestrength_eq(Tgas)  # scales S0 to S (equivalent to S0 in code)
         self._cutoff_linestrength()
 
         # ----------------------------------------------------------------------
 
         # Calculate line shift
-        self._calc_lineshift()  # scales wav to shiftwav (equivalent to v0)
+        self.calc_lineshift()  # scales wav to shiftwav (equivalent to v0)
 
         # ----------------------------------------------------------------------
         # Line broadening
@@ -1266,7 +1266,7 @@ class SpectrumFactory(BandFactory):
         # ----------------------------------------------------------------------
         # Calculate Populations, Linestrength and Emission Integral
         if singleTvibmode:
-            self._calc_populations_noneq(
+            self.calc_populations_noneq(
                 Tvib,
                 Trot,
                 vib_distribution=vib_distribution,
@@ -1292,7 +1292,7 @@ class SpectrumFactory(BandFactory):
         # ----------------------------------------------------------------------
 
         # Calculate lineshift
-        self._calc_lineshift()
+        self.calc_lineshift()
 
         # ----------------------------------------------------------------------
 
@@ -1636,8 +1636,8 @@ class SpectrumFactory(BandFactory):
             try:
                 self.df0["Aul"]
             except KeyError:
-                self._calc_weighted_trans_moment()
-                self._calc_einstein_coefficients()
+                self.calc_weighted_trans_moment()
+                self.calc_einstein_coefficients()
 
         # %% Start
         # ----------------------------------------------------------------------
@@ -1658,9 +1658,9 @@ class SpectrumFactory(BandFactory):
         # (Note: Emission Integral is non canonical quantity, equivalent to
         #  Linestrength for absorption)
         if non_eq_mode:
-            self._calc_populations_noneq(Tvib, Trot)
+            self.calc_populations_noneq(Tvib, Trot)
         else:
-            self._calc_populations_eq(Tgas)
+            self.calc_populations_eq(Tgas)
             self.df1["Aul"] = self.df1.A  # update einstein coefficients
         self._calc_emission_integral()
 


### PR DESCRIPTION
Add equations in docs :
- add equations in some BaseFactory method docstrings (automatically generated from Python code with [pytexit.py2tex](https://pytexit.readthedocs.io/) )
- make these methods public so they are displayed on the online documentation
- add references to Rothman-1998 equations (HITRAN-1996 paper)

improve docs, add links to research works using RADIS