### PR TITLE
Auto fetch hitemp for CO2 & H2O

### DIFF
--- a/radis/io/cache_files.py
+++ b/radis/io/cache_files.py
@@ -353,14 +353,14 @@ def check_not_deprecated(
         except AttributeError as err:
             if "Attribute 'metadata' does not exist in node: '/df'" in str(err):
                 raise DeprecatedFileWarning(
-                    "Cache files metadata is read/written with pytables instead of h5py starting from radis>=0.9.28. You should regenerate your file {0}".format(
+                    "Cache files metadata is read/written with pytables instead of h5py starting from radis>=0.9.28. You should regenerate your file `{0}`. If you want to do so, use cache=`regen`".format(
                         file
                     )
                 ) from err
         except TypeError as err:
             if "cannot properly create the storer" in str(err):
                 raise DeprecatedFileWarning(
-                    "Cache files metadata is read/written with pytables instead of h5py starting from radis>=0.9.28. You should regenerate your file {0}".format(
+                    "Cache files metadata is read/written with pytables instead of h5py starting from radis>=0.9.28. You should regenerate your file `{0}`. If you want to do so, use cache=`regen`".format(
                         file
                     )
                 ) from err

--- a/radis/io/cache_files.py
+++ b/radis/io/cache_files.py
@@ -353,17 +353,23 @@ def check_not_deprecated(
         except AttributeError as err:
             if "Attribute 'metadata' does not exist in node: '/df'" in str(err):
                 raise DeprecatedFileWarning(
-                    "Cache files metadata is read/written with pytables instead of h5py starting from radis>=0.9.28. You should regenerate your file `{0}`. If you want to do so, use cache=`regen`".format(
+                    "Missing metadata in `{0}`. Cache files metadata is read/written with pytables instead of h5py starting from radis>=0.9.28. You should regenerate your file `{0}`. If you want to do so, use cache=`regen`".format(
                         file
                     )
                 ) from err
-        except TypeError as err:
-            if "cannot properly create the storer" in str(err):
+            else:
+                raise
+        except (TypeError, KeyError) as err:
+            if "cannot properly create the storer" in str(
+                err
+            ) or "No object named df in the file" in str(err):
                 raise DeprecatedFileWarning(
-                    "Cache files metadata is read/written with pytables instead of h5py starting from radis>=0.9.28. You should regenerate your file `{0}`. If you want to do so, use cache=`regen`".format(
+                    "Wrong format for `{0}`. Cache files metadata is read/written with pytables instead of h5py starting from radis>=0.9.28. You should regenerate your file `{0}`. If you want to do so, use cache=`regen`".format(
                         file
                     )
                 ) from err
+            else:
+                raise
 
     # Raise an error if version is not found
     try:

--- a/radis/io/cdsd.py
+++ b/radis/io/cdsd.py
@@ -32,7 +32,7 @@ from radis.io.tools import (
 )
 
 # fmt: off
-columns_hitemp = OrderedDict(
+columns_cdsdhitemp = OrderedDict(
     [
         # name    # format # type  # description                                 # unit
         ("id", ("a2", int, "Molecular number", "")),
@@ -225,7 +225,7 @@ def cdsd2df(
         print("Last Modification time: {0}".format(metadata["last_modification"]))
 
     if version == "hitemp":
-        columns = columns_hitemp
+        columns = columns_cdsdhitemp
     elif version == "4000":
         columns = columns_4000
     else:

--- a/radis/io/dbmanager.py
+++ b/radis/io/dbmanager.py
@@ -5,6 +5,7 @@ Created on Mon Aug  9 19:42:51 2021
 @author: erwan
 """
 import os
+import shutil
 from io import BytesIO
 from os.path import abspath, exists, splitext
 from zipfile import ZipFile
@@ -281,7 +282,7 @@ class DatabaseManager(object):
         they may be downloaded but not fully parsed / registered."""
         if exists(self.tempdir):
             try:
-                os.remove(self.tempdir)
+                shutil.rmtree(self.tempdir)
             except PermissionError as err:
                 if self.verbose >= 3:
                     from radis.misc.printer import printr

--- a/radis/io/hdf5.py
+++ b/radis/io/hdf5.py
@@ -157,13 +157,14 @@ def hdf2df(
     df = manager.load(fname, columns=columns, where=where, **store_kwargs)
     metadata = manager.read_metadata(fname)
 
-    # Sanity Checks
-    if "total_lines" in metadata:
-        assert len(df) == metadata["total_lines"]
-    if "wavenumber_min" in metadata:
-        assert df["wav"].min() == metadata["wavenumber_min"]
-    if "wavenumber_max" in metadata:
-        assert df["wav"].max() == metadata["wavenumber_max"]
+    # Sanity Checks if loading the full file
+    if len(where) == 0:
+        if "total_lines" in metadata:
+            assert len(df) == metadata["total_lines"]
+        if "wavenumber_min" in metadata:
+            assert df["wav"].min() == metadata["wavenumber_min"]
+        if "wavenumber_max" in metadata:
+            assert df["wav"].max() == metadata["wavenumber_max"]
 
     df.attrs.update(metadata)
 

--- a/radis/io/hdf5.py
+++ b/radis/io/hdf5.py
@@ -38,7 +38,27 @@ class HDF5Manager(object):
         else:
             raise NotImplementedError(self.engine)
 
-    def add_metadata(self, local_file, metadata):
+    def load(self, fname, columns, where=None, **store_kwargs) -> pd.DataFrame:
+        """
+        Parameters
+        ----------
+        columns: list of str
+            list of columns to load. If ``None``, returns all columns in the file.
+        """
+        if self.engine == "pytables":
+            try:
+                df = pd.read_hdf(fname, columns=columns, where=where, **store_kwargs)
+            except TypeError as err:
+                if "reading from a Fixed format store" in str(err):
+                    raise TypeError(
+                        f"radis.io.hdf5.hdf2df can only be used to load specific HDF5 files generated in a 'Table' which allows to select only certain columns or rows. Here the file {fname} is in 'Fixed' format. Regenerate it ? If it's a cache file of a .par file, load the .par file directly ?"
+                    )
+        else:
+            raise NotImplementedError(self.engine)
+
+        return df
+
+    def add_metadata(self, local_file: str, metadata: dict):
 
         if self.engine == "pytables":
             with pd.HDFStore(local_file, mode="a", complib="blosc", complevel=9) as f:
@@ -46,6 +66,17 @@ class HDF5Manager(object):
                 f.get_storer("df").attrs.metadata = metadata
         else:
             raise NotImplementedError(self.engine)
+
+    def read_metadata(self, local_file: str) -> dict:
+
+        if self.engine == "pytables":
+            with pd.HDFStore(local_file, mode="r", complib="blosc", complevel=9) as f:
+
+                metadata = f.get_storer("df").attrs.metadata
+        else:
+            raise NotImplementedError(self.engine)
+
+        return metadata
 
 
 def hdf2df(
@@ -56,6 +87,7 @@ def hdf2df(
     load_wavenum_max=None,
     verbose=True,
     store_kwargs={},
+    engine="pytables",
 ):
     """Load a HDF5 line databank into a Pandas DataFrame.
 
@@ -120,15 +152,20 @@ def hdf2df(
 
     # Load :
     t0 = time()
-    try:
-        df = pd.read_hdf(fname, columns=columns, where=where, **store_kwargs)
-    except TypeError as err:
-        if "reading from a Fixed format store" in str(err):
-            raise TypeError(
-                f"radis.io.hdf5.hdf2df can only be used to load specific HDF5 files generated in a 'Table' which allows to select only certain columns or rows. Here the file {fname} is in 'Fixed' format. Regenerate it ? If it's a cache file of a .par file, load the .par file directly ?"
-            )
-    with pd.HDFStore(fname, mode="r") as store:
-        df.attrs.update(store.get_storer("df").attrs.metadata)
+
+    manager = HDF5Manager(engine)
+    df = manager.load(fname, columns=columns, where=where, **store_kwargs)
+    metadata = manager.read_metadata(fname)
+
+    # Sanity Checks
+    if "total_lines" in metadata:
+        assert len(df) == metadata["total_lines"]
+    if "wavenumber_min" in metadata:
+        assert df["wav"].min() == metadata["wavenumber_min"]
+    if "wavenumber_max" in metadata:
+        assert df["wav"].max() == metadata["wavenumber_max"]
+
+    df.attrs.update(metadata)
 
     if verbose >= 3:
         from radis.misc.printer import printg

--- a/radis/io/hdf5.py
+++ b/radis/io/hdf5.py
@@ -11,6 +11,43 @@ from time import time
 import pandas as pd
 
 
+class HDF5Manager(object):
+    def __init__(self, engine="pytables"):
+        self.engine = engine
+
+    def open(self, file, mode="w"):
+        if self.engine == "pytables":
+            return pd.HDFStore(file, mode=mode, complib="blosc", complevel=9)
+        else:
+            raise NotImplementedError(self.engine)
+
+    def write(self, handler, df, append=True):
+        if self.engine == "pytables":
+            DATA_COLUMNS = ["iso", "wav"]
+            """
+            list : only these column names will be searchable directly on disk to
+            only load certain lines. See :py:func:`~radis.io.hdf5.hdf2df`
+            """
+            handler.put(
+                key="df",
+                value=df,
+                append=append,
+                format="table",
+                data_columns=DATA_COLUMNS,
+            )
+        else:
+            raise NotImplementedError(self.engine)
+
+    def add_metadata(self, local_file, metadata):
+
+        if self.engine == "pytables":
+            with pd.HDFStore(local_file, mode="a", complib="blosc", complevel=9) as f:
+
+                f.get_storer("df").attrs.metadata = metadata
+        else:
+            raise NotImplementedError(self.engine)
+
+
 def hdf2df(
     fname,
     columns=None,

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -12,7 +12,9 @@ https://stupidpythonideas.blogspot.com/2014/07/three-ways-to-read-files.html
 
 import os
 from datetime import date
+from io import BytesIO
 from os.path import abspath, exists, expanduser, join
+from zipfile import ZipFile
 
 import numpy as np
 import pandas as pd
@@ -77,6 +79,20 @@ list : only these column names will be searchable directly on disk to
 only load certain lines. See :py:func:`~radis.io.hdf5.hdf2df`
 """
 # TODO: WIP. Maybe move somewhere else to be also used by HITRAN queries
+
+
+# Add a zip opener to the datasource _file_openers
+def open_zip(zipname, mode="r", encoding=None, newline=None):
+    output = BytesIO()
+    with ZipFile(zipname, mode[0]) as myzip:
+        fnames = myzip.namelist()
+        for fname in fnames:
+            output.write(myzip.read(fname))
+    output.seek(0)
+    return output
+
+
+np.lib._datasource._file_openers._file_openers[".zip"] = open_zip
 
 
 def fetch_hitemp(

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -37,45 +37,7 @@ from radis.misc.config import addDatabankEntries, getDatabankList
 from radis.misc.progress_bar import ProgressBar
 from radis.misc.warning import DatabaseAlreadyExists
 
-BASE_URL = "https://hitran.org/hitemp/data/bzip2format/"
-BASE_URL_MULTI = "https://hitran.org/hitemp/data/HITEMP-2010/{:s}_line_list/"
-HITEMP_SOURCE_FILES = {
-    "H2O": "01_HITEMP2010.zip",  # Only for purpose of naming local file
-    "CO2": "02_HITEMP2010.zip",  # Only for purpose of naming local file
-    "N2O": "04_HITEMP2019.par.bz2",
-    "CO": "05_HITEMP2019.par.bz2",
-    "CH4": "06_HITEMP2020.par.bz2",
-    "NO": "08_HITEMP2019.par.bz2",
-    "NO2": "10_HITEMP2019.par.bz2",
-    "OH": "13_HITEMP2020.par.bz2",
-}
-"""
-dict: list of available HITEMP source files
-
-Last update : 02 Feb 2021
-Compare with files available on https://hitran.org/hitemp/
-"""
-
-INFO_HITEMP_LINE_COUNT = {
-    "H2O": 114241164,
-    "CO2": 11193608,
-    "N2O": 3626425,
-    "CO": 752976,
-    "CH4": 31880412,
-    "NO": 1137192,
-    "NO2": 1108709,
-    "OH": 57019,
-}
-"""
-dict: total line count according to https://hitran.org/hitemp/
-Used for tests and to give an idea of the uncompress progress
-in :py:func:`~radis.io.hitemp.fetch_hitemp
-
-.. warning::
-    may change with new HITEMP updates. Only use as an informative
-    param, do not rely on this in the code.
-"""
-
+HITEMP_MOLECULES = ["H2O", "CO2", "N2O", "CO", "CH4", "NO", "NO2", "OH"]
 DATA_COLUMNS = ["iso", "wav"]
 """
 list : only these column names will be searchable directly on disk to
@@ -98,6 +60,21 @@ def open_zip(zipname, mode="r", encoding=None, newline=None):
 np.lib._datasource._file_openers._file_openers[".zip"] = open_zip
 
 
+def get_url_and_Nlines(molecule, hitemp_url='https://hitran.org/hitemp/'):
+    response = urllib.request.urlopen(hitemp_url)
+    text = response.read().decode()
+    text = text[text.find('<table id="hitemp-molecules-table" class="selectable-table list-table">'):text.find('</table>')]
+    text = re.sub(r'<!--.+?-->\s*\n','',text) #remove commented lines
+    html_molecule = re.sub(r'(\d{1})',r'(<sub>\1</sub>)',molecule)
+    text = text[re.search('<td>(?:<strong>)?'+html_molecule+'(?:</strong>)?</td>',text).start():]
+    lines = text.splitlines()
+
+    Nlines = int(re.findall(r'(\d+)',lines[3].replace('&nbsp;',''))[0])
+    url = 'https://hitran.org' + re.findall(r'href="(.+?)"',lines[7])[0]
+
+    return url, Nlines
+
+
 def fetch_hitemp(
     molecule,
     local_databases="~/.radisdb/",
@@ -117,7 +94,7 @@ def fetch_hitemp(
 
     Parameters
     ----------
-    molecule: `"CO2", "N2O", "CO", "CH4", "NO", "NO2", "OH"`
+    molecule: `"H2O", "CO2", "N2O", "CO", "CH4", "NO", "NO2", "OH"`
         HITEMP molecule. See :py:attr:`~radis.io.hitemp.HITEMP_SOURCE_FILES`
     local_databases: str
         where to create the RADIS HDF5 files. Default ``"~/.radisdb/"``
@@ -192,22 +169,26 @@ def fetch_hitemp(
 
     if molecule in ["H2O", "CO2"]:
 
-        base_url = BASE_URL_MULTI.format(molecule)
+        base_url, Ntotal_lines_expected = get_url_and_Nlines(molecule)
+        print(base_url)
         response = urllib.request.urlopen(base_url)
         response_string = response.read().decode()
         inputfiles = re.findall('href="(\S+.zip)"', response_string)
+        urlnames = [base_url + f for f in inputfiles]
+        local_fname = '-'.join(base_url.split('/')[-3:-1]) + '.h5'
 
     else:
 
         try:
-            inputfiles = [HITEMP_SOURCE_FILES[molecule]]
-            base_url = BASE_URL
+            url, Ntotal_lines_expected = get_url_and_Nlines(molecule)
+            urlnames = [url]
+            local_fname = splitext(url.split('/')[-1])[0] + '.h5'
         except KeyError as err:
             raise KeyError(
-                f"Please choose one of HITEMP molecules : {list(HITEMP_SOURCE_FILES.keys())}. Got '{molecule}'"
+                f"Please choose one of HITEMP molecules : {HITEMP_MOLECULES}. Got '{molecule}'"
             ) from err
 
-    urlnames = [base_url + f for f in inputfiles]
+    
 
     try:
         os.mkdir(local_databases)
@@ -220,7 +201,7 @@ def fetch_hitemp(
     local_file = abspath(
         join(
             local_databases,
-            molecule + "-" + splitext(HITEMP_SOURCE_FILES[molecule])[0] + ".h5",
+            molecule + "-" + local_fname,
         )
     )
 
@@ -317,15 +298,15 @@ def fetch_hitemp(
     Ntotal_downloads = len(urlnames)
 
     Nlines = 0
-    Ntotal_lines_expected = INFO_HITEMP_LINE_COUNT[molecule]
     pb = ProgressBar(N=Ntotal_lines_expected, active=verbose)
 
     wmin = np.inf
     wmax = 0
 
-    for urlname, inputf in zip(urlnames, inputfiles):
+    for urlname in urlnames:
 
         if verbose:
+            inputf = urlname.split('/')[-1]
             print(
                 f"Downloading {inputf} for {molecule} ({Ndownload}/{Ntotal_downloads})."
             )

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -83,12 +83,7 @@ def keep_only_relevant(
             relevantfiles.append(filepath)
             files_wmin = min(float(fname_wmin), files_wmin)
             files_wmax = max(float(fname_wmax), files_wmax)
-    # small checks
-    if relevantfiles:
-        if wavenum_min:
-            assert files_wmin <= wavenum_min
-        if wavenum_max:
-            assert files_wmax >= wavenum_max
+
     return relevantfiles, files_wmin, files_wmax
 
 

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -191,21 +191,21 @@ def fetch_hitemp(
     local_databases = abspath(local_databases.replace("~", expanduser("~")))
 
     if molecule in ["H2O", "CO2"]:
-        if verbose:
-            print("Fetching filelist...")
-        url = BASE_URL_MULTI.format(molecule)
-        response = urllib.request.urlopen(url)
+
+        base_url = BASE_URL_MULTI.format(molecule)
+        response = urllib.request.urlopen(base_url)
         response_string = response.read().decode()
         inputfiles = re.findall('href="(\S+.zip)"', response_string)
-        base_url = BASE_URL_MULTI
 
-    try:
-        inputfiles = [HITEMP_SOURCE_FILES[molecule]]
-        base_url = BASE_URL
-    except KeyError as err:
-        raise KeyError(
-            f"Please choose one of HITEMP molecules : {list(HITEMP_SOURCE_FILES.keys())}. Got '{molecule}'"
-        ) from err
+    else:
+
+        try:
+            inputfiles = [HITEMP_SOURCE_FILES[molecule]]
+            base_url = BASE_URL
+        except KeyError as err:
+            raise KeyError(
+                f"Please choose one of HITEMP molecules : {list(HITEMP_SOURCE_FILES.keys())}. Got '{molecule}'"
+            ) from err
 
     urlnames = [base_url + f for f in inputfiles]
 
@@ -311,8 +311,6 @@ def fetch_hitemp(
 
     ###################################################
 
-    # from here we start downloading
-
     # Doesnt exist : download
     ds = DataSource(join(local_databases, "downloads"))
     Ndownload = 1
@@ -329,7 +327,7 @@ def fetch_hitemp(
 
         if verbose:
             print(
-                f"Downloading {inputf} ({Ndownload}/{Ntotal_downloads}) for {molecule}."
+                f"Downloading {inputf} for {molecule} ({Ndownload}/{Ntotal_downloads})."
             )
         download_date = date.today().strftime("%d %b %Y")
 
@@ -387,9 +385,9 @@ def fetch_hitemp(
                         format="table",
                         data_columns=DATA_COLUMNS,
                     )
-
                     wmin = np.min((wmin, df.wav.min()))
                     wmax = np.max((wmax, df.wav.max()))
+
                     Nlines += len(df)
                     pb.update(
                         Nlines,
@@ -403,14 +401,18 @@ def fetch_hitemp(
 
         Ndownload += 1
 
-    f.get_storer("df").attrs.metadata = {
-        "wavenumber_min": wmin,
-        "wavenumber_max": wmax,
-        "download_date": download_date,
-        "download_url": "\n".join(urlnames),
-        "version": radis.__version__,
-    }
     pb.done()
+
+    url_store = urlnames[0] if len(urlnames) == 1 else urlnames
+    with pd.HDFStore(local_file, mode="a", complib="blosc", complevel=9) as f:
+
+        f.get_storer("df").attrs.metadata = {
+            "wavenumber_min": wmin,
+            "wavenumber_max": wmax,
+            "download_date": download_date,
+            "download_url": url_store,
+            "version": radis.__version__,
+        }
 
     # Done: add final checks
     # ... check on the created file that all lines are there :
@@ -434,7 +436,7 @@ def fetch_hitemp(
         wmin,
         wmax,
         download_date,
-        urlname,
+        url_store,
         verbose,
     )
 

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -347,7 +347,7 @@ class HITEMPDatabaseManager(DatabaseManager):
                             f"~{Ntotal_lines_expected:,} lines (estimate)"
                         )
                     pb.update(
-                        Nlines,
+                        Nlines_tot,
                         message=f"  Parsed {Nlines_tot:,} / {pbar_Ntot_message}. Wavenumber range {wmin:.2f}-{wmax:.2f} cm-1 is complete.",
                     )
                     # Reinitialize for next read
@@ -356,7 +356,7 @@ class HITEMPDatabaseManager(DatabaseManager):
                     )  # receives the HITRAN 160-character data.
         if pbar_last:
             pb.update(
-                Nlines + pbar_Nlines_already,
+                Nlines_tot,
                 message=f"  Parsed {Nlines_tot:,} / {Nlines_tot:,} lines. Wavenumber range {wmin:.2f}-{wmax:.2f} cm-1 is complete.",
             )
             pb.done()
@@ -379,7 +379,7 @@ class HITEMPDatabaseManager(DatabaseManager):
             },
         )
 
-        return Nlines - pbar_Nlines_already
+        return Nlines
 
 
 def fetch_hitemp(
@@ -535,17 +535,18 @@ def fetch_hitemp(
         ldb.clean_download_files()
 
     # Load and return
+    files_loaded = ldb.keep_only_relevant(
+        local_files, load_wavenum_min, load_wavenum_max
+    )
     df = ldb.load(
-        ldb.keep_only_relevant(
-            local_files, load_wavenum_min, load_wavenum_max
-        ),  # filter other files,
+        files_loaded,  # filter other files,
         columns=columns,
         isotope=isotope,
         load_wavenum_min=load_wavenum_min,  # for relevant files, get only the right range
         load_wavenum_max=load_wavenum_max,
     )
 
-    return (df, local_files) if return_local_path else df
+    return (df, files_loaded) if return_local_path else df
 
 
 #%%

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -13,34 +13,38 @@ https://stupidpythonideas.blogspot.com/2014/07/three-ways-to-read-files.html
 import os
 import re
 import urllib.request
-from datetime import date
-from io import BytesIO
-from os.path import abspath, exists, expanduser, join, splitext
-from zipfile import ZipFile
+from os.path import abspath, exists, expanduser
 
 import numpy as np
 import pandas as pd
-from dateutil.parser import parse as parse_date
-from numpy import DataSource
 
 import radis
-from radis.db import MOLECULES_LIST_NONEQUILIBRIUM
-from radis.io.cache_files import check_not_deprecated
-from radis.io.hdf5 import hdf2df
-from radis.io.hitran import columns_2004, parse_global_quanta, parse_local_quanta
-from radis.io.tools import (
-    _create_dtype,
-    _get_linereturnformat,
-    _ndarray2df,
-    replace_PQR_with_m101,
-)
-from radis.misc.config import addDatabankEntries, getDatabankEntries, getDatabankList
-from radis.misc.progress_bar import ProgressBar
-from radis.misc.warning import DatabaseAlreadyExists, DeprecatedFileWarning
+from radis.misc.printer import printr
 
-LAST_VALID_DATE = (
-    "01 Jan 2010"  # set to a later date to force re-download of all HITEMP databases
-)
+try:
+    from .cache_files import check_not_deprecated
+    from .hitran import columns_2004, parse_global_quanta, parse_local_quanta
+    from .linedb import DatabaseManager
+    from .tools import (
+        _create_dtype,
+        _get_linereturnformat,
+        _ndarray2df,
+        replace_PQR_with_m101,
+    )
+except ImportError:  # ran from here
+    from radis.io.linedb import DatabaseManager
+    from radis.io.cache_files import check_not_deprecated
+    from radis.io.hitran import columns_2004, parse_global_quanta, parse_local_quanta
+    from radis.io.tools import (
+        _create_dtype,
+        _get_linereturnformat,
+        _ndarray2df,
+        replace_PQR_with_m101,
+    )
+
+from radis.misc.progress_bar import ProgressBar
+from radis.misc.warning import DeprecatedFileWarning
+
 HITEMP_MOLECULES = ["H2O", "CO2", "N2O", "CO", "CH4", "NO", "NO2", "OH"]
 DATA_COLUMNS = ["iso", "wav"]
 """
@@ -50,65 +54,259 @@ only load certain lines. See :py:func:`~radis.io.hdf5.hdf2df`
 # TODO: WIP. Maybe move somewhere else to be also used by HITRAN queries
 
 
-# Add a zip opener to the datasource _file_openers
-def open_zip(zipname, mode="r", encoding=None, newline=None):
-    output = BytesIO()
-    with ZipFile(zipname, mode[0]) as myzip:
-        fnames = myzip.namelist()
-        for fname in fnames:
-            output.write(myzip.read(fname))
-    output.seek(0)
-    return output
-
-
-np.lib._datasource._file_openers._file_openers[".zip"] = open_zip
-
-
-def get_url_and_Nlines(molecule, hitemp_url="https://hitran.org/hitemp/"):
-    response = urllib.request.urlopen(hitemp_url)
-    text = response.read().decode()
-    text = text[
-        text.find(
-            '<table id="hitemp-molecules-table" class="selectable-table list-table">'
-        ) : text.find("</table>")
-    ]
-    text = re.sub(r"<!--.+?-->\s*\n", "", text)  # remove commented lines
-    html_molecule = re.sub(r"(\d{1})", r"(<sub>\1</sub>)", molecule)
-    text = text[
-        re.search(
-            "<td>(?:<strong>)?" + html_molecule + "(?:</strong>)?</td>", text
-        ).start() :
-    ]
-    lines = text.splitlines()
-
-    Nlines = int(re.findall(r"(\d+)", lines[3].replace("&nbsp;", ""))[0])
-    url = "https://hitran.org" + re.findall(r'href="(.+?)"', lines[7])[0]
-
-    return url, Nlines
-
-
 def keep_only_relevant(
-    inputfiles, wavenum_min=None, wavenum_max=None, wavenum_format=r"\d{5}"
+    inputfiles,
+    wavenum_min=None,
+    wavenum_max=None,
 ):
     """Parser file names for ``wavenum_format`` (min and max) and only keep
-    relevant files if the requested range is ``[wavenum_min, wavenum_max]``"""
-    relevant = []
+    relevant files if the requested range is ``[wavenum_min, wavenum_max]``
+
+    Returns
+    -------
+    relevant: list of relevant files
+    files_wmin, files_wmax: (float, float) : wavenum min & max of relevant range
+    """
+    wavenum_format = r"\d{5}"
+    relevantfiles = []
+    files_wmin = np.inf
+    files_wmax = 0
     for file in inputfiles:
         fname_wmin, fname_wmax = re.findall(wavenum_format, file)
+        relevant = False
         if wavenum_min is not None and wavenum_max is not None:
             if (float(fname_wmax) >= wavenum_min) and (
                 float(fname_wmin) <= wavenum_max
             ):
-                relevant.append(file)
+                relevant = True
         elif wavenum_min is not None:
             if float(fname_wmax) >= wavenum_min:
-                relevant.append(file)
+                relevant = True
         elif wavenum_max is not None:
             if float(fname_wmin) <= wavenum_max:
-                relevant.append(file)
+                relevant = True
         else:
-            relevant.append(file)
-    return relevant
+            relevant = True
+        if relevant:
+            relevantfiles.append(file)
+            files_wmin = min(float(fname_wmin), files_wmin)
+            files_wmax = max(float(fname_wmax), files_wmax)
+    # small checks
+    if relevantfiles:
+        if wavenum_min:
+            assert files_wmin <= wavenum_min
+        if wavenum_max:
+            assert files_wmax >= wavenum_max
+    return relevantfiles, files_wmin, files_wmax
+
+
+#%%
+def get_last(b):
+    """Get non-empty lines of a chunk b, parsing the bytes."""
+    element_length = np.vectorize(lambda x: len(x.__str__()))(b)
+    non_zero = element_length > element_length[-1]
+    threshold = non_zero.argmin() - 1
+    assert (non_zero[: threshold + 1] == 1).all()
+    assert (non_zero[threshold + 1 :] == 0).all()
+    return b[non_zero]
+
+
+class HITEMPDatabaseManager(DatabaseManager):
+    def __init__(
+        self,
+        name,
+        molecule,
+        local_databases="~/.radisdb/",
+        verbose=True,
+        chunksize=100000,
+    ):
+        super().__init__(name, molecule, local_databases, verbose=verbose)
+        self.chunksize = chunksize
+        self.downloadable = True
+        self.base_url = None
+        self.Nlines = None
+
+    def fetch_url_and_Nlines(self, hitemp_url="https://hitran.org/hitemp/"):
+        """requires connexion"""
+
+        molecule = self.molecule
+
+        if self.base_url is not None and self.Nlines is not None:
+            return self.base_url, self.Nlines
+
+        else:
+
+            response = urllib.request.urlopen(hitemp_url)
+            text = response.read().decode()
+            text = text[
+                text.find(
+                    '<table id="hitemp-molecules-table" class="selectable-table list-table">'
+                ) : text.find("</table>")
+            ]
+            text = re.sub(r"<!--.+?-->\s*\n", "", text)  # remove commented lines
+            html_molecule = re.sub(r"(\d{1})", r"(<sub>\1</sub>)", molecule)
+            text = text[
+                re.search(
+                    "<td>(?:<strong>)?" + html_molecule + "(?:</strong>)?</td>", text
+                ).start() :
+            ]
+            lines = text.splitlines()
+
+            Nlines = int(re.findall(r"(\d+)", lines[3].replace("&nbsp;", ""))[0])
+            url = "https://hitran.org" + re.findall(r'href="(.+?)"', lines[7])[0]
+
+            self.base_url, self.Nlines = url, Nlines
+
+        return url, Nlines
+
+    def fetch_urlnames(self):
+        """requires connexion"""
+
+        molecule = self.molecule
+
+        if molecule in ["H2O", "CO2"]:
+
+            base_url, Ntotal_lines_expected = self.fetch_url_and_Nlines()
+            response = urllib.request.urlopen(base_url)
+            response_string = response.read().decode()
+            inputfiles = re.findall('href="(\S+.zip)"', response_string)
+
+            # inputfiles = keep_only_relevant(
+            #     inputfiles, load_wavenum_min, load_wavenum_max, wavenum_format=r"\d{5}"
+            # )
+            # if verbose:
+            #     print("relevant files:", inputfiles)
+
+            urlnames = [base_url + f for f in inputfiles]
+
+        elif molecule in HITEMP_MOLECULES:
+            url, Ntotal_lines_expected = self.fetch_url_and_Nlines()
+            urlnames = [url]
+        else:
+            raise KeyError(
+                f"Please choose one of HITEMP molecules : {HITEMP_MOLECULES}. Got '{molecule}'"
+            )
+
+        return urlnames
+
+    def parse_to_local_file(
+        self,
+        opener,
+        urlname,
+        local_file,
+        pbar_t0=0,
+        pbar_Ntot_estimate_factor=None,
+        pbar_Nlines_already=0,
+    ):
+        """
+        Parameters
+        ----------
+        opener: an opener with an .open() command
+        gfile : file handler. Filename: for info"""
+
+        # Get linereturn (depends on OS, but file may also have been generated
+        # on a different OS. Here we simply read the file to find out)
+        columns = columns_2004
+        chunksize = self.chunksize
+        verbose = self.verbose
+        molecule = self.molecule
+
+        with opener.open(urlname) as gfile:  # locally downloaded file
+            dt = _create_dtype(
+                columns, "a2"
+            )  # 'a2' allocates space to get \n or \n\r for linereturn character
+            b = np.zeros(1, dtype=dt)
+            try:
+                gfile.readinto(b)
+            except EOFError as err:
+                raise ValueError(
+                    f"End of file while parsing file {opener.abspath(urlname)}. May be due to download error. Delete file ?"
+                ) from err
+            linereturnformat = _get_linereturnformat(b, columns)
+
+        Nlines = pbar_Nlines_already
+        if verbose:
+            _, Ntotal_lines_expected = self.fetch_url_and_Nlines()
+            if pbar_Ntot_estimate_factor:
+                # multiply Ntotal_lines_expected by pbar_Ntot_estimate_factor
+                # (accounts for total lines divided in number of files, and
+                # not all files downloaded)
+                Ntotal_lines_expected = int(
+                    Ntotal_lines_expected * pbar_Ntot_estimate_factor
+                )
+        pb = ProgressBar(N=Ntotal_lines_expected, active=verbose, t0=pbar_t0)
+        wmin = np.inf
+        wmax = 0
+
+        with opener.open(urlname) as gfile:  # locally downloaded file
+
+            dt = _create_dtype(columns, linereturnformat)
+            b = np.zeros(chunksize, dtype=dt)  # receives the HITRAN 160-character data.
+
+            if verbose:
+                print(f"Download complete. Parsing {molecule} database to {local_file}")
+
+            with pd.HDFStore(local_file, mode="a", complib="blosc", complevel=9) as f:
+                # TODO : implement with engines = 'h5py' too
+
+                for nbytes in iter(lambda: gfile.readinto(b), 0):
+
+                    if not b[-1]:
+                        # End of file flag within the chunk (but does not start
+                        # with End of file flag) so nbytes != 0
+                        b = get_last(b)
+
+                    df = _ndarray2df(b, columns, linereturnformat)
+
+                    # Post-processing :
+                    # ... Add local quanta attributes, based on the HITRAN group
+                    df = parse_local_quanta(df, molecule)
+
+                    # ... Add global quanta attributes, based on the HITRAN class
+                    df = parse_global_quanta(df, molecule)
+
+                    # Switch 'P', 'Q', 'R' to -1, 0, 1
+                    if "branch" in df:
+                        replace_PQR_with_m101(df)
+
+                    f.put(
+                        key="df",
+                        value=df,
+                        append=True,
+                        format="table",
+                        data_columns=DATA_COLUMNS,
+                    )
+                    wmin = np.min((wmin, df.wav.min()))
+                    wmax = np.max((wmax, df.wav.max()))
+
+                    Nlines += len(df)
+                    if pbar_Ntot_estimate_factor is None:
+                        pbar_Ntot_message = f"{Ntotal_lines_expected:,} lines"
+                    else:
+                        pbar_Ntot_message = (
+                            f"~{Ntotal_lines_expected:,} lines (estimate)"
+                        )
+                    pb.update(
+                        Nlines,
+                        message=f"Parsed {Nlines:,} / {pbar_Ntot_message}. Wavenumber range {wmin:.2f}-{wmax:.2f} cm-1 is complete.",
+                    )
+                    # Reinitialize for next read
+                    b = np.zeros(
+                        chunksize, dtype=dt
+                    )  # receives the HITRAN 160-character data.
+
+        # Add metadata
+        with pd.HDFStore(local_file, mode="a", complib="blosc", complevel=9) as f:
+
+            f.get_storer("df").attrs.metadata = {
+                "wavenumber_min": wmin,
+                "wavenumber_max": wmax,
+                "download_date": self.get_today(),
+                "download_url": urlname,
+                "version": radis.__version__,
+            }
+
+        return Nlines
 
 
 def fetch_hitemp(
@@ -196,459 +394,235 @@ def fetch_hitemp(
     :py:func:`~radis.io.hdf5.hdf2df`
 
     """
-    # TODO ? : unzip only parts of the database
-    # see https://github.com/radis/radis/pull/194
 
     if databank_name == "HITEMP-{molecule}":
         databank_name = databank_name.format(**{"molecule": molecule})
 
-    Ntotal_lines_expected = None
-
-    # First; checking if the database is registered in radis.json
-    def fetch_urlnames(molecule):
-
-        if molecule in ["H2O", "CO2"]:
-
-            base_url, Ntotal_lines_expected = get_url_and_Nlines(molecule)
-            response = urllib.request.urlopen(base_url)
-            response_string = response.read().decode()
-            inputfiles = re.findall('href="(\S+.zip)"', response_string)
-
-            inputfiles = keep_only_relevant(
-                inputfiles, load_wavenum_min, load_wavenum_max, wavenum_format=r"\d{5}"
-            )
-            if verbose:
-                print("relevant files:", inputfiles)
-
-            urlnames = [base_url + f for f in inputfiles]
-
-            # harcoded local name; regroups all 0X_[wmin]_[wmax]_HITEMP2010* files :
-            assert "HITEMP2010" in inputfiles[0]
-            local_fname = inputfiles[0][:3] + "HITEMP2010.h5"
-
-        elif molecule in HITEMP_MOLECULES:
-            url, Ntotal_lines_expected = get_url_and_Nlines(molecule)
-            urlnames = [url]
-            local_fname = (
-                splitext(splitext(url.split("/")[-1])[0])[0]  # twice to remove .par.bz2
-                + ".h5"
-            )
-        else:
-            raise KeyError(
-                f"Please choose one of HITEMP molecules : {HITEMP_MOLECULES}. Got '{molecule}'"
-            )
-
-        try:
-            os.mkdir(local_databases)
-        except OSError:
-            pass
-        else:
-            if verbose:
-                print("Created folder :", local_databases)
-
-        local_file = abspath(
-            join(
-                local_databases,
-                molecule + "-" + local_fname,
-            )
-        )
-        return local_file, urlnames
-
-    if databank_name in getDatabankList():
-        entries = getDatabankEntries(databank_name)
-        try:
-            assert "download_url" in entries
-            assert "download_date" in entries
-            assert parse_date(entries["download_date"]) > parse_date(LAST_VALID_DATE)
-        except AssertionError as err:
-            raise DeprecatedFileWarning("Database file {0} not valid anymore") from err
-        else:
-            local_file = entries["path"]
-            assert len(local_file) == 1
-            local_file = local_file[0]
-    else:
-        local_file, urlnames = fetch_urlnames(molecule)
-
-    # Now, check if the local file (as registered in radis.json, or fetched from the website)
-    # exists
     local_databases = abspath(local_databases.replace("~", expanduser("~")))
 
-    if not cache or cache == "regen":
-        # Delete existing HDF5 file
+    ldb = HITEMPDatabaseManager(
+        databank_name,
+        molecule=molecule,
+        local_databases=local_databases,
+        verbose=verbose,
+        chunksize=chunksize,
+    )
+
+    # Get list of all expected local files for this database:
+    local_files, urlnames = ldb.get_filenames()
+
+    # Delete files if needed:
+    if cache == "regen":
+        ldb.remove_local_files(local_files)
+
+    # Get number of lines to download
+    download_files = []
+    for local_file in local_files:
         if exists(local_file):
-            if verbose:
-                print("Removing existing file ", local_file)
-                # TODO: also clean the getDatabankList? Todo once it is in JSON format. https://github.com/radis/radis/issues/167
-            os.remove(local_file)
-
-    if exists(local_file):
-        # Read and return from local file
-
-        # check metadata :
-        check_not_deprecated(
-            local_file,
-            metadata_is={},
-            metadata_keys_contain=["wavenumber_min", "wavenumber_max"],
-        )
-        # check database is registered in ~/radis.json
-        if not databank_name in getDatabankList():
-            # if not, register it.
-            # ... First check number of lines is correct :
-            if Ntotal_lines_expected is None:
-                _, Ntotal_lines_expected = get_url_and_Nlines(molecule)
-            error_msg = ""
-            with pd.HDFStore(local_file, "r") as store:
-                nrows = store.get_storer("df").nrows
-                # TODO: replace with Database.get_rows()  # which would work for any backend (pytables / h5py)
-                if nrows != Ntotal_lines_expected:
-                    error_msg += (
-                        f"\nNumber of lines in local database ({nrows:,}) "
-                        + "differ from the expected number of lines for "
-                        + f"HITEMP {molecule}: {Ntotal_lines_expected}"
-                    )
-                file_metadata = store.get_storer("df").attrs.metadata
-                # TODO: replace with Database.get_metadata()  # which would work for any backend (pytables / h5py)
-                for k in [
-                    "wavenumber_min",
-                    "wavenumber_max",
-                    "download_url",
-                    "download_date",
-                ]:
-                    if k not in file_metadata:
-                        error_msg += (
-                            "\nMissing key in file metadata to register the database "
-                            + f"automatically : {k}"
-                        )
-
-            if error_msg:
-                raise ValueError(
-                    f"{databank_name} not declared in your RADIS ~/.config file although "
-                    + f"{local_file} exists. {error_msg}\n"
-                    + "If you know this file, add it to ~/radis.json manually. "
-                    + "Else regenerate the database with:\n\t"
-                    + ">>> radis.SpectrumFactory().fetch_databank(..., use_cached='regen')"
-                    + "\nor\n\t"
-                    + ">>> radis.io.hitemp.fetch_hitemp({molecule}, cache='regen')"
-                    + "\n\n⚠️ It will re-download & uncompress the whole database "
-                    + "from HITEMP.\n\nList of declared databanks: {getDatabankList()}.\n"
-                    + f"{local_file} metadata: {file_metadata}"
+            try:
+                check_not_deprecated(
+                    local_file,
+                    metadata_is={},
+                    metadata_keys_contain=["wavenumber_min", "wavenumber_max"],
                 )
-
-            # ... Database looks ok : register it
-            if verbose:
-                print(
-                    f"{databank_name} not declared in your RADIS ~/.config file although "
-                    + f"{local_file} exists. Registering the database automatically."
-                )
-
-            register_database(
-                databank_name,
-                [local_file],
-                molecule=molecule,
-                wmin=file_metadata["wavenumber_min"],
-                wmax=file_metadata["wavenumber_max"],
-                download_date=file_metadata["download_date"],
-                urlname=file_metadata["download_url"],
-                verbose=verbose,
-            )
-
-        # Database exists, and is registered : we can return it directly
-        # ... unless it's CO2 / H2O : there are many files and maybe it's not complete.
-
-        full_range_downloaded = True
-
-        if molecule in ["CO2", "H2O"]:
-            # ... Check database is complete
-            entries = getDatabankEntries(databank_name)
-            if load_wavenum_min is not None and load_wavenum_max is not None:
-                if (float(entries["wavenum_max"]) < load_wavenum_min) or (
-                    float(entries["wavenum_min"]) > load_wavenum_max
-                ):
-                    # downloaded range is enough
-                    full_range_downloaded = False
-                    # TODO / Unless we're asking for a range beyond the maximum range given...
-                    # That's relevant for all databases... What to do ? BeyondTheRangeWarning (checking if also complete)
-            # if only one of the two extrema is given > NotImplemented > we
-            # ... require to download the full database.
-            # elif load_wavenum_min is not None:
-            #     if float(fname_wmax) >= wavenum_min:
-            #         relevant.append(file)
-            # elif load_wavenum_max is not None:
-            #     if float(fname_wmin) <= wavenum_max:
-            #         relevant.append(file)
-            else:
-                # check number of lines is complete
-                with pd.HDFStore(local_file, "r") as store:
-                    nrows = store.get_storer("df").nrows
-                    # TODO: replace with Database.get_rows()  # which would work for any backend (pytables / h5py)
-                    if nrows < Ntotal_lines_expected:
-                        raise DeprecatedFileWarning(
-                            f"\nNumber of lines in local database ({nrows:,}) "
-                            + "differ from the expected number of lines for "
-                            + f"HITEMP {molecule}: {Ntotal_lines_expected}"
+            except DeprecatedFileWarning as err:
+                if cache == "force":
+                    raise err
+                else:  # delete file to regenerate it in the end of the script
+                    if verbose:
+                        printr(
+                            "File {0} deprecated:\n{1}\nDeleting it!".format(
+                                local_file, str(err)
+                            )
                         )
-        if full_range_downloaded:
-            if verbose:
-                print(f"Using existing database {databank_name}")
-            df = hdf2df(
-                local_file,
-                isotope=isotope,
-                load_wavenum_min=load_wavenum_min,
-                load_wavenum_max=load_wavenum_max,
-                verbose=verbose,
-            )
-            return (df, local_file) if return_local_path else df
-
+                    os.remove(local_file)
+                    download_files.append(local_file)
         else:
-            # keep a continuous database (i.e. : all lines from [wmin] to [wmax] even if we only need two separate sections)
+            download_files.append(local_file)
 
-            # Note : with Vaex it's very easy to open many different files with
-            # only a minimal overhead. Why put everything in a large file then ?
-            raise NotImplementedError
-            # ... TODO
+    # Download files
+    # url_to_download =
+    if len(download_files) > 0:
+        _, Ntotal_lines_expected = ldb.fetch_url_and_Nlines()
+        if urlnames is None:
+            urlnames = ldb.fetch_urlnames()
+        filesmap = dict(zip(local_files, urlnames))
+        download_urls = [filesmap[k] for k in download_files]
+        ldb.download_and_parse(download_urls, download_files)
 
-            # use is_relevant function of Corentin ?
+        # Done: add final checks
+        if molecule not in ["CO2", "H2O"]:
+            # ... check on the created file that all lines are there :
+            nrows = ldb.get_nrows(local_files[0])
+            # assert nrows == Nlines
+            if nrows != Ntotal_lines_expected:
+                raise AssertionError(
+                    f"Number of lines in local database ({nrows:,}) "
+                    + "differ from the expected number of lines for "
+                    + f"HITEMP {molecule}: {Ntotal_lines_expected}"
+                )
 
-            # therefore, only download relevant_files...
+    # # Open and run
+
+    # if local_files_exist:
+
+    # check that the database is correctly registered in ~/radis.json
+    # if not databank_name in getDatabankList():
+    #     # if not, register it.
+    #     if len(local_files) == 1:
+    #         local_file = local_files[0]
+    #         # ... First check number of lines is correct :
+    #         if Ntotal_lines_expected is None:
+    #             _, Ntotal_lines_expected = get_url_and_Nlines(molecule)
+    #         error_msg = ""
+    #         with pd.HDFStore(local_file, "r") as store:
+    #             nrows = store.get_storer("df").nrows
+    #             # TODO: replace with Database.get_rows()  # which would work for any backend (pytables / h5py)
+    #             if nrows != Ntotal_lines_expected:
+    #                 error_msg += (
+    #                     f"\nNumber of lines in local database ({nrows:,}) "
+    #                     + "differ from the expected number of lines for "
+    #                     + f"HITEMP {molecule}: {Ntotal_lines_expected}"
+    #                 )
+    #             file_metadata = store.get_storer("df").attrs.metadata
+    #             # TODO: replace with Database.get_metadata()  # which would work for any backend (pytables / h5py)
+    #             for k in [
+    #                 "wavenumber_min",
+    #                 "wavenumber_max",
+    #                 "download_url",
+    #                 "download_date",
+    #             ]:
+    #                 if k not in file_metadata:
+    #                     error_msg += (
+    #                         "\nMissing key in file metadata to register the database "
+    #                         + f"automatically : {k}"
+    #                     )
+
+    #         if error_msg:
+    #             raise ValueError(
+    #                 f"{databank_name} not declared in your RADIS ~/.config file although "
+    #                 + f"{local_file} exists. {error_msg}\n"
+    #                 + "If you know this file, add it to ~/radis.json manually. "
+    #                 + "Else regenerate the database with:\n\t"
+    #                 + ">>> radis.SpectrumFactory().fetch_databank(..., use_cached='regen')"
+    #                 + "\nor\n\t"
+    #                 + ">>> radis.io.hitemp.fetch_hitemp({molecule}, cache='regen')"
+    #                 + "\n\n⚠️ It will re-download & uncompress the whole database "
+    #                 + "from HITEMP.\n\nList of declared databanks: {getDatabankList()}.\n"
+    #                 + f"{local_file} metadata: {file_metadata}"
+    #             )
+
+    #         # ... Database looks ok : register it
+    #         if verbose:
+    #             print(
+    #                 f"{databank_name} not declared in your RADIS ~/.config file although "
+    #                 + f"{local_file} exists. Registering the database automatically."
+    #             )
+
+    #         register_database(
+    #             databank_name,
+    #             [local_file],
+    #             molecule=molecule,
+    #             wmin=file_metadata["wavenumber_min"],
+    #             wmax=file_metadata["wavenumber_max"],
+    #             download_date=file_metadata["download_date"],
+    #             urlname=file_metadata["download_url"],
+    #             verbose=verbose,
+    #         )
+    #     else:    # case of CO2, H2O
+
+    #         _, files_wmin, files_wmax = keep_only_relevant(inputfiles)
+
+    #         # just register the full database
+    #         register_database(
+    #             databank_name,
+    #             local_files,  # write all filenames in the database
+    #             molecule=molecule,
+    #             wmin=files_wmin,
+    #             wmax=files_wmax,
+    #             download_date=file_metadata["download_date"],
+    #             urlname=file_metadata["download_url"],
+    #             verbose=verbose,
+    #         )
+
+    # Database exists, and is registered : we can return it directly
+    # ... unless it's CO2 / H2O : there are many files and we don't need all of them
+
+    # if molecule in ["CO2", "H2O"]:
+    #     # ... Check database is complete
+    #     entries = getDatabankEntries(databank_name)
+    #     if load_wavenum_min is not None and load_wavenum_max is not None:
+    #         if (float(entries["wavenum_max"]) < load_wavenum_min) or (
+    #             float(entries["wavenum_min"]) > load_wavenum_max
+    #         ):
+    #             # downloaded range is enough
+    #             full_range_downloaded = False
+    #             # TODO / Unless we're asking for a range beyond the maximum range given...
+    #             # That's relevant for all databases... What to do ? BeyondTheRangeWarning (checking if also complete)
+    #     # if only one of the two extrema is given > NotImplemented > we
+    #     # ... require to download the full database.
+    #     # elif load_wavenum_min is not None:
+    #     #     if float(fname_wmax) >= wavenum_min:
+    #     #         relevant.append(file)
+    #     # elif load_wavenum_max is not None:
+    #     #     if float(fname_wmin) <= wavenum_max:
+    #     #         relevant.append(file)
+    #     else:
+    #         # check number of lines is complete
+    #         with pd.HDFStore(local_file, "r") as store:
+    #             nrows = store.get_storer("df").nrows
+    #             # TODO: replace with Database.get_rows()  # which would work for any backend (pytables / h5py)
+    #             if nrows < Ntotal_lines_expected:
+    #                 raise DeprecatedFileWarning(
+    #                     f"\nNumber of lines in local database ({nrows:,}) "
+    #                     + "differ from the expected number of lines for "
+    #                     + f"HITEMP {molecule}: {Ntotal_lines_expected}"
+    #                 )
+    # if full_range_downloaded:
+    #     if verbose:
+    #         print(f"Using existing database {databank_name}")
+    #     df = hdf2df(
+    #         local_file,
+    #         isotope=isotope,
+    #         load_wavenum_min=load_wavenum_min,
+    #         load_wavenum_max=load_wavenum_max,
+    #         verbose=verbose,
+    #     )
+    #     return (df, local_file) if return_local_path else df
+
+    # else:
+    #     # keep a continuous database (i.e. : all lines from [wmin] to [wmax] even if we only need two separate sections)
+
+    #     # Note : with Vaex it's very easy to open many different files with
+    #     # only a minimal overhead. Why put everything in a large file then ?
+    #     raise NotImplementedError
+    #     # ... TODO
+
+    #     # use is_relevant function of Corentin ?
+
+    #     # therefore, only download relevant_files...
 
     # TODO here: for CO2; H2O : if exists : re-check if valid ; compare with relevant range ;
     # download only missing!
 
     ###################################################
-    # Doesnt exist : download
-    if Ntotal_lines_expected is None:
-        _, Ntotal_lines_expected = get_url_and_Nlines(molecule)
-    ds = DataSource(join(local_databases, "downloads"))
-    Ndownload = 1
-    Ntotal_downloads = len(urlnames)
+    # Doesnt exist : download    missing files
 
-    Nlines = 0
-    pb = ProgressBar(N=Ntotal_lines_expected, active=verbose)
+    if not ldb.is_registered():
+        ldb.register(local_files, urlnames)
 
-    wmin = np.inf
-    wmax = 0
+    if len(download_files) > 0 and clean_cache_files:
+        ldb.clean_download_files(urlnames)
 
-    for urlname in urlnames:
-
-        if verbose:
-            inputf = urlname.split("/")[-1]
-            print(
-                f"Downloading {inputf} for {molecule} ({Ndownload}/{Ntotal_downloads})."
-            )
-        download_date = date.today().strftime("%d %b %Y")
-
-        columns = columns_2004
-
-        # Get linereturn (depends on OS, but file may also have been generated
-        # on a different OS. Here we simply read the file to find out)
-        with ds.open(urlname) as gfile:  # locally downloaded file
-            dt = _create_dtype(
-                columns, "a2"
-            )  # 'a2' allocates space to get \n or \n\r for linereturn character
-            b = np.zeros(1, dtype=dt)
-            try:
-                gfile.readinto(b)
-            except EOFError as err:
-                raise ValueError(
-                    f"End of file while parsing file {ds.abspath(urlname)}. May be due to download error. Delete file ?"
-                ) from err
-            linereturnformat = _get_linereturnformat(b, columns)
-
-        with ds.open(urlname) as gfile:  # locally downloaded file
-
-            dt = _create_dtype(columns, linereturnformat)
-            b = np.zeros(chunksize, dtype=dt)  # receives the HITRAN 160-character data.
-
-            if verbose:
-                print(
-                    f"Download complete. Building {molecule} database to {local_file}"
-                )
-
-            with pd.HDFStore(local_file, mode="a", complib="blosc", complevel=9) as f:
-
-                for nbytes in iter(lambda: gfile.readinto(b), 0):
-
-                    if not b[-1]:
-                        # End of file flag within the chunk (but does not start
-                        # with End of file flag) so nbytes != 0
-                        b = get_last(b)
-
-                    df = _ndarray2df(b, columns, linereturnformat)
-
-                    # Post-processing :
-                    # ... Add local quanta attributes, based on the HITRAN group
-                    df = parse_local_quanta(df, molecule)
-
-                    # ... Add global quanta attributes, based on the HITRAN class
-                    df = parse_global_quanta(df, molecule)
-
-                    # Switch 'P', 'Q', 'R' to -1, 0, 1
-                    if "branch" in df:
-                        replace_PQR_with_m101(df)
-
-                    f.put(
-                        key="df",
-                        value=df,
-                        append=True,
-                        format="table",
-                        data_columns=DATA_COLUMNS,
-                    )
-                    wmin = np.min((wmin, df.wav.min()))
-                    wmax = np.max((wmax, df.wav.max()))
-
-                    Nlines += len(df)
-                    pb.update(
-                        Nlines,
-                        message=f"Parsed {Nlines:,} / {Ntotal_lines_expected:,} lines. Wavenumber range {wmin:.2f}-{wmax:.2f} cm-1 is complete.",
-                    )
-
-                    # Reinitialize for next read
-                    b = np.zeros(
-                        chunksize, dtype=dt
-                    )  # receives the HITRAN 160-character data.
-
-        Ndownload += 1
-
-    pb.done()
-
-    url_store = urlnames[0] if len(urlnames) == 1 else urlnames
-    with pd.HDFStore(local_file, mode="a", complib="blosc", complevel=9) as f:
-
-        f.get_storer("df").attrs.metadata = {
-            "wavenumber_min": wmin,
-            "wavenumber_max": wmax,
-            "download_date": download_date,
-            "download_url": url_store,
-            "version": radis.__version__,
-        }
-
-    # Done: add final checks
-    # ... check on the created file that all lines are there :
-    with pd.HDFStore(local_file, "r") as store:
-        nrows = store.get_storer("df").nrows
-        assert nrows == Nlines
-        if nrows != Ntotal_lines_expected:
-            raise AssertionError(
-                f"Number of lines in local database ({nrows:,}) "
-                + "differ from the expected number of lines for "
-                + f"HITEMP {molecule}: {Ntotal_lines_expected}"
-            )
-
-    # Add database to  ~/radis.json
-    register_database(
-        databank_name,
-        [local_file],
-        molecule,
-        wmin,
-        wmax,
-        download_date,
-        url_store,
-        verbose,
-    )
-
-    df = hdf2df(
-        local_file,
+    # Load and return
+    df = ldb.load(
+        local_files,
         isotope=isotope,
         load_wavenum_min=load_wavenum_min,
         load_wavenum_max=load_wavenum_max,
-        verbose=verbose,
     )
 
-    # Fully unzipped (and working, as it was reloaded): clean
-    if clean_cache_files:
-        os.remove(ds._findfile(urlname))
-        if verbose >= 3:
-            from radis.misc.printer import printg
-
-            printg("... removed downloaded cache file")
-
-    return (df, local_file) if return_local_path else df
-
-
-def register_database(
-    databank_name, path_list, molecule, wmin, wmax, download_date, urlname, verbose
-):
-    """Add to registered databases in RADIS config file.
-
-    If database exists, assert it has the same entries.
-
-    Parameters
-    ----------
-    databank_name: str
-        name of the database in :ref:`~/radis.json config file <label_lbl_config_file>`
-
-    Other Parameters
-    ----------------
-    verbose: bool
-
-    Returns
-    -------
-    None:
-        adds to :ref:`~/radis.json <label_lbl_config_file>` with all the input
-        parameters. Also adds ::
-
-            format : "hitemp-radisdb"
-            parfuncfmt : "hapi"   # TIPS-2017 for equilibrium partition functions
-
-        And if the molecule is in :py:attr:`~radis.db.MOLECULES_LIST_NONEQUILIBRIUM`::
-
-            levelsfmt : "radis"   # use RADIS spectroscopic constants for rovibrational energies (nonequilibrium)
-
-    """
-    dict_entries = {
-        "info": f"HITEMP {molecule} lines ({wmin:.1f}-{wmax:.1f} cm-1) with TIPS-2017 (through HAPI) for partition functions",
-        "path": path_list,
-        "format": "hitemp-radisdb",
-        "parfuncfmt": "hapi",
-        "wavenumber_min": f"{wmin}",
-        "wavenumber_max": f"{wmax}",
-        "download_date": download_date,
-        "download_url": urlname,
-    }
-    if molecule in MOLECULES_LIST_NONEQUILIBRIUM:
-        dict_entries[
-            "info"
-        ] += " and RADIS spectroscopic constants for rovibrational energies (nonequilibrium)"
-        dict_entries["levelsfmt"] = "radis"
-
-    # Register database in ~/radis.json to be able to use it with load_databank()
-    try:
-        addDatabankEntries(databank_name, dict_entries)
-    except DatabaseAlreadyExists as err:
-        # Check that the existing database had the same entries
-        try:
-            from radis.misc.config import getDatabankEntries
-
-            for k, v in getDatabankEntries(databank_name).items():
-                if k == "download_date":
-                    continue
-                assert dict_entries[k] == v
-            # TODO @dev : replace once we have configfile as JSON (https://github.com/radis/radis/issues/167)
-        except AssertionError:
-            raise DatabaseAlreadyExists(
-                f"{databank_name} already exists in your ~/radis.json config file, "
-                + f"with different key `{k}` : `{v}` (~/radis.json) ≠ `{dict_entries[k]}` (new). "
-                + "If you're sure of what you're doing, fix the registered database in ~/radis.json. "
-                + "Else, remove it from your config file, or choose a different name "
-                + "for the downloaded database with `fetch_hitemp(databank_name=...)`, "
-                + "and restart."
-            ) from err
-        else:  # no other error raised
-            if verbose:
-                print(
-                    f"{databank_name} already registered in ~/radis.json config file, with the same parameters."
-                )
-
-
-#%%
-def get_last(b):
-    """Get non-empty lines of a chunk b, parsing the bytes."""
-    element_length = np.vectorize(lambda x: len(x.__str__()))(b)
-    non_zero = element_length > element_length[-1]
-    threshold = non_zero.argmin() - 1
-    assert (non_zero[: threshold + 1] == 1).all()
-    assert (non_zero[threshold + 1 :] == 0).all()
-    return b[non_zero]
+    return (df, local_files) if return_local_path else df
 
 
 #%%

--- a/radis/io/hitran.py
+++ b/radis/io/hitran.py
@@ -524,8 +524,8 @@ def _parse_HITRAN_class6(df):
     # ... somehow negative. The regex above is adapted to catch negation signs with \-
 
     # 2. Convert to numeric
-    dgu = dgu.apply(pd.to_numeric)
-    dgl = dgl.apply(pd.to_numeric)
+    dgu = dgu.apply(pd.to_numeric, errors='coerce').astype(float64)
+    dgl = dgl.apply(pd.to_numeric, errors='coerce').astype(float64)
 
     # 3. Clean
     del df["globu"]
@@ -691,12 +691,16 @@ def _parse_HITRAN_group1(df):
     )
     # ... note @EP: in HITRAN H2O files, for iso=2, the Kau, Kcu can somehow
     # ... be negative. The regex above is adapted to catch negation signs with \-
+    
+    try:
+        # 2. Convert to numeric
+        for k in ["ju", "Kau", "Kcu"]:
+            dgu[k] = pd.to_numeric(dgu[k], errors='coerce').astype(float64)
+        for k in ["jl", "Kal", "Kcl"]:
+            dgl[k] = pd.to_numeric(dgl[k], errors='coerce').astype(float64)
 
-    # 2. Convert to numeric
-    for k in ["ju", "Kau", "Kcu"]:
-        dgu[k] = pd.to_numeric(dgu[k])
-    for k in ["jl", "Kal", "Kcl"]:
-        dgl[k] = pd.to_numeric(dgl[k])
+    except:
+        print(dgu)
 
     # 3. Clean
     del df["locu"]

--- a/radis/io/hitran.py
+++ b/radis/io/hitran.py
@@ -28,7 +28,7 @@ from collections import OrderedDict
 from os.path import exists, getmtime
 
 import pandas as pd
-from numpy import float64
+from numpy import int64
 
 import radis
 from radis import OLDEST_COMPATIBLE_VERSION
@@ -88,6 +88,13 @@ columns_2004 = OrderedDict(
 )
 """ OrderedDict: parsing order of HITRAN 2004 format """
 # fmt: on
+
+
+def cast_to_int64_with_missing_values(dg, keys):
+    """replace missing values of int64 columns with -1"""
+    for c in keys:
+        if dg.dtypes[c] != int64:
+            dg[c] = dg[c].fillna(-1).astype(int64)
 
 
 def hit2df(
@@ -317,12 +324,12 @@ def _parse_HITRAN_class1(df):
     """
 
     # 1. Parse
-    dgu = df["globu"].str.extract(r"[ ]{13}(?P<vu>[\d ]{2})", expand=True)
-    dgl = df["globl"].str.extract(r"[ ]{13}(?P<vl>[\d ]{2})", expand=True)
+    dgu = df["globu"].astype(str).str.extract(r"[ ]{13}(?P<vu>[\d ]{2})", expand=True)
+    dgl = df["globl"].astype(str).str.extract(r"[ ]{13}(?P<vl>[\d ]{2})", expand=True)
 
     # 2. Convert to numeric
-    dgu = dgu.apply(pd.to_numeric)
-    dgl = dgl.apply(pd.to_numeric)
+    cast_to_int64_with_missing_values(dgu, ["vu"])
+    cast_to_int64_with_missing_values(dgl, ["vl"])
 
     # 3. Clean
     del df["globu"]
@@ -416,18 +423,26 @@ def _parse_HITRAN_class4(df):
     """
 
     # 1. Parse
-    dgu = df["globu"].str.extract(
-        r"[ ]{7}(?P<v1u>[\d ]{2})(?P<v2u>[\d ]{2})(?P<l2u>[\d ]{2})(?P<v3u>[\d ]{2})",
-        expand=True,
+    dgu = (
+        df["globu"]
+        .astype(str)
+        .str.extract(
+            r"[ ]{7}(?P<v1u>[\d ]{2})(?P<v2u>[\d ]{2})(?P<l2u>[\d ]{2})(?P<v3u>[\d ]{2})",
+            expand=True,
+        )
     )
-    dgl = df["globl"].str.extract(
-        r"[ ]{7}(?P<v1l>[\d ]{2})(?P<v2l>[\d ]{2})(?P<l2l>[\d ]{2})(?P<v3l>[\d ]{2})",
-        expand=True,
+    dgl = (
+        df["globl"]
+        .astype(str)
+        .str.extract(
+            r"[ ]{7}(?P<v1l>[\d ]{2})(?P<v2l>[\d ]{2})(?P<l2l>[\d ]{2})(?P<v3l>[\d ]{2})",
+            expand=True,
+        )
     )
 
     # 2. Convert to numeric
-    dgu = dgu.apply(pd.to_numeric)
-    dgl = dgl.apply(pd.to_numeric)
+    cast_to_int64_with_missing_values(dgu, ["v1u", "v2u", "l2u", "v3u"])
+    cast_to_int64_with_missing_values(dgl, ["v1l", "v2l", "l2l", "v3l"])
 
     # 3. Clean
     del df["globu"]
@@ -463,18 +478,26 @@ def _parse_HITRAN_class5(df):
     """
 
     # 1. Parse
-    dgu = df["globu"].str.extract(
-        r"[ ]{6}(?P<v1u>[\d ]{2})(?P<v2u>[\d ]{2})(?P<l2u>[\d ]{2})(?P<v3u>[\d ]{2})(?P<ru>\d)",
-        expand=True,
+    dgu = (
+        df["globu"]
+        .astype(str)
+        .str.extract(
+            r"[ ]{6}(?P<v1u>[\d ]{2})(?P<v2u>[\d ]{2})(?P<l2u>[\d ]{2})(?P<v3u>[\d ]{2})(?P<ru>\d)",
+            expand=True,
+        )
     )
-    dgl = df["globl"].str.extract(
-        r"[ ]{6}(?P<v1l>[\d ]{2})(?P<v2l>[\d ]{2})(?P<l2l>[\d ]{2})(?P<v3l>[\d ]{2})(?P<rl>\d)",
-        expand=True,
+    dgl = (
+        df["globl"]
+        .astype(str)
+        .str.extract(
+            r"[ ]{6}(?P<v1l>[\d ]{2})(?P<v2l>[\d ]{2})(?P<l2l>[\d ]{2})(?P<v3l>[\d ]{2})(?P<rl>\d)",
+            expand=True,
+        )
     )
 
     # 2. Convert to numeric
-    dgu = dgu.apply(pd.to_numeric).astype(float64)
-    dgl = dgl.apply(pd.to_numeric)
+    cast_to_int64_with_missing_values(dgu, ["v1u", "v2u", "l2u", "v3u", "ru"])
+    cast_to_int64_with_missing_values(dgl, ["v1l", "v2l", "l2l", "v3l", "rl"])
 
     # 3. Clean
     del df["globu"]
@@ -510,22 +533,37 @@ def _parse_HITRAN_class6(df):
     """
 
     # 1. Parse
-    dgu = df["globu"].str.extract(
-        #        '[ ]{9}(?P<v1u>[\d ]{2})(?P<v2u>[\d ]{2})(?P<v3u>[\d ]{2})',
-        r"[ ]{9}(?P<v1u>[\-\d ]{2})(?P<v2u>[\-\d ]{2})(?P<v3u>[\-\d ]{2})",
-        expand=True,
+    dgu = (
+        df["globu"]
+        .astype(str)
+        .str.extract(
+            #        '[ ]{9}(?P<v1u>[\d ]{2})(?P<v2u>[\d ]{2})(?P<v3u>[\d ]{2})',
+            r"[ ]{9}(?P<v1u>[\-\d ]{2})(?P<v2u>[\-\d ]{2})(?P<v3u>[\-\d ]{2})",
+            expand=True,
+        )
     )
-    dgl = df["globl"].str.extract(
-        #        '[ ]{9}(?P<v1l>[\d ]{2})(?P<v2l>[\d ]{2})(?P<v3l>[\d ]{2})',
-        r"[ ]{9}(?P<v1l>[\-\d ]{2})(?P<v2l>[\-\d ]{2})(?P<v3l>[\-\d ]{2})",
-        expand=True,
+    dgl = (
+        df["globl"]
+        .astype(str)
+        .str.extract(
+            #        '[ ]{9}(?P<v1l>[\d ]{2})(?P<v2l>[\d ]{2})(?P<v3l>[\d ]{2})',
+            r"[ ]{9}(?P<v1l>[\-\d ]{2})(?P<v2l>[\-\d ]{2})(?P<v3l>[\-\d ]{2})",
+            expand=True,
+        )
     )
     # ... note @EP: in HITRAN H2O files, for iso=2, vibrational levels are
     # ... somehow negative. The regex above is adapted to catch negation signs with \-
 
     # 2. Convert to numeric
-    dgu = dgu.apply(pd.to_numeric, errors='coerce').astype(float64)
-    dgl = dgl.apply(pd.to_numeric, errors='coerce').astype(float64)
+    cast_to_int64_with_missing_values(
+        dgu,
+        [
+            "v1u",
+            "v2u",
+            "v3u",
+        ],
+    )
+    cast_to_int64_with_missing_values(dgl, ["v1l", "v2l", "v3l"])
 
     # 3. Clean
     del df["globu"]
@@ -648,7 +686,8 @@ def _parse_HITRAN_class10(df):
 
 
 def _parse_HITRAN_group1(df):
-    r"""
+    r"""Parse asymmetric rotors (:py:attr:`~radis.db.classes.HITRAN_GROUP1` ):
+    H2O, O3, SO2, NO2, HNO3, H2CO, HOCl, H2O2, COF2, H2S, HO2, HCOOH, ClONO2, HOBr, C2H4
 
     Parameters
     ----------
@@ -677,30 +716,32 @@ def _parse_HITRAN_group1(df):
     # --------------
     # J'  | Ka' | Kc' | F'  | Sym'
     # I3  | I3  | I3  | A5  | A1
-    dgu = df["locu"].str.extract(
-        r"(?P<ju>[\d ]{3})(?P<Kau>[\-\d ]{3})(?P<Kcu>[\-\d ]{3})(?P<Fu>.{5})(?P<symu>.)",
-        expand=True,
+    dgu = (
+        df["locu"]
+        .astype(str)
+        .str.extract(
+            r"(?P<ju>[\d ]{3})(?P<Kau>[\-\d ]{3})(?P<Kcu>[\-\d ]{3})(?P<Fu>.{5})(?P<symu>.)",
+            expand=True,
+        )
     )
     # Ref [1] : locl
     # --------------
     # J'' | Ka''| Kc''| F'' | Sym''
     # I3  | I3  | I3  | A5  | A1
-    dgl = df["locl"].str.extract(
-        r"(?P<jl>[\d ]{3})(?P<Kal>[\-\d ]{3})(?P<Kcl>[\-\d ]{3})(?P<Fl>.{5})(?P<syml>.)",
-        expand=True,
+    dgl = (
+        df["locl"]
+        .astype(str)
+        .str.extract(
+            r"(?P<jl>[\d ]{3})(?P<Kal>[\-\d ]{3})(?P<Kcl>[\-\d ]{3})(?P<Fl>.{5})(?P<syml>.)",
+            expand=True,
+        )
     )
     # ... note @EP: in HITRAN H2O files, for iso=2, the Kau, Kcu can somehow
     # ... be negative. The regex above is adapted to catch negation signs with \-
-    
-    try:
-        # 2. Convert to numeric
-        for k in ["ju", "Kau", "Kcu"]:
-            dgu[k] = pd.to_numeric(dgu[k], errors='coerce').astype(float64)
-        for k in ["jl", "Kal", "Kcl"]:
-            dgl[k] = pd.to_numeric(dgl[k], errors='coerce').astype(float64)
 
-    except:
-        print(dgu)
+    # 2. Convert to numeric
+    cast_to_int64_with_missing_values(dgu, ["ju", "Kau", "Kcu"])
+    cast_to_int64_with_missing_values(dgl, ["jl", "Kal", "Kcl"])
 
     # 3. Clean
     del df["locu"]
@@ -710,7 +751,8 @@ def _parse_HITRAN_group1(df):
 
 
 def _parse_HITRAN_group2(df):
-    r"""
+    r"""Parse diatomic and linear molecules (:py:attr:`~radis.db.classes.HITRAN_GROUP2` ):
+    CO2, N2O, CO, HF, HCl, HBr, HI, OCS, N2, HCN, C2H2, NO+
 
     Parameters
     ----------
@@ -739,19 +781,24 @@ def _parse_HITRAN_group2(df):
     # --------------
     #     | F'  |
     # 10X | A5  |
-    dgu = df["locu"].str.extract(r"[ ]{10}(?P<Fu>.{5})", expand=True)
+    dgu = df["locu"].astype(str).str.extract(r"[ ]{10}(?P<Fu>.{5})", expand=True)
     # Ref [1] : locl
     # --------------
     #     | Br  | J'' | Sym''| F'' |
     # 5X  | A1  | I3  | A1   | A5  |
-    dgl = df["locl"].str.extract(
-        r"[ ]{5}(?P<branch>[\S]{1})(?P<jl>[\d ]{3})(?P<syml>.)(?P<Fl>.{5})", expand=True
+    dgl = (
+        df["locl"]
+        .astype(str)
+        .str.extract(
+            r"[ ]{5}(?P<branch>[\S]{1})(?P<jl>[\d ]{3})(?P<syml>.)(?P<Fl>.{5})",
+            expand=True,
+        )
     )
 
     # 2. Convert to numeric
 
     # dgl['jl'] = dgl.jl.apply(pd.to_numeric)
-    dgl["jl"] = pd.to_numeric(dgl.jl)
+    cast_to_int64_with_missing_values(dgl, ["jl"])
 
     # 3. Clean
     del df["locu"]
@@ -770,7 +817,8 @@ def _parse_HITRAN_group2(df):
 
 
 def _parse_HITRAN_group3(df):
-    r"""
+    r"""Parse Spherical rotors (:py:attr:`~radis.db.classes.HITRAN_GROUP3` ) :
+    SF6, CH4
 
     Parameters
     ----------
@@ -797,7 +845,8 @@ def _parse_HITRAN_group3(df):
 
 
 def _parse_HITRAN_group4(df):
-    r"""
+    r"""Parse symmetric rotors (:py:attr:`~radis.db.classes.HITRAN_GROUP4` ):
+    CH3D, CH3Cl, C2H6, NH3, PH3, CH3OH
 
     Parameters
     ----------
@@ -824,7 +873,8 @@ def _parse_HITRAN_group4(df):
 
 
 def _parse_HITRAN_group5(df):
-    r"""
+    r"""Parse Triplet-Sigma ground electronic states (:py:attr:`~radis.db.classes.HITRAN_GROUP5` ) :
+    O2
 
     Parameters
     ----------
@@ -851,7 +901,8 @@ def _parse_HITRAN_group5(df):
 
 
 def _parse_HITRAN_group6(df):
-    r"""
+    r"""Parse Doublet-Pi ground electronic states (:py:attr:`~radis.db.classes.HITRAN_GROUP6` ) :
+    NO, OH, ClO
 
     Parameters
     ----------
@@ -891,10 +942,6 @@ def parse_local_quanta(df, mol):
         molecule name
     """
 
-    # had some problems with bytes types
-    df["locu"] = df.locu.astype(str)
-    df["locl"] = df.locl.astype(str)
-
     if mol in HITRAN_GROUP1:
         df = _parse_HITRAN_group1(df)
     elif mol in HITRAN_GROUP2:
@@ -926,10 +973,6 @@ def parse_global_quanta(df, mol):
     mol: str
         molecule name
     """
-
-    # had some problems with bytes types
-    df["globu"] = df.globu.astype(str)
-    df["globl"] = df.globl.astype(str)
 
     if mol in HITRAN_CLASS1:
         df = _parse_HITRAN_class1(df)

--- a/radis/io/hitran.py
+++ b/radis/io/hitran.py
@@ -28,6 +28,7 @@ from collections import OrderedDict
 from os.path import exists, getmtime
 
 import pandas as pd
+from numpy import float64
 
 import radis
 from radis import OLDEST_COMPATIBLE_VERSION
@@ -472,7 +473,7 @@ def _parse_HITRAN_class5(df):
     )
 
     # 2. Convert to numeric
-    dgu = dgu.apply(pd.to_numeric)
+    dgu = dgu.apply(pd.to_numeric).astype(float64)
     dgl = dgl.apply(pd.to_numeric)
 
     # 3. Clean

--- a/radis/io/linedb.py
+++ b/radis/io/linedb.py
@@ -1,0 +1,331 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Aug  9 19:42:51 2021
+
+@author: erwan
+"""
+import os
+from io import BytesIO
+from os.path import abspath, exists, splitext
+from zipfile import ZipFile
+
+from radis.db import MOLECULES_LIST_NONEQUILIBRIUM
+from radis.misc.config import addDatabankEntries, getDatabankEntries, getDatabankList
+from radis.misc.warning import DatabaseAlreadyExists, DeprecatedFileWarning
+
+try:
+    from .hdf5 import hdf2df
+except ImportError:
+    from radis.io.hdf5 import hdf2df
+
+from datetime import date
+from os.path import join
+
+import numpy as np
+import pandas as pd
+from dateutil.parser import parse as parse_date
+from numpy import DataSource
+
+LAST_VALID_DATE = (
+    "01 Jan 2010"  # set to a later date to force re-download of all HITEMP databases
+)
+
+# Add a zip opener to the datasource _file_openers
+def open_zip(zipname, mode="r", encoding=None, newline=None):
+    output = BytesIO()
+    with ZipFile(zipname, mode[0]) as myzip:
+        fnames = myzip.namelist()
+        for fname in fnames:
+            output.write(myzip.read(fname))
+    output.seek(0)
+    return output
+
+
+np.lib._datasource._file_openers._file_openers[".zip"] = open_zip
+
+
+class DatabaseManager(object):
+    """Line Database parser
+
+    Parameters
+    ----------
+    name: str
+        database name as registered in ~/radis.json
+    molecule: str
+    local_databases: str
+        path to local database
+    """
+
+    # Should be as a close as possible to the content of the corresponding ~/radis.json entry
+    # Essentially a FileManager
+
+    def __init__(self, name, molecule, local_databases, verbose=False):
+
+        self.name = name
+        self.molecule = molecule
+        self.local_databases = local_databases
+        self.downloadable = False  # by default
+
+        self.ds = DataSource(join(self.local_databases, "downloads"))
+
+        self.verbose = verbose
+
+    def get_filenames(self):
+        verbose = self.verbose
+        local_databases = self.local_databases
+
+        # First; checking if the database is registered in radis.json
+        if self.is_registered():
+            entries = getDatabankEntries(self.name)
+            try:
+                assert "download_url" in entries
+                assert "download_date" in entries
+                assert parse_date(entries["download_date"]) > parse_date(
+                    LAST_VALID_DATE
+                )
+            except AssertionError as err:
+                raise DeprecatedFileWarning(
+                    "Database file {0} not valid anymore"
+                ) from err
+            else:
+                local_files = entries["path"]
+            urlnames = None
+
+        elif self.is_downloadable():
+            # local_files = self.fetch_filenames()
+            urlnames = self.fetch_urlnames()
+            local_fnames = [
+                (
+                    splitext(splitext(url.split("/")[-1])[0])[
+                        0
+                    ]  # twice to remove .par.bz2
+                    + ".h5"
+                )
+                for url in urlnames
+            ]
+
+            try:
+                os.mkdir(local_databases)
+            except OSError:
+                pass
+            else:
+                if verbose:
+                    print("Created folder :", local_databases)
+
+            local_files = [
+                abspath(
+                    join(
+                        local_databases,
+                        self.molecule + "-" + local_fname,
+                    )
+                )
+                for local_fname in local_fnames
+            ]
+
+        else:
+            raise NotImplementedError
+
+        return local_files, urlnames
+
+    def remove_local_files(self, local_files):
+        # Delete existing HDF5 file
+        for local_file in local_files:
+            if exists(local_file):
+                if self.verbose:
+                    print("Removing existing file ", local_file)
+                    # TODO: also clean the getDatabankList? Todo once it is in JSON format. https://github.com/radis/radis/issues/167
+                os.remove(local_file)
+
+    def is_downloadable(self):
+        return self.downloadable
+
+    def is_registered(self):
+        return self.name in getDatabankList()
+
+    def fetch_filenames(self):
+        raise NotImplementedError
+
+    def get_today(self):
+        return date.today().strftime("%d %b %Y")
+
+    def register(self, local_files, urlname):
+        download_date = self.get_today()
+        verbose = self.verbose
+
+        # Add database to  ~/radis.json
+        return register_database(
+            self.name,
+            local_files,
+            self.molecule,
+            self.wmin,
+            self.wmax,
+            download_date,
+            urlname,
+            verbose,
+        )
+
+    def download_and_parse(self, urlnames, local_files):
+        all_local_files, _ = self.get_filenames()
+
+        verbose = self.verbose
+        molecule = self.molecule
+
+        # self.parse_to_local_file(ds, urlname, local_file, molecule)
+
+        from time import time
+
+        t0 = time()
+        pbar_Ntot_estimate_factor = None
+        if len(urlnames) != len(all_local_files):
+            # we're only downloading a part of the database
+            # expected number of lines is approximately Ntot * N_files/N_files_total
+            # (this is just to give the user an expected download & parse time)
+            pbar_Ntot_estimate_factor = len(urlnames) / len(all_local_files)
+        else:
+            pbar_Ntot_estimate_factor = None
+        Nlines_total = 0
+        Ndownload = 1
+        Ntotal_downloads = len(local_files)
+        for urlname, local_file in zip(urlnames, local_files):
+
+            if verbose:
+                inputf = urlname.split("/")[-1]
+                print(
+                    f"Downloading {inputf} for {molecule} ({Ndownload}/{Ntotal_downloads})."
+                )
+
+            Nlines = self.parse_to_local_file(
+                self.ds,
+                urlname,
+                local_file,
+                pbar_t0=time() - t0,
+                pbar_Ntot_estimate_factor=pbar_Ntot_estimate_factor,
+                pbar_Nlines_already=Nlines_total,
+            )
+            Ndownload += 1
+            Nlines_total += Nlines
+
+    def clean_download_files(self, urlnames):
+        # Fully unzipped (and working, as it was reloaded): clean
+        if not isinstance(urlnames, list):
+            urlnames = [urlnames]
+        for urlname in urlnames:
+            os.remove(self.ds._findfile(urlname))
+            if self.verbose >= 3:
+                from radis.misc.printer import printg
+
+                printg(f"... removed downloaded cache file for {urlname}")
+
+    def load(
+        self,
+        local_files,
+        isotope,
+        load_wavenum_min,
+        load_wavenum_max,
+        engine="pytables",
+    ):
+        if engine == "pytables":
+            df_all = []
+            for local_file in local_files:
+                df_all.append(
+                    hdf2df(
+                        local_file,
+                        isotope=isotope,
+                        load_wavenum_min=load_wavenum_min,
+                        load_wavenum_max=load_wavenum_max,
+                        verbose=self.verbose,
+                    )
+                )
+            return pd.concat(df_all)
+
+        elif engine in ["vaex", "h5py"]:
+            raise NotImplementedError
+        else:
+            raise ValueError(engine)
+
+    def get_nrows(self, local_file, engine="pytables"):
+        if engine == "pytables":
+            with pd.HDFStore(local_file, "r") as store:
+                nrows = store.get_storer("df").nrows
+
+        elif engine in ["vaex", "h5py"]:
+            raise NotImplementedError
+        else:
+            raise ValueError(engine)
+        return nrows
+
+
+def register_database(
+    databank_name, path_list, molecule, wmin, wmax, download_date, urlname, verbose
+):
+    """Add to registered databases in RADIS config file.
+
+    If database exists, assert it has the same entries.
+
+    Parameters
+    ----------
+    databank_name: str
+        name of the database in :ref:`~/radis.json config file <label_lbl_config_file>`
+
+    Other Parameters
+    ----------------
+    verbose: bool
+
+    Returns
+    -------
+    None:
+        adds to :ref:`~/radis.json <label_lbl_config_file>` with all the input
+        parameters. Also adds ::
+
+            format : "hitemp-radisdb"
+            parfuncfmt : "hapi"   # TIPS-2017 for equilibrium partition functions
+
+        And if the molecule is in :py:attr:`~radis.db.MOLECULES_LIST_NONEQUILIBRIUM`::
+
+            levelsfmt : "radis"   # use RADIS spectroscopic constants for rovibrational energies (nonequilibrium)
+
+    """
+    dict_entries = {
+        "info": f"HITEMP {molecule} lines ({wmin:.1f}-{wmax:.1f} cm-1) with TIPS-2017 (through HAPI) for partition functions",
+        "path": path_list,
+        "format": "hitemp-radisdb",
+        "parfuncfmt": "hapi",
+        "wavenumber_min": f"{wmin}",
+        "wavenumber_max": f"{wmax}",
+        "download_date": download_date,
+        "download_url": urlname,
+    }
+
+    if molecule in MOLECULES_LIST_NONEQUILIBRIUM:
+        dict_entries[
+            "info"
+        ] += " and RADIS spectroscopic constants for rovibrational energies (nonequilibrium)"
+        dict_entries["levelsfmt"] = "radis"
+
+    # Register database in ~/radis.json to be able to use it with load_databank()
+    try:
+        addDatabankEntries(databank_name, dict_entries)
+    except DatabaseAlreadyExists as err:
+        # Check that the existing database had the same entries
+        try:
+            from radis.misc.config import getDatabankEntries
+
+            for k, v in getDatabankEntries(databank_name).items():
+                if k == "download_date":
+                    continue
+                assert dict_entries[k] == v
+            # TODO @dev : replace once we have configfile as JSON (https://github.com/radis/radis/issues/167 )
+        except AssertionError:
+            raise DatabaseAlreadyExists(
+                f"{databank_name} already exists in your ~/radis.json config file, "
+                + f"with different key `{k}` : `{v}` (~/radis.json) ≠ `{dict_entries[k]}` (new). "
+                + "If you're sure of what you're doing, fix the registered database in ~/radis.json. "
+                + "Else, remove it from your config file, or choose a different name "
+                + "for the downloaded database with `fetch_hitemp(databank_name=...)`, "
+                + "and restart."
+            ) from err
+        else:  # no other error raised
+            if verbose:
+                print(
+                    f"{databank_name} already registered in ~/radis.json config file, with the same parameters."
+                )

--- a/radis/misc/progress_bar.py
+++ b/radis/misc/progress_bar.py
@@ -24,6 +24,11 @@ class ProgressBar:
     active: bool
         if ``False``, do not show anything (tip : feed it a ``verbose`` argument)
 
+    Other Parameters
+    ----------------
+    t0: float
+        initializes starting time at ``t0`` (useful for successive loops)
+
     Example
     -------
     add a progress bar in a loop::
@@ -40,9 +45,11 @@ class ProgressBar:
     # Todo: One day extend for multiprocss with several progress values?
     # https://stackoverflow.com/questions/7392779/is-it-possible-to-print-a-string-at-a-certain-screen-position-inside-idle
 
-    def __init__(self, N, active=True):
+    def __init__(self, N, active=True, t0=None):
 
         self.t0 = time()
+        if t0 is not None:
+            self.t0 -= t0
         self.N = N
         self.active = active
 

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -2091,6 +2091,11 @@ class Spectrum(object):
              If areas before and after resampling differ by
              more than that an error is raised.
 
+        Returns
+        -------
+        Spectrum : same Spectrum, with new spectral arrays.
+            Allows :ref:`chaining <label_spectrum_chaining>`
+
 
         Notes
         -----
@@ -2636,6 +2641,10 @@ class Spectrum(object):
     def get_conditions(self):
         """Get all physical / computational parameters.
 
+
+        .. minigallery:: radis.spectrum.spectrum.Spectrum.get_conditions
+            :add-heading:
+
         See Also
         --------
         :py:meth:`~radis.spectrum.Spectrum.print_conditions`,
@@ -2645,19 +2654,28 @@ class Spectrum(object):
         return self.conditions
 
     def print_conditions(self, **kwargs):
-        """Prints all physical / computational parameters. You can also simply
-        print the Spectrum object directly::
-
-            print(s)
+        """Prints all physical / computational parameters.
 
         Parameters
         ----------
         kwargs: dict
             refer to :py:func:`~radis.spectrum.utils.print_conditions`
 
+        Examples
+        --------
+        ::
+            s.print_conditions()
+
+        You can also simply print the Spectrum object directly::
+
+            print(s)
+
+        .. minigallery:: radis.spectrum.spectrum.Spectrum.print_conditions
+            :add-heading:
+
+
         See Also
         --------
-
         :py:meth:`~radis.spectrum.spectrum.Spectrum.get_conditions`,
         :py:func:`~radis.spectrum.utils.print_conditions`,
         :ref:`the Spectrum page <label_spectrum>`
@@ -2740,6 +2758,8 @@ class Spectrum(object):
             s2 = load_spec('test.spec')
             s2.update()                           # regenerate missing quantities
 
+        .. minigallery:: radis.spectrum.spectrum.Spectrum.store
+            :add-heading:
 
         See Also
         --------
@@ -2852,9 +2872,13 @@ class Spectrum(object):
 
         Returns
         -------
-        s: Spectrum
-            resampled Spectrum object. If using ``inplace=True``, the Spectrum
+        Spectrum : resampled Spectrum object. If using ``inplace=True``, the Spectrum
             object has been modified anyway.
+
+        Examples
+        --------
+
+        .. minigallery:: radis.spectrum.spectrum.Spectrum.resample
 
         See Also
         --------
@@ -3118,6 +3142,10 @@ class Spectrum(object):
             default ``True``
         quantity: 'all', or one of 'radiance_noslit', 'absorbance', etc.
             if not 'all', copy only one quantity. Default ``'all'``
+
+        .. minigallery:: radis.spectrum.spectrum.Spectrum.copy
+            :add-heading:
+
         """
         try:
             return self.__copy__(copy_lines=copy_lines, quantity=quantity)
@@ -3287,6 +3315,9 @@ class Spectrum(object):
         :meth:`~radis.spectrum.spectrum.Spectrum.compare_with` internally::
 
             s1 == s2       # will return True or False
+
+        .. minigallery:: radis.spectrum.spectrum.Spectrum.compare_with
+            :add-heading:
 
 
         See Also
@@ -3491,6 +3522,9 @@ class Spectrum(object):
         Use it to chain other commands ::
 
             s.take('radiance').normalize().plot()
+
+        .. minigallery:: radis.spectrum.spectrum.Spectrum.take
+            :add-heading:
 
         """
 

--- a/radis/test/io/test_hitemp.py
+++ b/radis/test/io/test_hitemp.py
@@ -154,7 +154,9 @@ def test_fetch_hitemp_all_molecules(molecule, verbose=True, *args, **kwargs):
         - chunksize=1000 --> 90s  ,  1 iteration << 1s
     """
 
-    df = fetch_hitemp(molecule, columns=["int", "wav"], verbose=verbose)
+    df, local_files = fetch_hitemp(
+        molecule, columns=["int", "wav"], verbose=verbose, return_local_path=True
+    )
 
     assert f"HITEMP-{molecule}" in getDatabankList()
 
@@ -292,11 +294,11 @@ if __name__ == "__main__":
     test_relevant_files_filter()
     test_fetch_hitemp_OH()
     test_partial_loading()
+    test_calc_hitemp_CO_noneq()
     test_fetch_hitemp_partial_download_CO2()
-    # test_calc_hitemp_spectrum()
-    # test_fetch_hitemp_all_molecules("OH")
-    # test_fetch_hitemp_all_molecules("CO")
-    # test_fetch_hitemp_all_molecules("N2O", verbose=3)
-    # test_fetch_hitemp_all_molecules("NO", verbose=3)
-    # test_fetch_hitemp_all_molecules("CO2", verbose=3)
-    # test_calc_hitemp_CO_noneq()
+    test_calc_hitemp_spectrum()
+    test_fetch_hitemp_all_molecules("OH")
+    test_fetch_hitemp_all_molecules("CO")
+    test_fetch_hitemp_all_molecules("CO2", verbose=3)
+    test_fetch_hitemp_all_molecules("N2O", verbose=3)
+    test_fetch_hitemp_all_molecules("NO", verbose=3)

--- a/radis/test/io/test_hitemp.py
+++ b/radis/test/io/test_hitemp.py
@@ -8,7 +8,7 @@ Created on Tue Feb  2 13:51:40 2021
 
 import pytest
 
-from radis.io.hitemp import HITEMP_SOURCE_FILES, INFO_HITEMP_LINE_COUNT, fetch_hitemp
+from radis.io.hitemp import fetch_hitemp, HITEMP_MOLECULES, get_url_and_Nlines
 from radis.misc.config import getDatabankList
 
 
@@ -40,7 +40,7 @@ def test_fetch_hitemp_OH(verbose=True, *args, **kwargs):
 @pytest.mark.needs_connection
 @pytest.mark.download_large_databases
 @pytest.mark.parametrize(
-    "molecule", [mol for mol, url in HITEMP_SOURCE_FILES.items() if url]
+    "molecule", [mol for mol in HITEMP_MOLECULES]
 )
 def test_fetch_hitemp_all_molecules(molecule, verbose=False, *args, **kwargs):
     """Test fetch HITEMP for all molecules whose download URL is available.
@@ -72,8 +72,10 @@ def test_fetch_hitemp_all_molecules(molecule, verbose=False, *args, **kwargs):
     df = fetch_hitemp(molecule, verbose=verbose)
 
     assert f"HITEMP-{molecule}" in getDatabankList()
+    
+    url, Nlines = get_url_and_Nlines(molecule)
 
-    assert len(df) == INFO_HITEMP_LINE_COUNT[molecule]
+    assert len(df) == Nlines
 
 
 @pytest.mark.needs_connection

--- a/radis/test/io/test_hitemp.py
+++ b/radis/test/io/test_hitemp.py
@@ -12,6 +12,47 @@ from radis.io.hitemp import HITEMP_MOLECULES, fetch_hitemp, get_url_and_Nlines
 from radis.misc.config import getDatabankList
 
 
+@pytest.mark.fast
+def test_relevant_files_filter():
+    from radis.io.hitemp import keep_only_relevant
+
+    files = [
+        "02_00000-00500_HITEMP2010.zip",
+        "02_00500-00625_HITEMP2010.zip",
+        "02_00625-00750_HITEMP2010.zip",
+        "02_00750-01000_HITEMP2010.zip",
+        "02_01000-01500_HITEMP2010.zip",
+        "02_01500-02000_HITEMP2010.zip",
+        "02_02000-02125_HITEMP2010.zip",
+        "02_02125-02250_HITEMP2010.zip",
+        "02_02250-02500_HITEMP2010.zip",
+        "02_02500-03000_HITEMP2010.zip",
+        "02_03000-03250_HITEMP2010.zip",
+        "02_03250-03500_HITEMP2010.zip",
+        "02_03500-03750_HITEMP2010.zip",
+        "02_03750-04000_HITEMP2010.zip",
+        "02_04000-04500_HITEMP2010.zip",
+        "02_04500-05000_HITEMP2010.zip",
+        "02_05000-05500_HITEMP2010.zip",
+        "02_05500-06000_HITEMP2010.zip",
+        "02_06000-06500_HITEMP2010.zip",
+        "02_06500-12785_HITEMP2010.zip",
+    ]
+
+    assert keep_only_relevant(files) == files
+    assert keep_only_relevant(files, wavenum_max=300) == [
+        "02_00000-00500_HITEMP2010.zip"
+    ]
+    assert keep_only_relevant(files, wavenum_min=7000) == [
+        "02_06500-12785_HITEMP2010.zip"
+    ]
+    assert keep_only_relevant(files, wavenum_min=600, wavenum_max=800) == [
+        "02_00500-00625_HITEMP2010.zip",
+        "02_00625-00750_HITEMP2010.zip",
+        "02_00750-01000_HITEMP2010.zip",
+    ]
+
+
 @pytest.mark.needs_connection
 def test_fetch_hitemp_OH(verbose=True, *args, **kwargs):
     """Test proper download of HITEMP OH database.
@@ -93,18 +134,23 @@ def test_partial_loading(*args, **kwargs):
     assert df.wav.max() <= wmax
 
     # Test with isotope:
+    wmin = 0
+    wmax = 300
     df = fetch_hitemp("OH", load_wavenum_min=wmin, load_wavenum_max=wmax, isotope="2")
     assert df.iso.unique() == 2
+    df = fetch_hitemp("OH", load_wavenum_min=wmin, load_wavenum_max=wmax, isotope="1,2")
+    assert set(df.iso.unique()) == {1, 2}
 
-    # multiple isotope selection not implemetned with vaex
-    with pytest.raises(NotImplementedError):
-        fetch_hitemp(
-            "OH",
-            load_wavenum_min=wmin,
-            load_wavenum_max=wmax,
-            isotope="1,2,3",
-            engine="vaex",
-        )
+    # TODO : active with vaex engine implementation
+    # # multiple isotope selection not implemetned with vaex
+    # with pytest.raises(NotImplementedError):
+    #     fetch_hitemp(
+    #         "OH",
+    #         load_wavenum_min=wmin,
+    #         load_wavenum_max=wmax,
+    #         isotope="1,2,3",
+    #         engine="vaex",
+    #     )
 
 
 @pytest.mark.needs_connection
@@ -181,12 +227,14 @@ def test_calc_hitemp_CO_noneq(verbose=True, *args, **kwargs):
 
 
 if __name__ == "__main__":
-    test_fetch_hitemp_OH()
-    test_partial_loading()
-    test_calc_hitemp_spectrum()
-    test_fetch_hitemp_all_molecules("OH")
-    test_fetch_hitemp_all_molecules("CO")
-    test_fetch_hitemp_all_molecules("N2O", verbose=3)
-    test_fetch_hitemp_all_molecules("NO", verbose=3)
+    test_relevant_files_filter()
     test_fetch_hitemp_all_molecules("CO2", verbose=3)
-    test_calc_hitemp_CO_noneq()
+    # test_fetch_hitemp_OH()
+    # test_partial_loading()
+    # test_calc_hitemp_spectrum()
+    # test_fetch_hitemp_all_molecules("OH")
+    # test_fetch_hitemp_all_molecules("CO")
+    # test_fetch_hitemp_all_molecules("N2O", verbose=3)
+    # test_fetch_hitemp_all_molecules("NO", verbose=3)
+    # test_fetch_hitemp_all_molecules("CO2", verbose=3)
+    # test_calc_hitemp_CO_noneq()

--- a/radis/test/io/test_hitemp.py
+++ b/radis/test/io/test_hitemp.py
@@ -8,7 +8,7 @@ Created on Tue Feb  2 13:51:40 2021
 
 import pytest
 
-from radis.io.hitemp import fetch_hitemp, HITEMP_MOLECULES, get_url_and_Nlines
+from radis.io.hitemp import HITEMP_MOLECULES, fetch_hitemp, get_url_and_Nlines
 from radis.misc.config import getDatabankList
 
 
@@ -39,9 +39,7 @@ def test_fetch_hitemp_OH(verbose=True, *args, **kwargs):
 
 @pytest.mark.needs_connection
 @pytest.mark.download_large_databases
-@pytest.mark.parametrize(
-    "molecule", [mol for mol in HITEMP_MOLECULES]
-)
+@pytest.mark.parametrize("molecule", [mol for mol in HITEMP_MOLECULES])
 def test_fetch_hitemp_all_molecules(molecule, verbose=False, *args, **kwargs):
     """Test fetch HITEMP for all molecules whose download URL is available.
 
@@ -72,7 +70,7 @@ def test_fetch_hitemp_all_molecules(molecule, verbose=False, *args, **kwargs):
     df = fetch_hitemp(molecule, verbose=verbose)
 
     assert f"HITEMP-{molecule}" in getDatabankList()
-    
+
     url, Nlines = get_url_and_Nlines(molecule)
 
     assert len(df) == Nlines
@@ -93,6 +91,20 @@ def test_partial_loading(*args, **kwargs):
     df = fetch_hitemp("OH", load_wavenum_min=wmin, load_wavenum_max=wmax)
     assert df.wav.min() >= wmin
     assert df.wav.max() <= wmax
+
+    # Test with isotope:
+    df = fetch_hitemp("OH", load_wavenum_min=wmin, load_wavenum_max=wmax, isotope="2")
+    assert df.iso.unique() == 2
+
+    # multiple isotope selection not implemetned with vaex
+    with pytest.raises(NotImplementedError):
+        fetch_hitemp(
+            "OH",
+            load_wavenum_min=wmin,
+            load_wavenum_max=wmax,
+            isotope="1,2,3",
+            engine="vaex",
+        )
 
 
 @pytest.mark.needs_connection
@@ -176,4 +188,5 @@ if __name__ == "__main__":
     test_fetch_hitemp_all_molecules("CO")
     test_fetch_hitemp_all_molecules("N2O", verbose=3)
     test_fetch_hitemp_all_molecules("NO", verbose=3)
+    test_fetch_hitemp_all_molecules("CO2", verbose=3)
     test_calc_hitemp_CO_noneq()

--- a/radis/test/io/test_hitemp.py
+++ b/radis/test/io/test_hitemp.py
@@ -8,7 +8,7 @@ Created on Tue Feb  2 13:51:40 2021
 
 import pytest
 
-from radis.io.hitemp import HITEMP_MOLECULES, fetch_hitemp, get_url_and_Nlines
+from radis.io.hitemp import HITEMP_MOLECULES, HITEMPDatabaseManager, fetch_hitemp
 from radis.misc.config import getDatabankList
 
 
@@ -39,14 +39,14 @@ def test_relevant_files_filter():
         "02_06500-12785_HITEMP2010.zip",
     ]
 
-    assert keep_only_relevant(files) == files
-    assert keep_only_relevant(files, wavenum_max=300) == [
+    assert keep_only_relevant(files)[0] == files
+    assert keep_only_relevant(files, wavenum_max=300)[0] == [
         "02_00000-00500_HITEMP2010.zip"
     ]
-    assert keep_only_relevant(files, wavenum_min=7000) == [
+    assert keep_only_relevant(files, wavenum_min=7000)[0] == [
         "02_06500-12785_HITEMP2010.zip"
     ]
-    assert keep_only_relevant(files, wavenum_min=600, wavenum_max=800) == [
+    assert keep_only_relevant(files, wavenum_min=600, wavenum_max=800)[0] == [
         "02_00500-00625_HITEMP2010.zip",
         "02_00625-00750_HITEMP2010.zip",
         "02_00750-01000_HITEMP2010.zip",
@@ -81,7 +81,7 @@ def test_fetch_hitemp_OH(verbose=True, *args, **kwargs):
 @pytest.mark.needs_connection
 @pytest.mark.download_large_databases
 @pytest.mark.parametrize("molecule", [mol for mol in HITEMP_MOLECULES])
-def test_fetch_hitemp_all_molecules(molecule, verbose=False, *args, **kwargs):
+def test_fetch_hitemp_all_molecules(molecule, verbose=True, *args, **kwargs):
     """Test fetch HITEMP for all molecules whose download URL is available.
 
     ..warning::
@@ -112,7 +112,8 @@ def test_fetch_hitemp_all_molecules(molecule, verbose=False, *args, **kwargs):
 
     assert f"HITEMP-{molecule}" in getDatabankList()
 
-    url, Nlines = get_url_and_Nlines(molecule)
+    ldb = HITEMPDatabaseManager(name=f"HITEMP-{molecule}", molecule=molecule)
+    url, Nlines = ldb.fetch_url_and_Nlines()
 
     assert len(df) == Nlines
 
@@ -228,13 +229,13 @@ def test_calc_hitemp_CO_noneq(verbose=True, *args, **kwargs):
 
 if __name__ == "__main__":
     test_relevant_files_filter()
-    test_fetch_hitemp_all_molecules("CO2", verbose=3)
-    # test_fetch_hitemp_OH()
-    # test_partial_loading()
+    # test_fetch_hitemp_all_molecules("CO2", verbose=3)
+    test_fetch_hitemp_OH()
+    test_partial_loading()
     # test_calc_hitemp_spectrum()
-    # test_fetch_hitemp_all_molecules("OH")
-    # test_fetch_hitemp_all_molecules("CO")
-    # test_fetch_hitemp_all_molecules("N2O", verbose=3)
+    test_fetch_hitemp_all_molecules("OH")
+    test_fetch_hitemp_all_molecules("CO")
+    test_fetch_hitemp_all_molecules("N2O", verbose=3)
     # test_fetch_hitemp_all_molecules("NO", verbose=3)
     # test_fetch_hitemp_all_molecules("CO2", verbose=3)
     # test_calc_hitemp_CO_noneq()

--- a/radis/test/io/test_hitran_cdsd.py
+++ b/radis/test/io/test_hitran_cdsd.py
@@ -303,5 +303,5 @@ def _run_testcases(verbose=True, *args, **kwargs):
 
 
 if __name__ == "__main__":
-    # print("Testing io.py: ", _run_testcases(verbose=True))
+    print("Testing test_hitran_cdsd.py: ", _run_testcases(verbose=True))
     test_cache_regeneration(verbose=3)

--- a/radis/tools/line_survey.py
+++ b/radis/tools/line_survey.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from radis.db.classes import get_molecule, get_molecule_identifier
 from radis.io.cdsd import columns_4000 as cdsd4000columns
-from radis.io.cdsd import columns_hitemp as cdsdcolumns
+from radis.io.cdsd import columns_cdsdhitemp as cdsdhitempcolumns
 from radis.io.hitran import (  # HITRAN_CLASS2,; HITRAN_CLASS3,; HITRAN_CLASS6,; HITRAN_CLASS7,; HITRAN_CLASS8,; HITRAN_CLASS9,; HITRAN_CLASS10,
     HITRAN_CLASS1,
     HITRAN_CLASS4,
@@ -187,7 +187,7 @@ def LineSurvey(
     if dbformat in ["hitran", "hitemp"]:
         columndescriptor = hitrancolumns
     elif dbformat == "cdsd-hitemp":
-        columndescriptor = cdsdcolumns
+        columndescriptor = cdsdhitempcolumns
     elif dbformat == "cdsd-4000":
         columndescriptor = cdsd4000columns
     else:


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request implements automatic downloads for HITEMP H2O and CO2.
https://github.com/radis/radis/pull/203
https://github.com/radis/radis/issues/210

There is still an open debate on how exactly to handle missing lines. To prevent issues with empty global/local quanta strings, the quantum numbers are returned as `np.float64` for now, which is definitely not a great solution. See discussion over at https://github.com/radis/radis/issues/280.

Some points of note:

* The fetcher now tests whether the databank name already exists _before_ downloading the database. Some checks may have been lost after moving it to the front.
* The progress bar and download updates don't show properly on my system so I can't say how well these are looking.
* The H2O HITEMP database has 100M lines, which is getting close to CDSD4000 (620M). I haven't tried it, but I think this code should be very easy to adapt for downloading CDSD4000 as well.

For my system CO2-HITEMP takes ~400s and H2O-HITEMP takes ~4000s to download and parse.


