### PR TITLE
Set load_energies=False and updated Error message

### DIFF
--- a/docs/examples/examples.rst
+++ b/docs/examples/examples.rst
@@ -197,7 +197,7 @@ also featured in the [RADIS-2018]_ article ::
                          molecule=molecule,
                          optimization=None,
                          )
-    sf.fetch_databank('astroquery', load_energies=False)
+    sf.fetch_databank('astroquery')
 
     s = sf.eq_spectrum(Tgas=T, pressure=pressure_bar)
     s.plot()

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -1000,9 +1000,6 @@ class BaseFactory(DatabankLoader):
 
         # Check energy levels are here
         for iso in self._get_isotope_list():
-            print(
-                "molecule - ", molecule, "\nisotope - ", iso, "\nelec-state - ", state
-            )
             if not iso in self.get_partition_function_molecule(molecule):
                 raise AttributeError(
                     "No Partition function calculator defined for isotope {0}".format(

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -623,17 +623,24 @@ class BaseFactory(DatabankLoader):
             t0 = time()
 
         # Check energy levels are here
-        for iso in self._get_isotope_list():
-            if not iso in self.parsum_calc["CO2"]:
-                raise AttributeError(
-                    "No Partition function calculator defined for isotope {0}".format(
-                        iso
+        try:
+            for iso in self._get_isotope_list():
+                if not iso in self.parsum_calc["CO2"]:
+                    raise AttributeError(
+                        "No Partition function calculator defined for isotope {0}".format(
+                            iso
+                        )
+                        + ". You need energies to calculate a non-equilibrium spectrum!"
+                        + " Fill the levels parameter in your database definition, "
+                        + " with energies of known format: {0}".format(KNOWN_LVLFORMAT)
+                        + ". See SpectrumFactory.load_databank() help for more details"
                     )
-                    + ". You need energies to calculate a non-equilibrium spectrum!"
-                    + " Fill the levels parameter in your database definition, "
-                    + " with energies of known format: {0}".format(KNOWN_LVLFORMAT)
-                    + ". See SpectrumFactory.load_databank() help for more details"
-                )
+        except:
+            raise KeyError(
+                "Error while calculating the non-equilibrium spectrum!"
+                + " Load the energies levels with SpectrumFactory.load_databank"
+                + "('path', load_energies=True)"
+            )
 
         def get_Evib_CDSD_pcN_1iso(df, iso):
             """Calculate Evib for a given isotope (energies are specific to a
@@ -999,17 +1006,24 @@ class BaseFactory(DatabankLoader):
             t0 = time()
 
         # Check energy levels are here
-        for iso in self._get_isotope_list():
-            if not iso in self.parsum_calc[molecule]:
-                raise AttributeError(
-                    "No Partition function calculator defined for isotope {0}".format(
-                        iso
+        try:
+            for iso in self._get_isotope_list():
+                if not iso in self.parsum_calc[molecule]:
+                    raise AttributeError(
+                        "No Partition function calculator defined for isotope {0}".format(
+                            iso
+                        )
+                        + ". You need energies to calculate a non-equilibrium spectrum!"
+                        + " Fill the levels parameter in your database definition, "
+                        + " with energies of known format: {0}".format(KNOWN_LVLFORMAT)
+                        + ". See SpectrumFactory.load_databank() help for more details"
                     )
-                    + ". You need energies to calculate a non-equilibrium spectrum!"
-                    + " Fill the levels parameter in your database definition, "
-                    + " with energies of known format: {0}".format(KNOWN_LVLFORMAT)
-                    + ". See SpectrumFactory.load_databank() help for more details"
-                )
+        except:
+            raise KeyError(
+                "Error while calculating the non-equilibrium spectrum!"
+                + " Load the energies levels with SpectrumFactory.load_databank"
+                + "('path', load_energies=True)"
+            )
 
         def get_Evib_RADIS_cls1_1iso(df, iso):
             """Calculate Evib & Erot for a given isotope.

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -468,7 +468,7 @@ class BaseFactory(DatabankLoader):
 
         # Check energy levels are here
         for iso in self._get_isotope_list(molecule):
-            if not iso in self.parsum_calc["CO2"]:
+            if not iso in self.get_partition_function_molecule(molecule):
                 raise AttributeError(
                     "No Partition function calculator defined for isotope {0}".format(
                         iso
@@ -623,24 +623,17 @@ class BaseFactory(DatabankLoader):
             t0 = time()
 
         # Check energy levels are here
-        try:
-            for iso in self._get_isotope_list():
-                if not iso in self.parsum_calc["CO2"]:
-                    raise AttributeError(
-                        "No Partition function calculator defined for isotope {0}".format(
-                            iso
-                        )
-                        + ". You need energies to calculate a non-equilibrium spectrum!"
-                        + " Fill the levels parameter in your database definition, "
-                        + " with energies of known format: {0}".format(KNOWN_LVLFORMAT)
-                        + ". See SpectrumFactory.load_databank() help for more details"
+        for iso in self._get_isotope_list():
+            if not iso in self.get_partition_function_molecule(molecule):
+                raise AttributeError(
+                    "No Partition function calculator defined for isotope {0}".format(
+                        iso
                     )
-        except:
-            raise KeyError(
-                "Error while calculating the non-equilibrium spectrum!"
-                + " Load the energies levels with SpectrumFactory.load_databank"
-                + "('path', load_energies=True)"
-            )
+                    + ". You need energies to calculate a non-equilibrium spectrum!"
+                    + " Fill the levels parameter in your database definition, "
+                    + " with energies of known format: {0}".format(KNOWN_LVLFORMAT)
+                    + ". See SpectrumFactory.load_databank() help for more details"
+                )
 
         def get_Evib_CDSD_pcN_1iso(df, iso):
             """Calculate Evib for a given isotope (energies are specific to a
@@ -741,7 +734,7 @@ class BaseFactory(DatabankLoader):
 
         # Check energy levels are here
         for iso in self._get_isotope_list(molecule):
-            if not iso in self.parsum_calc["CO2"]:
+            if not iso in self.get_partition_function_molecule(molecule):
                 raise AttributeError(
                     "No Partition function calculator defined for isotope {0}".format(
                         iso
@@ -1006,24 +999,20 @@ class BaseFactory(DatabankLoader):
             t0 = time()
 
         # Check energy levels are here
-        try:
-            for iso in self._get_isotope_list():
-                if not iso in self.parsum_calc[molecule]:
-                    raise AttributeError(
-                        "No Partition function calculator defined for isotope {0}".format(
-                            iso
-                        )
-                        + ". You need energies to calculate a non-equilibrium spectrum!"
-                        + " Fill the levels parameter in your database definition, "
-                        + " with energies of known format: {0}".format(KNOWN_LVLFORMAT)
-                        + ". See SpectrumFactory.load_databank() help for more details"
-                    )
-        except:
-            raise KeyError(
-                "Error while calculating the non-equilibrium spectrum!"
-                + " Load the energies levels with SpectrumFactory.load_databank"
-                + "('path', load_energies=True)"
+        for iso in self._get_isotope_list():
+            print(
+                "molecule - ", molecule, "\nisotope - ", iso, "\nelec-state - ", state
             )
+            if not iso in self.get_partition_function_molecule(molecule):
+                raise AttributeError(
+                    "No Partition function calculator defined for isotope {0}".format(
+                        iso
+                    )
+                    + ". You need energies to calculate a non-equilibrium spectrum!"
+                    + " Fill the levels parameter in your database definition, "
+                    + " with energies of known format: {0}".format(KNOWN_LVLFORMAT)
+                    + ". See SpectrumFactory.load_databank() help for more details"
+                )
 
         def get_Evib_RADIS_cls1_1iso(df, iso):
             """Calculate Evib & Erot for a given isotope.
@@ -1103,24 +1092,17 @@ class BaseFactory(DatabankLoader):
             t0 = time()
 
         # Check energy levels are here
-        try:
-            for iso in self._get_isotope_list(molecule):
-                if not iso in self.parsum_calc[molecule]:
-                    raise AttributeError(
-                        "No Partition function calculator defined for isotope {0}".format(
-                            iso
-                        )
-                        + ". You need energies to calculate a non-equilibrium spectrum!"
-                        + " Fill the levels parameter in your database definition, "
-                        + " with energies of known format: {0}".format(KNOWN_LVLFORMAT)
-                        + ". See SpectrumFactory.load_databank() help for more details"
+        for iso in self._get_isotope_list(molecule):
+            if not iso in self.get_partition_function_molecule(molecule):
+                raise AttributeError(
+                    "No Partition function calculator defined for isotope {0}".format(
+                        iso
                     )
-        except:
-            raise KeyError(
-                "Error while calculating the non-equilibrium spectrum!"
-                + " Load the energies levels with SpectrumFactory.load_databank"
-                + "('path', load_energies=True)"
-            )
+                    + ". You need energies to calculate a non-equilibrium spectrum!"
+                    + " Fill the levels parameter in your database definition, "
+                    + " with energies of known format: {0}".format(KNOWN_LVLFORMAT)
+                    + ". See SpectrumFactory.load_databank() help for more details"
+                )
 
         def get_Evib123_RADIS_cls5_1iso(df, iso):
             """Fetch Evib & Erot for a given isotope.
@@ -1232,7 +1214,7 @@ class BaseFactory(DatabankLoader):
 
         # Check energy levels are here
         for iso in self._get_isotope_list(molecule):
-            if not iso in self.parsum_calc[molecule]:
+            if not iso in self.get_partition_function_molecule(molecule):
                 raise AttributeError(
                     "No Partition function calculator defined for isotope {0}".format(
                         iso

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -1445,6 +1445,11 @@ class BaseFactory(DatabankLoader):
         the nonequilibrium energies)
         """
 
+        # Checks and loads Energy level database
+        if self.misc.load_energies == False:
+            self._init_rovibrational_energies(self.levels, self.params.levelsfmt)
+            self.misc.load_energies = True
+
         if self.verbose >= 2:
             t0 = time()
 

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -1089,17 +1089,24 @@ class BaseFactory(DatabankLoader):
             t0 = time()
 
         # Check energy levels are here
-        for iso in self._get_isotope_list(molecule):
-            if not iso in self.parsum_calc[molecule]:
-                raise AttributeError(
-                    "No Partition function calculator defined for isotope {0}".format(
-                        iso
+        try:
+            for iso in self._get_isotope_list(molecule):
+                if not iso in self.parsum_calc[molecule]:
+                    raise AttributeError(
+                        "No Partition function calculator defined for isotope {0}".format(
+                            iso
+                        )
+                        + ". You need energies to calculate a non-equilibrium spectrum!"
+                        + " Fill the levels parameter in your database definition, "
+                        + " with energies of known format: {0}".format(KNOWN_LVLFORMAT)
+                        + ". See SpectrumFactory.load_databank() help for more details"
                     )
-                    + ". You need energies to calculate a non-equilibrium spectrum!"
-                    + " Fill the levels parameter in your database definition, "
-                    + " with energies of known format: {0}".format(KNOWN_LVLFORMAT)
-                    + ". See SpectrumFactory.load_databank() help for more details"
-                )
+        except:
+            raise KeyError(
+                "Error while calculating the non-equilibrium spectrum!"
+                + " Load the energies levels with SpectrumFactory.load_databank"
+                + "('path', load_energies=True)"
+            )
 
         def get_Evib123_RADIS_cls5_1iso(df, iso):
             """Fetch Evib & Erot for a given isotope.

--- a/radis/lbl/calc.py
+++ b/radis/lbl/calc.py
@@ -583,6 +583,7 @@ def _calc_spectrum(
             # constants (not all molecules are supported!)
             conditions["levelsfmt"] = "radis"
             conditions["lvl_use_cached"] = use_cached
+            conditions["load_energies"] = True
         # Details to identify lines
         conditions["parse_local_global_quanta"] = (not _equilibrium) or export_lines
         sf.fetch_databank(**conditions)
@@ -605,6 +606,7 @@ def _calc_spectrum(
                 # constants (not all molecules are supported!)
                 conditions["levelsfmt"] = "radis"
                 conditions["lvl_use_cached"] = use_cached
+                conditions["load_energies"] = True
         elif databank.endswith(".h5") or databank.endswith(".hdf5"):
             if verbose:
                 print(
@@ -615,6 +617,7 @@ def _calc_spectrum(
             conditions["format"] = "hdf5-radisdb"
             if not _equilibrium:
                 conditions["levelsfmt"] = "radis"
+                conditions["load_energies"] = True
         else:
             raise ValueError(
                 "Couldnt infer the format of the line database file: {0}. ".format(

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -1258,9 +1258,38 @@ class SpectrumFactory(BandFactory):
         # Check line database and parameters, reset populations and scaled line dataframe
         # ----------
         self._check_line_databank()
+        # Checking and loading Energy level database
+        # self.load_databank('HITEMP-CO2-TEST', load_energies=True)
+
+        # conditions_check = self.get_conditions()
+        # print(conditions_check)
+        # print(self.misc.load_energies)
+        """
+        if conditions_check['load_energies'] == True:
+            pass
+        else:
+            self.misc.load_energies = True
+            self._init_rovibrational_energies(self.levelspath, self.params.levelsfmt)
+            #self.load_databank('HITEMP-CO2-TEST')
+        print(self.get_conditions())
+        print(self.levelspath)
+        print(self.params.levelsfmt)
+        """
+        # self.load_databank('HITEMP-CO2-TEST', load_energies=True)
         # add nonequilibrium energies if needed (this may be a bottleneck
         # for a first calculation):
+
+        print(self.levelspath)
+        print(self.params.levelsfmt)
+        print(self.misc.load_energies)
+        print(self.levels)
+
+        if self.levels is not None:
+            self._init_rovibrational_energies(self.levels, self.params.levelsfmt)
+        else:
+            self._init_rovibrational_energies(self.levelspath, self.params.levelsfmt)
         self._calc_noneq_parameters(vib_distribution, singleTvibmode)
+
         self._reinitialize()  # creates scaled dataframe df1 from df0
 
         # ----------------------------------------------------------------------

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -1258,10 +1258,6 @@ class SpectrumFactory(BandFactory):
         # Check line database and parameters, reset populations and scaled line dataframe
         # ----------
         self._check_line_databank()
-        # Checks and loads Energy level database
-        if self.misc.load_energies == False:
-            self._init_rovibrational_energies(self.levels, self.params.levelsfmt)
-            self.misc.load_energies = True
 
         # add nonequilibrium energies if needed (this may be a bottleneck
         # for a first calculation):

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -1258,38 +1258,14 @@ class SpectrumFactory(BandFactory):
         # Check line database and parameters, reset populations and scaled line dataframe
         # ----------
         self._check_line_databank()
-        # Checking and loading Energy level database
-        # self.load_databank('HITEMP-CO2-TEST', load_energies=True)
-
-        # conditions_check = self.get_conditions()
-        # print(conditions_check)
-        # print(self.misc.load_energies)
-        """
-        if conditions_check['load_energies'] == True:
-            pass
-        else:
+        # Checks and loads Energy level database
+        if self.misc.load_energies == False:
+            self._init_rovibrational_energies(self.levels, self.params.levelsfmt)
             self.misc.load_energies = True
-            self._init_rovibrational_energies(self.levelspath, self.params.levelsfmt)
-            #self.load_databank('HITEMP-CO2-TEST')
-        print(self.get_conditions())
-        print(self.levelspath)
-        print(self.params.levelsfmt)
-        """
-        # self.load_databank('HITEMP-CO2-TEST', load_energies=True)
+
         # add nonequilibrium energies if needed (this may be a bottleneck
         # for a first calculation):
-
-        print(self.levelspath)
-        print(self.params.levelsfmt)
-        print(self.misc.load_energies)
-        print(self.levels)
-
-        if self.levels is not None:
-            self._init_rovibrational_energies(self.levels, self.params.levelsfmt)
-        else:
-            self._init_rovibrational_energies(self.levelspath, self.params.levelsfmt)
         self._calc_noneq_parameters(vib_distribution, singleTvibmode)
-
         self._reinitialize()  # creates scaled dataframe df1 from df0
 
         # ----------------------------------------------------------------------

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -913,6 +913,7 @@ class DatabankLoader(object):
         # Let's store all params so they can be parsed by "get_conditions()"
         # and saved in output spectra information
         self.params.dbformat = dbformat
+        self.levels = levels
         if levels is not None:
             self.levelspath = ",".join([format_paths(lvl) for lvl in levels.values()])
         else:
@@ -1413,6 +1414,7 @@ class DatabankLoader(object):
             [format_paths(k) for k in path]
         )  # else it's a nightmare to store
         self.params.dbformat = format
+        self.levels = levels
         if levels is not None:
             self.levelspath = ",".join([format_paths(lvl) for lvl in levels.values()])
         else:

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -800,7 +800,7 @@ class DatabankLoader(object):
         parfuncfmt="hapi",
         levels=None,
         levelsfmt="radis",
-        load_energies=True,
+        load_energies=False,
         include_neighbouring_lines=True,
         parse_local_global_quanta=True,
         drop_non_numeric=True,
@@ -1037,7 +1037,7 @@ class DatabankLoader(object):
         levelsfmt=None,
         db_use_cached=True,
         lvl_use_cached=True,
-        load_energies=True,
+        load_energies=False,
         include_neighbouring_lines=True,
         drop_columns="auto",
     ):
@@ -1240,7 +1240,7 @@ class DatabankLoader(object):
         levelsfmt=None,
         db_use_cached=None,
         lvl_use_cached=None,
-        load_energies=True,
+        load_energies=False,
         include_neighbouring_lines=True,
         drop_columns="auto",
     ):
@@ -1394,7 +1394,7 @@ class DatabankLoader(object):
         levelsfmt=None,
         db_use_cached=None,
         lvl_use_cached=None,
-        load_energies=True,
+        load_energies=False,
         include_neighbouring_lines=True,
     ):
         """store all params so they can be parsed by "get_conditions()" and

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -913,6 +913,7 @@ class DatabankLoader(object):
         # Let's store all params so they can be parsed by "get_conditions()"
         # and saved in output spectra information
         self.params.dbformat = dbformat
+        self.misc.load_energies = load_energies
         self.levels = levels
         if levels is not None:
             self.levelspath = ",".join([format_paths(lvl) for lvl in levels.values()])
@@ -1186,6 +1187,7 @@ class DatabankLoader(object):
             levels=levels,
             levelsfmt=levelsfmt,
             db_use_cached=db_use_cached,
+            load_energies=load_energies,
             lvl_use_cached=lvl_use_cached,
             include_neighbouring_lines=include_neighbouring_lines,
         )
@@ -2262,9 +2264,14 @@ class DatabankLoader(object):
         isotope: int
         elec_state: str
         """
-
-        parsum = self.parsum_calc[molecule][isotope][elec_state]
-
+        try:
+            parsum = self.parsum_calc[molecule][isotope][elec_state]
+        except:
+            raise KeyError(
+                "Error while Retrieving Partition Function Calculator!"
+                + " Load the energies levels with SpectrumFactory.load_databank"
+                + "('path', load_energies=True)"
+            )
         # helps IDE find methods
         assert isinstance(parsum, RovibParFuncCalculator)
 

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -2264,14 +2264,9 @@ class DatabankLoader(object):
         isotope: int
         elec_state: str
         """
-        try:
-            parsum = self.parsum_calc[molecule][isotope][elec_state]
-        except KeyError as err:
-            raise KeyError(
-                "Error while Retrieving Partition Function Calculator!"
-                + " Load the energies levels with SpectrumFactory.load_databank"
-                + "('path', load_energies=True)"
-            ) from err
+
+        parsum = self.get_partition_function_molecule(molecule)[isotope][elec_state]
+
         # helps IDE find methods
         assert isinstance(parsum, RovibParFuncCalculator)
 
@@ -2290,7 +2285,8 @@ class DatabankLoader(object):
             raise KeyError(
                 "Error while Retrieving Partition Function of Molecule!"
                 + " Load the energies levels with SpectrumFactory.load_databank"
-                + "('path', load_energies=True)"
+                + "('path', load_energies=True). If using SpectrumFactory.fetch_databank()"
+                + " consider adding arguement load_energies=True"
             ) from err
 
         return parsum

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -2266,14 +2266,32 @@ class DatabankLoader(object):
         """
         try:
             parsum = self.parsum_calc[molecule][isotope][elec_state]
-        except:
+        except KeyError as err:
             raise KeyError(
                 "Error while Retrieving Partition Function Calculator!"
                 + " Load the energies levels with SpectrumFactory.load_databank"
                 + "('path', load_energies=True)"
-            )
+            ) from err
         # helps IDE find methods
         assert isinstance(parsum, RovibParFuncCalculator)
+
+        return parsum
+
+    def get_partition_function_molecule(self, molecule):
+        """Retrieve Partition Function for Molecule.
+
+        Parameters
+        ----------
+        molecule: str
+        """
+        try:
+            parsum = self.parsum_calc[molecule]
+        except KeyError as err:
+            raise KeyError(
+                "Error while Retrieving Partition Function of Molecule!"
+                + " Load the energies levels with SpectrumFactory.load_databank"
+                + "('path', load_energies=True)"
+            ) from err
 
         return parsum
 

--- a/radis/test/benchmark/radis_vs_hapi_CH4_full_spectrum.py
+++ b/radis/test/benchmark/radis_vs_hapi_CH4_full_spectrum.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
         molecule=molecule,
         optimization=None,
     )
-    sf.fetch_databank("hitran", load_energies=False)
+    sf.fetch_databank("hitran")
 
     s = sf.eq_spectrum(Tgas=T, pressure=pressure_bar)
     s.name = "RADIS ({0:.1f}s)".format(s.conditions["calculation_time"])

--- a/radis/test/lbl/test_bands.py
+++ b/radis/test/lbl/test_bands.py
@@ -59,7 +59,7 @@ def test_plot_all_CO2_bandheads(verbose=True, plot=False, *args, **kwargs):
     sf.warnings["MissingSelfBroadeningWarning"] = "ignore"
     sf.warnings["NegativeEnergiesWarning"] = "ignore"
     sf.warnings["HighTemperatureWarning"] = "ignore"
-    sf.fetch_databank("hitran", load_energies=True)
+    sf.fetch_databank("hitran")
 
     s_tot = sf.non_eq_spectrum(Tvib=Tgas, Trot=Tgas)
     s_bands = sf.non_eq_bands(Tvib=Tgas, Trot=Tgas)

--- a/radis/test/lbl/test_bands.py
+++ b/radis/test/lbl/test_bands.py
@@ -59,7 +59,7 @@ def test_plot_all_CO2_bandheads(verbose=True, plot=False, *args, **kwargs):
     sf.warnings["MissingSelfBroadeningWarning"] = "ignore"
     sf.warnings["NegativeEnergiesWarning"] = "ignore"
     sf.warnings["HighTemperatureWarning"] = "ignore"
-    sf.fetch_databank("hitran")
+    sf.fetch_databank("hitran", load_energies=True)
 
     s_tot = sf.non_eq_spectrum(Tvib=Tgas, Trot=Tgas)
     s_bands = sf.non_eq_bands(Tvib=Tgas, Trot=Tgas)

--- a/radis/test/lbl/test_base.py
+++ b/radis/test/lbl/test_base.py
@@ -47,7 +47,7 @@ def test_populations(plot=True, verbose=True, warnings=True, *args, **kwargs):
         verbose=verbose,
     )
     sf.warnings["MissingSelfBroadeningWarning"] = "ignore"
-    sf.load_databank("HITRAN-CO-TEST")
+    sf.load_databank("HITRAN-CO-TEST", load_energies=True)
 
     # Populations cannot be calculated at equilibrium (no access to energy levels)
     s = sf.eq_spectrum(300)

--- a/radis/test/lbl/test_base.py
+++ b/radis/test/lbl/test_base.py
@@ -47,7 +47,7 @@ def test_populations(plot=True, verbose=True, warnings=True, *args, **kwargs):
         verbose=verbose,
     )
     sf.warnings["MissingSelfBroadeningWarning"] = "ignore"
-    sf.load_databank("HITRAN-CO-TEST", load_energies=True)
+    sf.load_databank("HITRAN-CO-TEST")
 
     # Populations cannot be calculated at equilibrium (no access to energy levels)
     s = sf.eq_spectrum(300)
@@ -123,7 +123,7 @@ def test_populations_CO2_hamiltonian(
         verbose=verbose,
     )
     sf.warnings["MissingSelfBroadeningWarning"] = "ignore"
-    sf.load_databank("HITEMP-CO2-HAMIL-TEST")
+    sf.load_databank("HITEMP-CO2-HAMIL-TEST", load_energies=True)
 
     # First run a calculation at equilibrium
     s = sf.eq_spectrum(300)

--- a/radis/test/lbl/test_calc.py
+++ b/radis/test/lbl/test_calc.py
@@ -479,7 +479,7 @@ def test_all_calc_methods_CO2pcN(
     del database_kwargs["info"]
     database_kwargs["levelsfmt"] = "cdsd-pcN"
     # ... load the new database
-    sf.load_databank(**database_kwargs)
+    sf.load_databank(**database_kwargs, load_energies=True)
 
     # Now, define Evib:
     Q_calc = sf.parsum_calc["CO2"][1]["X"]

--- a/radis/test/lbl/test_factory.py
+++ b/radis/test/lbl/test_factory.py
@@ -314,7 +314,7 @@ def test_power_integral(verbose=True, warnings=True, *args, **kwargs):
             "HighTemperatureWarning": "ignore",
         }
     )
-    sf.load_databank("HITRAN-CO-TEST", db_use_cached=True, load_energies=True)
+    sf.load_databank("HITRAN-CO-TEST", db_use_cached=True)
     unit = "µW/sr/cm2"
     T = 600
 

--- a/radis/test/lbl/test_factory.py
+++ b/radis/test/lbl/test_factory.py
@@ -175,10 +175,7 @@ def test_spec_generation(
     )
     sf.warnings["MissingSelfBroadeningWarning"] = "ignore"
     sf.warnings["NegativeEnergiesWarning"] = "ignore"
-    sf.load_databank(
-        "HITEMP-CO2-DUNHAM",
-        load_energies=False,  # no need to load energies at equilibrium
-    )
+    sf.load_databank("HITEMP-CO2-DUNHAM")
     s = sf.eq_spectrum(Tgas=300, name="test_spec_generation")
     if verbose:
         printm(
@@ -317,7 +314,7 @@ def test_power_integral(verbose=True, warnings=True, *args, **kwargs):
             "HighTemperatureWarning": "ignore",
         }
     )
-    sf.load_databank("HITRAN-CO-TEST", db_use_cached=True)
+    sf.load_databank("HITRAN-CO-TEST", db_use_cached=True, load_energies=True)
     unit = "µW/sr/cm2"
     T = 600
 

--- a/radis/test/lbl/test_overp.py
+++ b/radis/test/lbl/test_overp.py
@@ -187,7 +187,7 @@ def test_3Tvib_vs_1Tvib(verbose=True, plot=False, warnings=True, *args, **kwargs
             "HighTemperatureWarning": "ignore",
         }
     )
-    sf.load_databank("HITRAN-CO2-TEST")
+    sf.load_databank("HITRAN-CO2-TEST", load_energies=True)
 
     # Compare energies
     for I in iso:

--- a/radis/test/levels/test_partfunc.py
+++ b/radis/test/levels/test_partfunc.py
@@ -708,7 +708,8 @@ def test_levels_regeneration(verbose=True, warnings=True, *args, **kwargs):
         sf.warnings["MissingSelfBroadeningWarning"] = "ignore"
         sf.load_databank(
             "HITEMP-CO2-HAMIL-TEST",
-            db_use_cached=True,  # important to test CAche file here
+            load_energies=True,  # Loading Energy Database
+            db_use_cached=True,  # important to test Cache file here
         )
 
         # Now generate vibrational energies for a 2-T model

--- a/radis/test/validation/test_RADIS_vs_HAPI_line_broadening.py
+++ b/radis/test/validation/test_RADIS_vs_HAPI_line_broadening.py
@@ -146,7 +146,6 @@ def test_line_broadening(rtol=1e-3, verbose=True, plot=False, *args, **kwargs):
         pl.warnings["HighTemperatureWarning"] = "ignore"
         pl.fetch_databank(
             source="hitran",
-            load_energies=False,
             db_use_cached=True,
         )
 

--- a/radis/test/validation/test_compare_torch_CO2.py
+++ b/radis/test/validation/test_compare_torch_CO2.py
@@ -132,7 +132,6 @@ def test_compare_torch_CO2(
     #                             add_info=['Tgas'])
     sf.init_databank(
         "HITEMP-CO2-DUNHAM",
-        load_energies=False,
         db_use_cached=use_cache,
     )  # saves some memory
     #    sf.init_databank('CDSD-4000')

--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -12,7 +12,7 @@ Examples
 
 See and get objects from database::
 
-    from radis.lbl import SpecDatabase
+    from radis.tools import SpecDatabase
     db = SpecDatabase(r"path/to/database")     # create or loads database
 
     db.update()  # in case something changed (like a file was added manually)
@@ -2123,7 +2123,7 @@ class SpecDatabase(SpecList):
         --------
         ::
 
-            from radis.lbl import SpecDatabase
+            from radis.tools import SpecDatabase
             db = SpecDatabase(r"path/to/database")     # create or loads database
             db.add(s, discard=['populations'])
 


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to set the  `load_energies` parameter to False by default in Spectrum Factory and raise error to set `load_energies=True` if the user wants to calculate non_equilibrium spectrum using Spectrum Factory.
