### PR TITLE
Improve Evib/Erot fetch performances

### DIFF
--- a/radis/lbl/bands.py
+++ b/radis/lbl/bands.py
@@ -513,19 +513,10 @@ class BandFactory(BroadenFactory):
 
         # %% Make sure database is loaded
         self._check_line_databank()
-        self._check_noneq_parameters(vib_distribution, singleTvibmode)
+        self._calc_noneq_parameters(vib_distribution, singleTvibmode)
 
         if self.df0 is None:
             raise AttributeError("Load databank first (.load_databank())")
-
-        # Make sure database has pre-computed non equilibrium quantities
-        # (Evib, Erot, etc.)
-        if not "Evib" in self.df0:
-            self._calc_noneq_parameters()
-
-        if not "Aul" in self.df0:
-            self.calc_weighted_trans_moment()
-            self.calc_einstein_coefficients()
 
         if not "band" in self.df0:
             self._add_bands()

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -476,9 +476,6 @@ class BaseFactory(DatabankLoader):
                 )
         if self.verbose >= 2:
             t0 = time()
-            printg(
-                "Fetching vib / rot energies for all {0} transitions".format(len(df))
-            )
 
         def get_Evib_CDSD_pc_1iso(df, iso):
             """Calculate Evib for a given isotope (energies are specific to a
@@ -569,7 +566,11 @@ class BaseFactory(DatabankLoader):
         df["Erotl"] = df.El - df.Evibl
 
         if self.verbose >= 2:
-            printg("Fetched energies in {0:.0f}s".format(time() - t0))
+            printg(
+                "... Fetched energies in {0:.2f}s for all {1} transitions".format(
+                    time() - t0, len(df)
+                )
+            )
 
         if __debug__:
             self.assert_no_nan(df, "Evibu")
@@ -615,9 +616,6 @@ class BaseFactory(DatabankLoader):
         assert molecule == "CO2"
 
         if self.verbose >= 2:
-            printg(
-                "Fetching vib / rot energies for all {0} transitions".format(len(df))
-            )
             t0 = time()
 
         # Check energy levels are here
@@ -681,7 +679,11 @@ class BaseFactory(DatabankLoader):
         df["Erotl"] = df.El - df.Evibl
 
         if self.verbose >= 2:
-            printg("Fetched energies in {0:.0f}s".format(time() - t0))
+            printg(
+                "... Fetched energies in {0:.2f}s for all {1} transitions".format(
+                    time() - t0, len(df)
+                )
+            )
 
         if __debug__:
             self.assert_no_nan(df, "Evibu")
@@ -724,9 +726,6 @@ class BaseFactory(DatabankLoader):
         assert molecule == "CO2"
 
         if self.verbose >= 2:
-            printg(
-                "Fetching vib / rot energies for all {0} transitions".format(len(df))
-            )
             t0 = time()
 
         # Check energy levels are here
@@ -799,7 +798,11 @@ class BaseFactory(DatabankLoader):
         df["Erotl"] = df.El - df.Evibl
 
         if self.verbose >= 2:
-            printg("Fetched energies in {0:.0f}s".format(time() - t0))
+            printg(
+                "... Fetched energies in {0:.2f}s for all {1} transitions".format(
+                    time() - t0, len(df)
+                )
+            )
 
         if __debug__:
             self.assert_no_nan(df, "Evibu")
@@ -953,7 +956,7 @@ class BaseFactory(DatabankLoader):
             self.assert_no_nan(df, "Evib3l")
 
         if self.verbose >= 2:
-            printg("Fetched energies in {0:.0f}s".format(time() - t0))
+            printg("Fetched energies in {0:.2f}s".format(time() - t0))
 
         return  # None: Dataframe updated
 
@@ -989,9 +992,6 @@ class BaseFactory(DatabankLoader):
         # TODO: for multi-molecule mode: add loops on molecules and states too
 
         if self.verbose >= 2:
-            printg(
-                "Fetching vib / rot energies for all {0} transitions".format(len(df))
-            )
             t0 = time()
 
         # Check energy levels are here
@@ -1098,7 +1098,11 @@ class BaseFactory(DatabankLoader):
         assert np.isnan(df.Evibl).sum() == 0
 
         if self.verbose >= 2:
-            printg("Fetched energies in {0:.0f}s".format(time() - t0))
+            printg(
+                "... Fetched energies in {0:.2f}s for all {1} transitions".format(
+                    time() - t0, len(df)
+                )
+            )
 
         return  # None: Dataframe updated
 
@@ -1129,9 +1133,6 @@ class BaseFactory(DatabankLoader):
         # TODO: for multi-molecule mode: add loops on molecules and states too
 
         if self.verbose >= 2:
-            printg(
-                "Fetching vib / rot energies for all {0} transitions".format(len(df))
-            )
             t0 = time()
 
         # Check energy levels are here
@@ -1226,7 +1227,11 @@ class BaseFactory(DatabankLoader):
             self.assert_no_nan(df, "Evib3l")
 
         if self.verbose >= 2:
-            printg("Fetched energies in {0:.0f}s".format(time() - t0))
+            printg(
+                "... Fetched energies in {0:.2f}s for all {1} transitions".format(
+                    time() - t0, len(df)
+                )
+            )
 
         return  # None: Dataframe updated
 
@@ -1248,9 +1253,6 @@ class BaseFactory(DatabankLoader):
         # TODO: for multi-molecule mode: add loops on molecules and states too
 
         if self.verbose >= 2:
-            printg(
-                "Fetching vib / rot energies for all {0} transitions".format(len(df))
-            )
             t0 = time()
 
         # Check energy levels are here
@@ -1424,7 +1426,11 @@ class BaseFactory(DatabankLoader):
             self.assert_no_nan(df, "Evib3l")
 
         if self.verbose >= 2:
-            printg("Fetched energies in {0:.0f}s".format(time() - t0))
+            printg(
+                "... Fetched energies in {0:.2f}s for all {1} transitions".format(
+                    time() - t0, len(df)
+                )
+            )
 
         return df
 
@@ -1517,28 +1523,30 @@ class BaseFactory(DatabankLoader):
         # This may be a bottleneck for a first calculation (has to calculate
         # the nonequilibrium energies)
         calc_Evib_harmonic_anharmonic = vib_distribution in ["treanor"]
-        if singleTvibmode:
-            if (
-                not "Evib" in df
-                or calc_Evib_harmonic_anharmonic
-                and not all_in(["Evib_a", "Evib_h"], df)
-            ):
-                self._calc_noneq_parameters(
-                    calc_Evib_harmonic_anharmonic=calc_Evib_harmonic_anharmonic
-                )
+        if calc_Evib_harmonic_anharmonic:
+            if singleTvibmode:
+                required_columns = ["Evibl_a", "Evibl_h"]
+            else:
+                required_columns = [
+                    "Evib1l_a",
+                    "Evib1l_h",
+                    "Evib2l_a",
+                    "Evib2l_h",
+                    "Evib3l_a",
+                    "Evib3l_h",
+                ]
         else:
-            if (
-                not all_in(["Evib1", "Evib2", "Evib3"], df)
-                or calc_Evib_harmonic_anharmonic
-                and not all_in(
-                    ["Evib1_a", "Evib1_h", "Evib2_a", "Evib2_h", "Evib3_a", "Evib3_h"],
-                    df,
-                )
-            ):
-                self._calc_noneq_parameters(
-                    singleTvibmode=False,
-                    calc_Evib_harmonic_anharmonic=calc_Evib_harmonic_anharmonic,
-                )
+            if singleTvibmode:
+                required_columns = ["Evibl"]
+            else:
+                required_columns = ["Evib1l", "Evib2l", "Evib3l"]
+
+        if not all_in(required_columns, df):
+            self._calc_noneq_parameters(
+                singleTvibmode=singleTvibmode,
+                calc_Evib_harmonic_anharmonic=calc_Evib_harmonic_anharmonic,
+            )
+            assert all_in(required_columns, df)
 
         if not "Aul" in df:
             self.calc_weighted_trans_moment()
@@ -1759,7 +1767,6 @@ class BaseFactory(DatabankLoader):
 
         if self.verbose >= 2:
             t0 = time()
-            printg("Calculate weighted transition moment")
 
         id_set = df.id.unique()
         iso_set = self._get_isotope_list(self.input.molecule)  # df1.iso.unique()
@@ -1822,7 +1829,9 @@ class BaseFactory(DatabankLoader):
 
         if self.verbose >= 2:
             printg(
-                "Calculated weighted transition moment in {0:.2f}".format(time() - t0)
+                "... calculated weighted transition moment in {0:.2f}s".format(
+                    time() - t0
+                )
             )
 
         return

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -1260,7 +1260,7 @@ class SpectrumFactory(BandFactory):
         self._check_line_databank()
         # add nonequilibrium energies if needed (this may be a bottleneck
         # for a first calculation):
-        self._check_noneq_parameters(vib_distribution, singleTvibmode)
+        self._calc_noneq_parameters(vib_distribution, singleTvibmode)
         self._reinitialize()  # creates scaled dataframe df1 from df0
 
         # ----------------------------------------------------------------------
@@ -1628,16 +1628,7 @@ class SpectrumFactory(BandFactory):
         if non_eq_mode:
             # Make sure database has pre-computed non equilibrium quantities
             # (Evib, Erot, etc.)
-            try:
-                self.df0["Evib"]
-            except KeyError:
-                self._calc_noneq_parameters()
-
-            try:
-                self.df0["Aul"]
-            except KeyError:
-                self.calc_weighted_trans_moment()
-                self.calc_einstein_coefficients()
+            self._calc_noneq_parameters()
 
         # %% Start
         # ----------------------------------------------------------------------

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -1525,6 +1525,8 @@ class SpectrumFactory(BandFactory):
         Tvib=None,
         Trot=None,
         Ttrans=None,
+        vib_distribution="boltzmann",
+        rot_distribution="boltzmann",
         mole_fraction=None,
         path_length=None,
         unit="mW/cm2/sr",
@@ -1546,7 +1548,6 @@ class SpectrumFactory(BandFactory):
 
         Parameters
         ----------
-
         Tgas: float
             equilibrium temperature [K]
             If doing a non equilibrium case it should be None. Use Ttrans for
@@ -1568,9 +1569,8 @@ class SpectrumFactory(BandFactory):
 
         Returns
         -------
-
-        Returns total power density in mW/cm2/sr (unless different unit is chosen),
-        see ``unit=``.
+        float: Returns total power density in mW/cm2/sr (unless different unit is chosen),
+            see ``unit=``.
 
 
         See Also
@@ -1626,9 +1626,10 @@ class SpectrumFactory(BandFactory):
                 self._reload_databank()
 
         if non_eq_mode:
+            singleTvibmode = is_float(Tvib)
             # Make sure database has pre-computed non equilibrium quantities
             # (Evib, Erot, etc.)
-            self._calc_noneq_parameters()
+            self._calc_noneq_parameters(vib_distribution, singleTvibmode)
 
         # %% Start
         # ----------------------------------------------------------------------
@@ -1649,7 +1650,12 @@ class SpectrumFactory(BandFactory):
         # (Note: Emission Integral is non canonical quantity, equivalent to
         #  Linestrength for absorption)
         if non_eq_mode:
-            self.calc_populations_noneq(Tvib, Trot)
+            self.calc_populations_noneq(
+                Tvib,
+                Trot,
+                vib_distribution=vib_distribution,
+                rot_distribution=rot_distribution,
+            )
         else:
             self.calc_populations_eq(Tgas)
             self.df1["Aul"] = self.df1.A  # update einstein coefficients


### PR DESCRIPTION
### Description
<!-- Provide a general description of what your pull request does. -->

- Evib/Erot was always fetched in Treanor distributions, even if already in the database. Fixed. --> **CO2 3-Tvib calculations can be up to 5x faster**  @BlehMaks  @CorentinGrimaldi 

- implemented index.map(dict.get) method to fetch Evib/Erot for  (CO2  in 3-T Treanor distribution) and (CO non-equilibrium 
  --> **fetching rovibrational energies  is about ~30% faster** than groupby().apply() 

---

### Details 

Test case : 
```python
from radis import SpectrumFactory
sf = SpectrumFactory(2284, 2285,         # cm-1
                  molecule='CO2',
                  isotope='1,2,3',
                  pressure=1.01325,   # bar
                  mole_fraction=0.1,
                  path_length=1,      # cm
                  wstep=0.001,
                  verbose=3)
sf.load_databank("HITEMP-CO2-DUNHAM")

```
First calculation with vib_distribution='boltzmann'
```python
sf.non_eq_spectrum(Tvib=(900, 900, 1100), Trot=700,
                    vib_distribution='boltzmann')
"""
     ... Fetched energies in 1.56s for all 32763 transitions
     ... calculated weighted transition moment in 0.11s
     Checked nonequilibrium parameters in 1.77s
