### PR TITLE
do not try to parse comments when loading .spec (json) files

### DIFF
--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -454,10 +454,10 @@ def load_spec(file, binary=True):  # , return_binary_status=False):
     def _load(binary):
         if not binary:
             with open(file, "r") as f:
-                sload = json_tricks.load(f, preserve_order=False, ignore_comments=True)
+                sload = json_tricks.load(f, preserve_order=False, ignore_comments=False)
         else:
             with open(file, "rb") as f:
-                sload = json_tricks.load(f, preserve_order=False, ignore_comments=True)
+                sload = json_tricks.load(f, preserve_order=False, ignore_comments=False)
         return sload
 
     # first try to open with given binary info


### PR DESCRIPTION
Current loading of .spec files with json-tricks [tried to remove comments](https://github.com/mverleg/pyjson_tricks#comments) "#" . This is unecessary as no comments are stored in ".spec" files. 

Removed the option :  ~20% faster loading



---

Example with 275 files : 

```
Loading database co2SpecDatabase_noneq_Tvib3_CDSD_HITEMP_DUNHAM_iso12_cut1e27_broad20cm_1
*** Loading the database with -2 processor(s) (275 files)***
[Parallel(n_jobs=-2)]: Using backend LokyBackend with 7 concurrent workers.
[Parallel(n_jobs=-2)]: Done   4 tasks      | elapsed:   10.9s
[Parallel(n_jobs=-2)]: Done  58 tasks      | elapsed:   28.3s
[Parallel(n_jobs=-2)]: Done 148 tasks      | elapsed:   57.0s
Loaded in 97.52594423294067
[Parallel(n_jobs=-2)]: Done 275 out of 275 | elapsed:  1.6min finished
```

becomes : 

```
Loading database co2SpecDatabase_noneq_Tvib3_CDSD_HITEMP_DUNHAM_iso12_cut1e27_broad20cm_1
*** Loading the database with -2 processor(s) (275 files)***
[Parallel(n_jobs=-2)]: Using backend LokyBackend with 7 concurrent workers.
[Parallel(n_jobs=-2)]: Done   4 tasks      | elapsed:    2.2s
[Parallel(n_jobs=-2)]: Done  58 tasks      | elapsed:   18.2s
[Parallel(n_jobs=-2)]: Done 148 tasks      | elapsed:   43.8s
Loaded in 79.74476599693298
[Parallel(n_jobs=-2)]: Done 275 out of 275 | elapsed:  1.3min finished
```

(100 > 80 s for 275 files) .   
(Note that this is still a lot ; and we should move to HDF5 at some point.  #16 )
