### PR TITLE
Accelerate small spectra computation

### DIFF
--- a/radis/__init__.py
+++ b/radis/__init__.py
@@ -152,6 +152,7 @@ def get_version(verbose=False, add_git_number=True):
 
 
 __version__ = get_version(add_git_number=False)
+version = get_version() #complete version including commit number
 
 
 from .db import *  # database of molecules

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -527,7 +527,7 @@ class SpectrumFactory(BandFactory):
         self.SpecDatabase = None  # the database to store spectra. Not to be confused
         # with the databank where lines are stored
         self.database = None  # path to previous database
-
+        self.version = get_version()
         # Warnings
         # --------
 
@@ -747,7 +747,7 @@ class SpectrumFactory(BandFactory):
                 "lines_cutoff": self._Nlines_cutoff,
                 "lines_in_continuum": self._Nlines_in_continuum,
                 "thermal_equilibrium": True,
-                "radis_version": get_version(),
+                "radis_version": self.version
             }
         )
         conditions.update(
@@ -1392,7 +1392,7 @@ class SpectrumFactory(BandFactory):
                 "lines_cutoff": self._Nlines_cutoff,
                 "lines_in_continuum": self._Nlines_in_continuum,
                 "thermal_equilibrium": False,  # dont even try to guess if it's at equilibrium
-                "radis_version": get_version(),
+                "radis_version": self.version,
             }
         )
         conditions.update(

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -83,7 +83,7 @@ import numpy as np
 from numpy import arange, exp
 from scipy.constants import N_A, c, k, pi
 
-from radis import get_version
+from radis import version
 from radis.db import MOLECULES_LIST_EQUILIBRIUM, MOLECULES_LIST_NONEQUILIBRIUM
 from radis.db.classes import get_molecule, get_molecule_identifier
 from radis.db.molparam import MolParams
@@ -527,7 +527,6 @@ class SpectrumFactory(BandFactory):
         self.SpecDatabase = None  # the database to store spectra. Not to be confused
         # with the databank where lines are stored
         self.database = None  # path to previous database
-        self.version = get_version()
         # Warnings
         # --------
 
@@ -747,7 +746,7 @@ class SpectrumFactory(BandFactory):
                 "lines_cutoff": self._Nlines_cutoff,
                 "lines_in_continuum": self._Nlines_in_continuum,
                 "thermal_equilibrium": True,
-                "radis_version": self.version
+                "radis_version": version
             }
         )
         conditions.update(
@@ -1065,7 +1064,7 @@ class SpectrumFactory(BandFactory):
                 ),
                 "lines_calculated": _Nlines_calculated,
                 "thermal_equilibrium": True,
-                "radis_version": get_version(),
+                "radis_version": version,
             }
         )
         conditions.update(
@@ -1392,7 +1391,7 @@ class SpectrumFactory(BandFactory):
                 "lines_cutoff": self._Nlines_cutoff,
                 "lines_in_continuum": self._Nlines_in_continuum,
                 "thermal_equilibrium": False,  # dont even try to guess if it's at equilibrium
-                "radis_version": self.version,
+                "radis_version": version,
             }
         )
         conditions.update(

--- a/radis/levels/partfunc.py
+++ b/radis/levels/partfunc.py
@@ -405,20 +405,21 @@ class RovibParFuncCalculator(RovibPartitionFunction):
             else:
                 raise NotImplementedError
 
-            # If overpopulation, first check all levels exist
-            levels = df.viblvl.unique()
-            for viblvl in overpopulation.keys():
-                if not viblvl in levels:
-                    raise ValueError(
-                        "Level {0} not in energy levels database".format(viblvl)
-                    )
-                    # could be a simple warning too
-            # Add overpopulations (so they are taken into account in the partition function)
-            for viblvl, ov in overpopulation.items():
-                if ov != 1:
-                    df.loc[df.viblvl == viblvl, "nvibQvib"] *= ov
-                    # TODO: add warning if empty? I dont know how to do it without
-                    # an extra lookup though.
+            if overpopulation != {}:
+                # If overpopulation, first check all levels exist
+                levels = df.viblvl.unique()
+                for viblvl in overpopulation.keys():
+                    if not viblvl in levels:
+                        raise ValueError(
+                            "Level {0} not in energy levels database".format(viblvl)
+                        )
+                        # could be a simple warning too
+                # Add overpopulations (so they are taken into account in the partition function)
+                for viblvl, ov in overpopulation.items():
+                    if ov != 1:
+                        df.loc[df.viblvl == viblvl, "nvibQvib"] *= ov
+                        # TODO: add warning if empty? I dont know how to do it without
+                        # an extra lookup though.
 
             # Calculate sum of levels
             nQ = df.nvibQvib * df.nrotQrot


### PR DESCRIPTION
### Description
Hello,

Context: I'm doing CO2 and CO fitting on small waveranges. This involves to calculate a lot of spectra for each fitting. I noticed that a CO simulation at equilibrium cost approximately 0.3-0.4 s on my computer. Approximately 0.3 s is used to retrieve the RADIS version via `get_version()`. I reckoned it would be more efficient to store the version number in the SpectrumFactory object.

**Code to test pull-request:**
```pyton
from radis import SpectrumFactory
sf = SpectrumFactory(wavenum_min=2384,
                     wavenum_max=2385,
                     molecule='CO2',
                      isotope='1,2',
                     broadening_max_width=10,  # cm-1
                     medium='vacuum',
                     verbose=3,    # more for more details
                     )
sf.fetch_databank()
s = sf.eq_spectrum(Tgas=300, path_length=1)
```
**Before:**
```python
----------------------------------------
Scaling equilibrium linestrength
0.00s - Scaled equilibrium linestrength
0.00s - Calculated lineshift
0.00s - Calculate broadening HWHM
Calculating line broadening (260 lines: expect ~ 0.03s on 1 CPU)
...... 0.00s - Precomputed DLM lineshapes (10)
...... 0.00s - Initialized vectors
...... 0.00s - Get closest matching line & fraction
...... 0.00s - Distribute lines over DLM
...... 0.00s - Convolve and sum on spectral range
0.00s - Calculated line broadening
0.00s - Calculated other spectral quantities
0.02s - Spectrum calculated (before object generation)
0.13s - Generated Spectrum object
0.15s - Spectrum calculated
```

**After:**
```python
----------------------------------------
Scaling equilibrium linestrength
0.00s - Scaled equilibrium linestrength
0.00s - Calculated lineshift
0.02s - Calculate broadening HWHM
Calculating line broadening (260 lines: expect ~ 0.03s on 1 CPU)
...... 0.01s - Precomputed DLM lineshapes (10)
...... 0.00s - Initialized vectors
...... 0.00s - Get closest matching line & fraction
...... 0.00s - Distribute lines over DLM
...... 0.00s - Convolve and sum on spectral range
0.01s - Calculated line broadening
0.00s - Calculated other spectral quantities
0.02s - Spectrum calculated (before object generation)
0.00s - Generated Spectrum object
0.02s - Spectrum calculated
```