### PR TITLE
Update conditions with slit_shape

### DIFF
--- a/radis/spectrum/rescale.py
+++ b/radis/spectrum/rescale.py
@@ -1714,7 +1714,10 @@ def _recalculate(
             try:
                 shape = spec.conditions["slit_shape"]
             except KeyError:
-                warn("Recomputing with slit_shape not given. Assuming a triangular slit.", UserWarning)
+                warn(
+                    "Recomputing with slit_shape not given. Assuming a triangular slit.",
+                    UserWarning,
+                )
                 shape = "triangular"
             spec.apply_slit(
                 slit_function=slit_function,

--- a/radis/spectrum/rescale.py
+++ b/radis/spectrum/rescale.py
@@ -1714,6 +1714,7 @@ def _recalculate(
             try:
                 shape = spec.conditions["slit_shape"]
             except KeyError:
+                warn("Recomputing with slit_shape not given. Assuming a triangular slit.", UserWarning)
                 shape = "triangular"
             spec.apply_slit(
                 slit_function=slit_function,

--- a/radis/spectrum/rescale.py
+++ b/radis/spectrum/rescale.py
@@ -1712,7 +1712,7 @@ def _recalculate(
             slit_unit = spec.conditions["slit_unit"]
             norm_by = spec.conditions["norm_by"]
             try:
-                shape = spec.conditions["shape"]
+                shape = spec.conditions["slit_shape"]
             except KeyError:
                 shape = "triangular"
             spec.apply_slit(

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -2243,6 +2243,7 @@ class Spectrum(object):
         self.conditions["slit_function"] = slit_function
         self.conditions["slit_unit"] = unit  # input slit unit
         self.conditions["slit_dispersion"] = slit_dispersion
+        self.conditions["slit_shape"] = shape
         # TODO: probably removed after Spectrum is stored.
         self.conditions["norm_by"] = norm_by
 


### PR DESCRIPTION
Fix untimely warning when rescaling caused by no shape saved in the conditions spectrum.

<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>