### PR TITLE
Updated convolve_with_slit with warnings if instrumental function has large near-zero wings

### DIFF
--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -2355,7 +2355,7 @@ class Spectrum(object):
         imported from an experimental slit function (path to a text file or
         numpy array of shape n*2). Convoluted spectra are cut on the edge
         compared to non-convoluted spectra, to remove side effects. See
-        ``mode=`` to change this behaviour.
+        ``mode=`` to change this behaviour. 
 
         Warning with units: read about ``'unit'`` and ``'return_unit'`` parameters.
 
@@ -2372,6 +2372,8 @@ class Spectrum(object):
                 wavelengths and intensity (doesn't have to be normalized)
             If ``array``:
                 format must be 2-columns with wavelengths and intensity (doesn't have to be normalized)
+                It is recommended to truncate the input slit function to its minimum useful spectral
+                extension (see Notes of :func:`~radis.tools.slit.convolve_with_slit`).
         unit: ``'nm'`` or ``'cm-1'``
             unit of slit_function (FWHM, or imported file)
         shape: ``'triangular'``, ``'trapezoidal'``, ``'gaussian'``, or any of :data:`~radis.tools.slit.SLIT_SHAPES`

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -2355,7 +2355,7 @@ class Spectrum(object):
         imported from an experimental slit function (path to a text file or
         numpy array of shape n*2). Convoluted spectra are cut on the edge
         compared to non-convoluted spectra, to remove side effects. See
-        ``mode=`` to change this behaviour. 
+        ``mode=`` to change this behaviour.
 
         Warning with units: read about ``'unit'`` and ``'return_unit'`` parameters.
 

--- a/radis/tools/slit.py
+++ b/radis/tools/slit.py
@@ -647,7 +647,6 @@ def convolve_with_slit(
     w_range = abs(w[-1] - w[0])
     w_slit_range = abs(w_slit[-1] - w_slit[0])
     slit_FWHM = get_FWHM(w_slit, I_slit)
-    print(slit_FWHM)
 
     if w_slit_range >10*slit_FWHM:
         warn(

--- a/radis/tools/slit.py
+++ b/radis/tools/slit.py
@@ -673,10 +673,10 @@ def convolve_with_slit(
     if np.abs(w_range) < np.abs(w_slit_range):
         if mode == "valid":
             raise AssertionError(
-                f"Slit spectral range > Spectrum spectral range and mode is set to valid!\n" \
-              + f"Slit function is provided with a spectral range ({w_slit_range:.1f} nm) larger than " \
-              + f"the spectral range of the spectrum ({w_range:.1f} nm). The output spectrum is therefore empty! " \
-              + f"Set mode to same in this case. However, we recommend truncating the input slit function. "
+              f"Slit function is provided with a spectral range ({w_slit_range:.1f} {waveunit}) larger than " \
+              + f"the spectral range of the spectrum ({w_range:.1f} {waveunit}) : the output spectrum will therefore be empty " \
+              + f"as boundary effects of the convolution are automatically discarded. If you still want to apply the slit "
+              + f"despite potential boundary effects, set `mode='same'`. However, we recommend truncating the input slit function if possible, or compute the spectrum on a larger spectral range. "
               + f"See radis documentation about convolve_with_slit for more information."
             )
         else:

--- a/radis/tools/slit.py
+++ b/radis/tools/slit.py
@@ -78,7 +78,7 @@ def get_slit_function(
     verbose=True,
     auto_recenter_crop=True,
     *args,
-    **kwargs
+    **kwargs,
 ):
     """Import or generate slit function in correct wavespace
     Give a file path to import, or a float / tuple to generate arbitrary shapes
@@ -278,7 +278,7 @@ def get_slit_function(
                 wunit=return_unit,
                 scale=scale_slit,
                 *args,
-                **kwargs
+                **kwargs,
             )
 
         # Insert other slit shapes here
@@ -294,7 +294,7 @@ def get_slit_function(
                 wunit=return_unit,
                 scale=scale_slit,
                 *args,
-                **kwargs
+                **kwargs,
             )
 
         elif shape == "trapezoidal":
@@ -361,7 +361,7 @@ def get_slit_function(
             wunit=return_unit,
             scale=scale_slit,
             *args,
-            **kwargs
+            **kwargs,
         )
 
     # Or import it from file or numpy input
@@ -385,7 +385,7 @@ def get_slit_function(
             auto_recenter=auto_recenter_crop,
             bplot=False,  # we will plot after resampling
             *args,
-            **kwargs
+            **kwargs,
         )
 
         # ... get unit
@@ -501,13 +501,13 @@ def convolve_with_slit(
 ):
     """Convolves spectrum (w,I) with instrumental slit function (w_slit, I_slit)
 
-        Returns a convolved spectrum on a valid range. 
+        Returns a convolved spectrum on a valid range.
 
         Check Notes section below for more details about its implementation.
 
         This function is called directly from a :py:class:`~radis.spectrum.spectrum.Spectrum`
         object with the :py:meth:`~radis.spectrum.spectrum.Spectrum.apply_slit` method.
-    
+
 
     .. warning::
 
@@ -534,11 +534,11 @@ def convolve_with_slit(
 
         ``'same'``:
         returns output of same length as initial spectra,
-        but boundary effects are still visible. 
+        but boundary effects are still visible.
 
         ``'valid'``:
         returns output of length len(spectra) - len(slit) + 1, assuming len(I_slit) < len(I),
-        for which lines outside of the calculated range have no impact. 
+        for which lines outside of the calculated range have no impact.
 
         Default ``'valid'``.
 
@@ -581,8 +581,8 @@ def convolve_with_slit(
     two adjacent points). The minimal step between values of ``w`` is used to determine
     this reference spacing.
 
-    If the slit function covers a spectral interval much larger than its 
-    Full Width a Half Maximum (FWHM), it will potentially add non-zero elements in the sum 
+    If the slit function covers a spectral interval much larger than its
+    Full Width a Half Maximum (FWHM), it will potentially add non-zero elements in the sum
     and mix spectral features that are much further away from each other than the FWHM, as
     it would have been expected.
     For an experimental slit function, this also means introducing more noise and artificial
@@ -591,9 +591,9 @@ def convolve_with_slit(
 
     For instance, if you have an instrumental slit function that looks like so, we recommend
     to cut it where the vertical lines are drawn.
-    
+
     ::
-    
+
         I_slit  ^
                 |     |   _   |
                 |     |  / \\  |
@@ -603,13 +603,13 @@ def convolve_with_slit(
                     cut       cut        w_slit
 
     When we apply a slit function, we should consider the contributions of spectral features outside
-    of the initial spectral range (i.e. ``w[0]`` - FWHM, ``w[-1]`` + FWHM) that would matter to reproduce 
+    of the initial spectral range (i.e. ``w[0]`` - FWHM, ``w[-1]`` + FWHM) that would matter to reproduce
     the entire spectrum. Those points are probably not taken into account during the simulation and
     it could be interesting to extend the spectral range of ``w`` when possible to gauge this contribution.
 
     Since, we don't have access to this extra points, we truncated the output spectrum to the spectral
-    range we can trust (no missing information). The ``valid`` mode operates this truncation by cutting 
-    the edge of the spectrum ever a spectral width corresponding to the spectral width of the provided 
+    range we can trust (no missing information). The ``valid`` mode operates this truncation by cutting
+    the edge of the spectrum ever a spectral width corresponding to the spectral width of the provided
     slit function. This is meant to remove incorrect points on the edge. We recommend using this mode.
     You can however access those removed points using the ``same`` mode (at your own risk).
 
@@ -648,29 +648,29 @@ def convolve_with_slit(
     w_slit_range = abs(w_slit[-1] - w_slit[0])
     slit_FWHM = get_FWHM(w_slit, I_slit)
 
-    if w_slit_range >10*slit_FWHM:
+    if w_slit_range > 10 * slit_FWHM:
         warn(
-            f"FWHM >> spectral range!\n" \
-          + f"Slit Function is provided with a spectral range {w_slit_range:.1f} nm that is much " \
-          + f"wider than its estimated FWHM {slit_FWHM:.1f}. We recommend truncating the input " \
-          + f"slit function. See radis documentation about convolve_with_slit for more information."
+            f"FWHM >> spectral range!\n"
+            + f"Slit Function is provided with a spectral range {w_slit_range:.1f} nm that is much "
+            + f"wider than its estimated FWHM {slit_FWHM:.1f}. We recommend truncating the input "
+            + f"slit function. See radis documentation about convolve_with_slit for more information."
         )
 
     if w_range < w_slit_range:
         if mode == "valid":
             raise AssertionError(
-              f"Slit function is provided with a spectral range ({w_slit_range:.1f} {waveunit}) larger than " \
-              + f"the spectral range of the spectrum ({w_range:.1f} {waveunit}) : the output spectrum will therefore be empty " \
-              + f"as boundary effects of the convolution are automatically discarded. If you still want to apply the slit "
-              + f"despite potential boundary effects, set `mode='same'`. However, we recommend truncating the input slit function if possible, or compute the spectrum on a larger spectral range. "
-              + f"See radis documentation about convolve_with_slit for more information."
+                f"Slit function is provided with a spectral range ({w_slit_range:.1f} {waveunit}) larger than "
+                + f"the spectral range of the spectrum ({w_range:.1f} {waveunit}) : the output spectrum will therefore be empty "
+                + f"as boundary effects of the convolution are automatically discarded. If you still want to apply the slit "
+                + f"despite potential boundary effects, set `mode='same'`. However, we recommend truncating the input slit function if possible, or compute the spectrum on a larger spectral range. "
+                + f"See radis documentation about convolve_with_slit for more information."
             )
         else:
             warn(
-                f"Slit spectral range > Spectrum spectral range!\n" \
-              + f"Slit function is provided with a spectral range ({w_slit_range:.1f} nm) larger than " \
-              + f"the spectral range of the spectrum ({w_range:.1f} nm). We recommend truncating the input " \
-              + f"slit function. See radis documentation about convolve_with_slit for more information."
+                f"Slit spectral range > Spectrum spectral range!\n"
+                + f"Slit function is provided with a spectral range ({w_slit_range:.1f} nm) larger than "
+                + f"the spectral range of the spectrum ({w_range:.1f} nm). We recommend truncating the input "
+                + f"slit function. See radis documentation about convolve_with_slit for more information."
             )
 
     # 2. Interpolate the slit function on the spectrum grid, resample it if not
@@ -804,12 +804,12 @@ def get_FWHM(w, I, return_index=False):
     def get_zero(x1, y1, x2, y2):
         """
         Linear interpolation on data to get zero
-        Return location of zero by solving for f(x) = (y2-y1)/(x2-x1) * (x-x1) + y1 = 0 
+        Return location of zero by solving for f(x) = (y2-y1)/(x2-x1) * (x-x1) + y1 = 0
         """
-        return x1 - y1*(x2-x1)/(y2-y1)
+        return x1 - y1 * (x2 - x1) / (y2 - y1)
 
-    wmin = get_zero(w[xmin-1], I_offset[xmin-1], w[xmin], I_offset[xmin])
-    wmax = get_zero(w[xmax], I_offset[xmax], w[xmax+1], I_offset[xmax+1])
+    wmin = get_zero(w[xmin - 1], I_offset[xmin - 1], w[xmin], I_offset[xmin])
+    wmax = get_zero(w[xmax], I_offset[xmax], w[xmax + 1], I_offset[xmax + 1])
 
     if return_index:
         return abs(wmax - wmin), xmin, xmax

--- a/radis/tools/slit.py
+++ b/radis/tools/slit.py
@@ -644,20 +644,6 @@ def convolve_with_slit(
 
     # Assert slit function is thin enough
 
-    def lin_interp(x, y, i, half):
-        return x[i] + (x[i+1] - x[i]) * ((half - y[i]) / (y[i+1] - y[i]))
-
-    def half_max_x(x, y):
-        half = max(y)/2.0
-        signs = np.sign(np.add(y, -half))
-        zero_crossings = (signs[0:-2] != signs[1:-1])
-        zero_crossings_i = np.where(zero_crossings)[0]
-        return [lin_interp(x, y, zero_crossings_i[0], half),
-                lin_interp(x, y, zero_crossings_i[1], half)]
-    def fwhm(x,y):
-        hmx = half_max_x(x,y)
-        return hmx[1] - hmx[0]
-
     w_range = abs(w[-1] - w[0])
     w_slit_range = abs(w_slit[-1] - w_slit[0])
     slit_FWHM = get_FWHM(w_slit, I_slit)

--- a/radis/tools/slit.py
+++ b/radis/tools/slit.py
@@ -500,11 +500,14 @@ def convolve_with_slit(
     waveunit=None,
 ):
     """Convolves spectrum (w,I) with instrumental slit function (w_slit, I_slit)
-    Returns a convolved spectrum on a valid range.
+
+        Returns a convolved spectrum on a valid range. 
+
+        Check Notes section below for more details about its implementation.
 
         This function is called directly from a :py:class:`~radis.spectrum.spectrum.Spectrum`
         object with the :py:meth:`~radis.spectrum.spectrum.Spectrum.apply_slit` method.
-
+    
 
     .. warning::
 
@@ -520,17 +523,24 @@ def convolve_with_slit(
 
     w_slit, I_slit: array
         instrumental slit function  (wavespace unit (nm / cm-1))
+        It is recommended to truncate the input slit function to its minimum spectral
+        extension (see Notes).
 
         .. warning::
 
             Both wavespaces have to be the same!
 
     mode: ``'valid'``, ``'same'``
-        ``'same'`` returns output of same length as initial spectra,
-        but boundary effects are still visible. ``'valid'`` returns
-        output of length len(spectra) - len(slit) + 1, for
-        which lines outside of the calculated range have
-        no impact. Default ``'valid'``.
+
+        ``'same'``:
+        returns output of same length as initial spectra,
+        but boundary effects are still visible. 
+
+        ``'valid'``:
+        returns output of length len(spectra) - len(slit) + 1, assuming len(I_slit) < len(I),
+        for which lines outside of the calculated range have no impact. 
+
+        Default ``'valid'``.
 
     Other Parameters
     ----------------
@@ -561,12 +571,54 @@ def convolve_with_slit(
 
     Notes
     -----
+    The discrete convolution operation is defined as
 
-    Implementation is done in 5 steps:
+    .. math:: (I * I_{slit})[n] = \\sum_{m = -\\infty}^{\\infty} I[m] I_{slit}[n - m]
 
-    - Check input
+    This numerical discrete convolution doesn't take care of respecting the physical distances.
+    Therefore we have to make sure that the ``I`` and ``I_slit`` are expressed using the same
+    spectral spacing (e.g. that ``w`` and ``w`_slit`` have the same step in nm between
+    two adjacent points). The minimal step between values of ``w`` is used to determine
+    this reference spacing.
+
+    If the slit function covers a spectral interval much larger than its 
+    Full Width a Half Maximum (FWHM), it will potentially add non-zero elements in the sum 
+    and mix spectral features that are much further away from each other than the FWHM, as
+    it would have been expected.
+    For an experimental slit function, this also means introducing more noise and artificial
+    broadening. It is thus recommended to truncate the input slit function to its minimum
+    useful spectral range.
+
+    For instance, if you have an instrumental slit function that looks like so, we recommend
+    to cut it where the vertical lines are drawn.
+    
+    ::
+    
+        I_slit  ^
+                |     |   _   |
+                |     |  / \\  |
+                |     | /   \\ |
+               0|_____|/     \\|________
+              --|-----         --------->
+                    cut       cut        w_slit
+
+    When we apply a slit function, we should consider the contributions of spectral features outside
+    of the initial spectral range (i.e. ``w[0]`` - FWHM, ``w[-1]`` + FWHM) that would matter to reproduce 
+    the entire spectrum. Those points are probably not taken into account during the simulation and
+    it could be interesting to extend the spectral range of ``w`` when possible to gauge this contribution.
+
+    Since, we don't have access to this extra points, we truncated the output spectrum to the spectral
+    range we can trust (no missing information). The ``valid`` mode operates this truncation by cutting 
+    the edge of the spectrum ever a spectral width corresponding to the spectral width of the provided 
+    slit function. This is meant to remove incorrect points on the edge. We recommend using this mode.
+    You can however access those removed points using the ``same`` mode (at your own risk).
+
+    Implementation of :func:`~radis.tools.slit.convolve_with_slit` is done in 5 steps:
+
+    - Check input slit function: compare input slit spectral range to spectrum spectral range
+      if ranges are comparable, check FHWM and send a warning.
     - Interpolate the slit function on the spectrum grid, resample it if not
-      evenly spaced
+      evenly spaced (in order to match physical distances)
     - Check slit aspect, plot slit if asked for
     - Convolve!
     - Remove boundary effects
@@ -591,15 +643,49 @@ def convolve_with_slit(
         wunit = waveunit
 
     # Assert slit function is thin enough
-    try:
-        assert abs(w[-1] - w[0]) > abs(w_slit[-1] - w_slit[0])
-    except AssertionError:
-        raise AssertionError(
-            "Slit function is broader ({0:.1f}nm) than spectrum".format(
-                abs(w_slit[-1] - w_slit[0])
-            )
-            + " ({0:.1f}nm). No valid range.".format(abs(w[-1] - w[0]))
+
+    def lin_interp(x, y, i, half):
+        return x[i] + (x[i+1] - x[i]) * ((half - y[i]) / (y[i+1] - y[i]))
+
+    def half_max_x(x, y):
+        half = max(y)/2.0
+        signs = np.sign(np.add(y, -half))
+        zero_crossings = (signs[0:-2] != signs[1:-1])
+        zero_crossings_i = np.where(zero_crossings)[0]
+        return [lin_interp(x, y, zero_crossings_i[0], half),
+                lin_interp(x, y, zero_crossings_i[1], half)]
+    def fwhm(x,y):
+        hmx = half_max_x(x,y)
+        return hmx[1] - hmx[0]
+
+    w_range = w[-1] - w[0]
+    w_slit_range = w_slit[-1] - w_slit[0]
+    slit_FWHM = fwhm(w_slit, I_slit)
+
+    if np.abs(w_slit_range) >10*slit_FWHM:
+        warn(
+            f"FWHM >> spectral range!\n" \
+          + f"Slit Function is provided with a spectral range {w_slit_range:.1f} nm that is much " \
+          + f"wider than its estimated FWHM {slit_FWHM:.1f}. We recommend truncating the input " \
+          + f"slit function. See radis documentation about convolve_with_slit for more information."
         )
+
+    if np.abs(w_range) < np.abs(w_slit_range):
+        if mode == "valid":
+            raise AssertionError(
+                f"Slit spectral range > Spectrum spectral range and mode is set to valid!\n" \
+              + f"Slit function is provided with a spectral range ({w_slit_range:.1f} nm) larger than " \
+              + f"the spectral range of the spectrum ({w_range:.1f} nm). The output spectrum is therefore empty! " \
+              + f"Set mode to same in this case. However, we recommend truncating the input slit function. "
+              + f"See radis documentation about convolve_with_slit for more information."
+            )
+        else:
+            warn(
+                f"Slit spectral range > Spectrum spectral range!\n" \
+              + f"Slit function is provided with a spectral range ({w_slit_range:.1f} nm) larger than " \
+              + f"the spectral range of the spectrum ({w_range:.1f} nm). We recommend truncating the input " \
+              + f"slit function. See radis documentation about convolve_with_slit for more information."
+            )
 
     # 2. Interpolate the slit function on the spectrum grid, resample it if not
     #    evenly spaced

--- a/radis/tools/slit.py
+++ b/radis/tools/slit.py
@@ -658,16 +658,12 @@ def convolve_with_slit(
         hmx = half_max_x(x,y)
         return hmx[1] - hmx[0]
 
-    w_range = w[-1] - w[0]
-    w_slit_range = w_slit[-1] - w_slit[0]
-    slit_FWHM = fwhm(w_slit, I_slit)
-    print(slit_FWHM)
     w_range = abs(w[-1] - w[0])
     w_slit_range = abs(w_slit[-1] - w_slit[0])
     slit_FWHM = get_FWHM(w_slit, I_slit)
     print(slit_FWHM)
 
-    if np.abs(w_slit_range) >10*slit_FWHM:
+    if w_slit_range >10*slit_FWHM:
         warn(
             f"FWHM >> spectral range!\n" \
           + f"Slit Function is provided with a spectral range {w_slit_range:.1f} nm that is much " \
@@ -675,7 +671,7 @@ def convolve_with_slit(
           + f"slit function. See radis documentation about convolve_with_slit for more information."
         )
 
-    if np.abs(w_range) < np.abs(w_slit_range):
+    if w_range < w_slit_range:
         if mode == "valid":
             raise AssertionError(
               f"Slit function is provided with a spectral range ({w_slit_range:.1f} {waveunit}) larger than " \

--- a/radis/tools/slit.py
+++ b/radis/tools/slit.py
@@ -813,7 +813,7 @@ def get_FWHM(w, I, return_index=False):
     wmax = get_zero(w[xmax], I_offset[xmax], w[xmax+1], I_offset[xmax+1])
 
     if return_index:
-        return abs(wmin - wmax), xmin, xmax
+        return abs(wmax - wmin), xmin, xmax
     else:
         return abs(wmax - wmin)
 


### PR DESCRIPTION
updated warnings on convolve_with slit and the documentaiton of the function, modified doc of spectrum to point to the doc of convolve_with_wlit

<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

PR in order to update the documentation and the errors of radis.tools.slit.py convolve_with_slit.

Convolution intervene in mainly 2 places:
- convolution with physical broadening of spectral features during simulation
- convolution with instrumental function to fit simulation to experimental spectra

I did my best to explain to the user what to expect out of the convolution product in the case of intrumental functions.

It is important to tell users how convolution could affect data outside of the know spectral range. 

I modified apply_slit to point to the Notes I wrote in convolve_with_slit.

I transformed the AssertError of convolve with slit with several warnings, that look both at the spectral range and the FWHM of the input experimental slit. IMO, it will better guide users to what they should do in order to improve the output of the convolution.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->