### PR TITLE
do not load energies if equilibrium calculation in calc_spectrum

### DIFF
--- a/radis/lbl/calc.py
+++ b/radis/lbl/calc.py
@@ -588,7 +588,7 @@ def _calc_spectrum(
             # constants (not all molecules are supported!)
             conditions["levelsfmt"] = "radis"
             conditions["lvl_use_cached"] = use_cached
-            conditions["load_energies"] = True
+        conditions["load_energies"] = not _equilibrium
         # Details to identify lines
         conditions["parse_local_global_quanta"] = (not _equilibrium) or export_lines
         sf.fetch_databank(**conditions)
@@ -611,7 +611,6 @@ def _calc_spectrum(
                 # constants (not all molecules are supported!)
                 conditions["levelsfmt"] = "radis"
                 conditions["lvl_use_cached"] = use_cached
-                conditions["load_energies"] = True
         elif databank.endswith(".h5") or databank.endswith(".hdf5"):
             if verbose:
                 print(
@@ -622,7 +621,6 @@ def _calc_spectrum(
             conditions["format"] = "hdf5-radisdb"
             if not _equilibrium:
                 conditions["levelsfmt"] = "radis"
-                conditions["load_energies"] = True
         else:
             raise ValueError(
                 "Couldnt infer the format of the line database file: {0}. ".format(
@@ -632,7 +630,7 @@ def _calc_spectrum(
                 + "and define the format there. More information on "
                 + "https://radis.readthedocs.io/en/latest/lbl/lbl.html#configuration-file"
             )
-
+        conditions["load_energies"] = not _equilibrium
         sf.load_databank(**conditions)
 
     else:  # manual mode: get from user-defined line databases defined in ~/radis.json


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

Fixes #297  ; directly from calc_spectrum 
(was already fixed by https://github.com/radis/radis/pull/252 at the SpectrumFactory level by delaying the loading of rovibrational energies until a noneq calculation was triggered ; here we use the extra information we have with calc_spectrum (is it an eq or non eq calculation) to directly load rovibrational energies from the start. 
