### PR TITLE
Generate default values automatically in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ extensions = [
     #'numpydoc',
     #'sphinxcontrib.napoleon',
     "sphinx.ext.napoleon",
-    'sphinx_autodoc_defaultargs'
+    "sphinx_autodoc_defaultargs",
     "sphinx.ext.intersphinx",
     "sphinx.ext.inheritance_diagram",
     "sphinxcontrib.apidoc",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -307,14 +307,16 @@ html_sidebars = {
 }
 
 
-# The default values of all documented arguments, and undocumented arguments if enabled, are automatically detected and added to the docstring. 
+# The default values of all documented arguments, and undocumented arguments if enabled, are automatically detected and added to the docstring.
 # It also detects existing documentation of default arguments with the text unchanged.
 
-rst_prolog = """
+rst_prolog = (
+    """
 .. |default| raw:: html
 
-    <div class="default-value-section">""" + \
-    ' <span class="default-value-label">Default:</span>'
+    <div class="default-value-section">"""
+    + ' <span class="default-value-label">Default:</span>'
+)
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
 # html_additional_pages = {}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,7 @@ extensions = [
     #'numpydoc',
     #'sphinxcontrib.napoleon',
     "sphinx.ext.napoleon",
+    'sphinx_autodoc_defaultargs'
     "sphinx.ext.intersphinx",
     "sphinx.ext.inheritance_diagram",
     "sphinxcontrib.apidoc",
@@ -304,6 +305,16 @@ html_sidebars = {
         "searchbox.html",
     ]
 }
+
+
+# The default values of all documented arguments, and undocumented arguments if enabled, are automatically detected and added to the docstring. 
+# It also detects existing documentation of default arguments with the text unchanged.
+
+rst_prolog = """
+.. |default| raw:: html
+
+    <div class="default-value-section">""" + \
+    ' <span class="default-value-label">Default:</span>'
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
 # html_additional_pages = {}


### PR DESCRIPTION
Default values in docstrings of Radis function & methods are set manually, and may not be up-to-date.
@zwang123 released a new package https://github.com/zwang123/sphinx-autodoc-defaultargs which may be very useful to do that automatically.

<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #223 