### PR TITLE
Added cutoff='None' option in calc_spectrum()

### DIFF
--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -352,7 +352,7 @@ class SpectrumFactory(BandFactory):
         folding_thresh=1e-6,
         zero_padding=-1,
         broadening_method=Default("fft"),
-        cutoff=1e-27,
+        cutoff=0,
         verbose=True,
         warnings=True,
         save_memory=False,
@@ -476,7 +476,12 @@ class SpectrumFactory(BandFactory):
         # Initialize computation variables
         self.params.wstep = wstep
         self.params.pseudo_continuum_threshold = pseudo_continuum_threshold
+
+        if cutoff is None:
+            # If None, use no cutoff : https://github.com/radis/radis/pull/259
+            cutoff = 0
         self.params.cutoff = cutoff
+
         self.params.broadening_max_width = broadening_max_width  # line broadening
         self.misc.export_lines = export_lines
         self.misc.export_populations = export_populations


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->
Added a new cutoff option in calc_spectrum(), which gives the user the option to give None as a parameter for the cutoff parameter. This is an alternate to the cutoff = 0. 

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #251 