"""
```
2nd calculation : 

```python
sf.non_eq_spectrum(Tvib=(900, 900, 1100), Trot=700,
                    vib_distribution='boltzmann')
"""
     Checked nonequilibrium parameters in 0.00s
"""
```
( Evib Erot are not re-fetched, as expected !)  ✔️ 


In Treanor things were diffferent : 

First calculation : 

```python
sf.non_eq_spectrum(Tvib=(900, 900, 1100), Trot=700,
                    vib_distribution='treanor')

"""
    ... Fetched energies in 2.40s for all 32763 transitions
    ... calculated weighted transition moment in 0.11s
    Checked nonequilibrium parameters in 2.63s
"""
```

2nd calculation : 
```python
sf.non_eq_spectrum(Tvib=(900, 900, 1100), Trot=700,
                    vib_distribution='treanor')

'''
     ... Fetched energies in 2.11s for all 32763 transitions
     Checked nonequilibrium parameters in 2.11s
'''
```
no change    ⚠️   


**This is fixed now.** 

Total calculation time  for 2nd calculation ::
```
    Spectrum calculated in 2.51s
```
becomes :
```
    Spectrum calculated in 0.52s
```

---

2nd change : the fetch function itself was improved, by replacing apply.group() by index.map(dict.get()) 

```python
"""
    ... Fetched energies in 1.72s for all 32763 transitions
    ... calculated weighted transition moment in 0.11s
    Checked nonequilibrium parameters in 1.94s
"""
```
 (compared to 2.4s for Fetched energy : ~30% faster)

---


Fixes #193 