### PR TITLE
Improve radis import speed

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,11 +3,13 @@ name: radis-env
 channels:
 - conda-forge
 - astropy
+- cantera
 dependencies:
 - python=3.8
 - numpy
 - scipy>=1.4.0
 - matplotlib
+- cantera   # for chemical equilibrium computations
 - cython
 - pandas>=1.0.5
 - pytables  # for pandas to HDF5 export

--- a/radis/io/query.py
+++ b/radis/io/query.py
@@ -23,8 +23,6 @@ from os.path import exists, isfile, join
 
 import numpy as np
 import pandas as pd
-from astropy import units as u
-from astroquery.hitran import Hitran
 
 import radis
 from radis.db.classes import get_molecule, get_molecule_identifier
@@ -79,6 +77,9 @@ def fetch_astroquery(
     :py:attr:`astroquery.query.BaseQuery.cache_location`
 
     """
+    from astropy import units as u
+    from astroquery.hitran import Hitran
+
     # Check input
     if not is_float(molecule):
         mol_id = get_molecule_identifier(molecule)

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -68,7 +68,6 @@ Most methods are written in inherited class with the following inheritance schem
 
 import sys
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from astropy import units as u
@@ -261,6 +260,8 @@ class BaseFactory(DatabankLoader):
             which feature to plot. Default ``'S'`` (scaled linestrength). Could also
             be ``'int'`` (reference linestrength intensity), ``'A'`` (Einstein coefficient)
         """
+        import matplotlib.pyplot as plt
+
         assert dataframe in ["df0", "df1"]
         plt.figure()
         df = getattr(self, dataframe)

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -62,7 +62,6 @@ Formula in docstrings generated with :py:func:`~pytexit.pytexit.py2tex` ::
 """
 from warnings import warn
 
-import matplotlib.pyplot as plt
 import numpy as np
 from numba import float64, jit
 from numpy import arange, exp
@@ -1504,6 +1503,7 @@ class BroadenFactory(BaseFactory):
         """
         # TODO #clean: make it a standalone function.
 
+        import matplotlib.pyplot as plt
         from publib import fix_style, set_style
 
         if pressure_atm is None:

--- a/radis/misc/plot.py
+++ b/radis/misc/plot.py
@@ -5,7 +5,6 @@ Created on Sat May  1 13:50:36 2021
 @author: erwan
 """
 
-import matplotlib.pyplot as plt
 import numpy as np
 
 
@@ -39,6 +38,7 @@ def split_and_plot_by_parts(w, I, *args, **kwargs):
     ax.plot
     """
 
+    import matplotlib.pyplot as plt
     from publib.tools import keep_color
 
     # Get defaults

--- a/radis/phys/units.py
+++ b/radis/phys/units.py
@@ -8,8 +8,6 @@
 
 import warnings
 
-import astropy.units as u
-
 
 def Unit(st, *args, **kwargs):
     """Radis evaluation of an unit, using :py:class:`~astropy.units.Unit`
@@ -28,6 +26,8 @@ def Unit(st, *args, **kwargs):
         a = 200 * u("mW/cm2/sr/nm")
         a += 0.1 * u("W/cm2/sr/nm")
     """
+
+    import astropy.units as u
 
     try:
         st = st.replace("µ", "u")
@@ -67,6 +67,8 @@ def conv2(quantity, fromunit, tounit):
     want to let the users choose another output unit
     """
 
+    import astropy.units as u
+
     try:
         a = quantity * Unit(fromunit)
         a = a.to(Unit(tounit))
@@ -87,6 +89,8 @@ def is_homogeneous(unit1, unit2):
     unit1, unit2: str
         units
     """
+
+    import astropy.units as u
 
     try:
         1 * Unit(unit1) + 1 * Unit(unit2)
@@ -330,6 +334,8 @@ def convert_universal(
     wavenumber is needed in case we convert from ~1/nm to ~1/cm-1 (requires
     a change of variable in the integral)
     """
+    import astropy.units as u
+
     Iunit0 = from_unit
     Iunit = to_unit
     try:

--- a/radis/phys/units_astropy.py
+++ b/radis/phys/units_astropy.py
@@ -1,4 +1,10 @@
-import astropy.units as u
+# -*- coding: utf-8 -*-
+"""
+
+-------------------------------------------------------------------------------
+
+
+"""
 
 
 def convert_and_strip_units(quantity, output_unit=None, digit=10):
@@ -37,7 +43,12 @@ def convert_and_strip_units(quantity, output_unit=None, digit=10):
     TypeError
         Raised when ``quantity`` is a astropy.units quantity and ``output_unit`` is ``None``.
     """
+
+    import astropy.units as u
+
     if isinstance(quantity, u.Quantity):
+        # TODO : make it possible to test if not adimensionned, before loading.
+        # This would allow not to have to load Astropy.units on start-up?
         if output_unit in (u.deg_C, u.imperial.deg_F, u.K):
             quantity = quantity.to_value(output_unit, equivalencies=u.temperature())
         elif isinstance(output_unit, (u.UnitBase, u.Quantity)):

--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -26,11 +26,7 @@ Routine Listings
 
 from warnings import warn
 
-import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib import gridspec
-from matplotlib.widgets import MultiCursor
-from publib import fix_style, set_style
 
 from radis.misc.arrays import array_allclose
 from radis.misc.basics import compare_dict, compare_lists
@@ -688,6 +684,11 @@ def plot_diff(
     :func:`~radis.spectrum.compare.get_residual`,
     :meth:`~radis.spectrum.spectrum.compare_with`
     """
+
+    import matplotlib.pyplot as plt
+    from matplotlib import gridspec
+    from matplotlib.widgets import MultiCursor
+    from publib import fix_style, set_style
 
     if (not show) and (
         not save

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -53,11 +53,8 @@ from os.path import basename
 from warnings import warn
 
 import astropy.units as u
-import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.widgets import Cursor
 from numpy import abs, diff
-from publib import fix_style, set_style
 
 # from radis.lbl.base import print_conditions
 from radis.misc.arrays import count_nans, evenly_distributed, nantrapz
@@ -1441,6 +1438,9 @@ class Spectrum(object):
         :ref:`the Spectrum page <label_spectrum>`
         """
 
+        import matplotlib.pyplot as plt
+        from publib import fix_style, set_style
+
         # Deprecated
         if "plot_medium" in kwargs:
             show_medium = kwargs.pop("plot_medium")
@@ -1568,6 +1568,8 @@ class Spectrum(object):
             fig.cursor
             # if already exist, do not add again
         except AttributeError:
+            from matplotlib.widgets import Cursor
+
             fig.cursor = Cursor(fig.gca(), useblit=True, color="r", lw=1, alpha=0.2)
 
         # ... Add Ruler
@@ -1783,6 +1785,8 @@ class Spectrum(object):
         kwargs: **dict
             are forwarded to the plot
         """
+        import matplotlib.pyplot as plt
+        from publib import fix_style, set_style
 
         # Check input, get defaults
         pops = self.populations

--- a/radis/test/io/test_query.py
+++ b/radis/test/io/test_query.py
@@ -10,7 +10,6 @@ from os.path import exists, join
 
 import pytest
 
-from radis.io.query import CACHE_FILE_NAME, Hitran, fetch_astroquery
 from radis.misc.warning import DeprecatedFileWarning
 
 
@@ -18,6 +17,8 @@ from radis.misc.warning import DeprecatedFileWarning
 @pytest.mark.needs_connection
 def test_fetch_astroquery(verbose=True, *args, **kwargs):
     """ Test astroquery """
+    from radis.io.query import fetch_astroquery
+
     df = fetch_astroquery("CO2", 1, 2200, 2400, verbose=verbose, cache=False)
 
     assert df.iloc[0].id == 2
@@ -30,6 +31,8 @@ def test_fetch_astroquery(verbose=True, *args, **kwargs):
 @pytest.mark.needs_connection
 def test_fetch_astroquery_empty(verbose=True, *args, **kwargs):
     """ Test astroquery: get a spectral range where there are no lines"""
+    from radis.io.query import fetch_astroquery
+
     df = fetch_astroquery(
         2, 1, 25000, 50000, verbose=verbose, cache=False
     )  # 200-400 nm
@@ -48,6 +51,9 @@ def test_fetch_astroquery_cache(verbose=True, *args, **kwargs):
     - Cache file is loaded.
     - Different metadata raises an error
     """
+    from astroquery.hitran import Hitran
+
+    from radis.io.query import CACHE_FILE_NAME, fetch_astroquery
 
     df = fetch_astroquery(
         "CO2",

--- a/radis/test/tools/test_gascomp.py
+++ b/radis/test/tools/test_gascomp.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Jul  7 12:55:28 2021
+
+@author: erwan
+
+Test the :py:func:`~radis.tools.gascomp.get_eq_mole_fraction` function.
+"""
+
+
+def test_get_eq_mole_fraction(*args, **kwargs):
+    from radis.misc.basics import all_in
+    from radis.tools.gascomp import get_eq_mole_fraction
+
+    gas = get_eq_mole_fraction("CO2:1", 3000, 1e5)
+
+    assert all_in(["C", "CO", "CO2", "O", "O2"], gas.keys())
+
+    return True

--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -64,7 +64,6 @@ from time import strftime
 from warnings import warn
 
 import json_tricks
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed
@@ -905,6 +904,8 @@ def plot_spec(file, what="radiance", title=True, **kwargs):
     :py:meth:`~radis.spectrum.spectrum.Spectrum.plot`
     """
 
+    import matplotlib.pyplot as plt
+
     if isinstance(file, str):
         s = load_spec(file)
     elif isinstance(file, Spectrum):
@@ -1636,6 +1637,8 @@ class SpecList(object):
         Spectrum :py:meth:`~radis.spectrum.spectrum.Spectrum.plot` method
         """
 
+        import matplotlib.pyplot as plt
+
         fig = plt.figure(num=nfig)
         ax = fig.gca()
         for s in self:
@@ -1667,6 +1670,8 @@ class SpecList(object):
                                                   # procedure...
         """
         # %%
+
+        import matplotlib.pyplot as plt
 
         x = self.df[cond_x]
         y = self.df[cond_y]

--- a/radis/tools/gascomp.py
+++ b/radis/tools/gascomp.py
@@ -6,17 +6,6 @@ Determine gas mixture composition under chemical equilibrium using CANTERA.
 
 """
 
-from radis.misc.utils import NotInstalled
-
-try:
-    import cantera as ct
-except:
-    ct = NotInstalled(
-        "cantera",
-        "Cantera is needed to calculate equilibrium mole fractions"
-        + ". Install with  `pip install cantera`",
-    )
-
 
 def get_eq_mole_fraction(initial_mixture, T_K, p_Pa):
     """Calculates chemical equilibrium mole fraction at temperature T, using
@@ -64,6 +53,14 @@ def get_eq_mole_fraction(initial_mixture, T_K, p_Pa):
 
     [CANTERA]_
     """
+
+    try:
+        import cantera as ct
+    except ImportError as err:
+        raise ImportError(
+            "Cantera is needed to calculate equilibrium mole fractions"
+            + ". Install with  `pip install cantera` or (better) `conda install -c cantera cantera`",
+        ) from err
 
     # %% Init Cantera
     g = ct.Solution("gri30.xml")

--- a/radis/tools/plot_tools.py
+++ b/radis/tools/plot_tools.py
@@ -21,534 +21,536 @@ Examples
 """
 import warnings
 
-import matplotlib.pyplot as plt
-import numpy as np
-from matplotlib.backend_tools import ToolToggleBase
-from matplotlib.widgets import AxesWidget
-
-
-class Ruler(AxesWidget):
-    """
-    A ruler to measure distances and angles on an axes instance.
-
-    For the ruler to remain responsive you must keep a reference to it.
-
-    Parameters
-    ----------
-    ax  : the  :class:`matplotlib.axes.Axes` instance
-
-    active : bool, default is True
-        Whether the ruler is active or not.
-
-    wunit, Iunit: str
-        unit of spectra
-
-    print_text  : bool, default is False
-        Whether the length measure string is printed to the console
-
-    useblit : bool, default is False
-        If True, use the backend-dependent blitting features for faster
-        canvas updates.
-
-    lineprops : dict, default is None
-      Dictionary of :class:`matplotlib.lines.Line2D` properties
-
-    markerprops : dict, default is None
-      Dictionary of :class:`matplotlib.markers.MarkerStyle` properties
-
-    textprops: dict, default is None
-        Dictionary of :class:`matplotlib.text.Text` properties. To reposition the
-        textbox you can overide the defaults which position the box in the top left
-        corner of the axes.
-
-    Usage:
-    ----------
-
-    1. Hold left click drag and release to draw the ruler in the axes.
-      - Hold shift while dragging to lock the ruler to the horizontal axis.
-      - Hold control while drawing to lock the ruler to the vertical axis.
-
-    2. Right click one of the markers to move the ruler.
-
-    The keyboard can be used to activate and deactivate the ruler and toggle
-    visibility of the line and text:
-
-    'm' : Toggles the ruler on and off.
-
-    'ctl+m' : Toggles the visibility of the ruler and text.
-
-    Example
-    ----------
-
-    >>> xCoord = np.arange(0, 5, 1)
-    >>> yCoord = [0, 1, -3, 5, -3]
-    >>> fig = plt.figure()
-    >>> ax = fig.add_subplot(111)
-
-    >>> markerprops = dict(marker='o', markersize=5, markeredgecolor='red')
-    >>> lineprops = dict(color='red', linewidth=2)
-
-    >>> ax.grid(True)
-    >>> ax.plot(xCoord, yCoord)
-
-    >>> ruler = Ruler(ax=ax,
-                  useblit=True,
-                  markerprops=markerprops,
-                  lineprops=lineprops)
-
-    >>> plt.show()
-
-    """
-
-    def __init__(
-        self,
-        ax,
-        active=True,
-        print_text=False,
-        useblit=False,
-        lineprops=None,
-        textprops=None,
-        markerprops=None,
-        wunit="",
-        Iunit="",
-    ):
-        """
-        Add a ruler to *ax*. If ``ruler_active=True``, the ruler will be
-        activated when the plot is first created. If ``ruler_unit`` is set the
-        string will be appended to the length text annotations.
-
-        """
-        AxesWidget.__init__(self, ax)
-
-        self.connect_events()
-
-        self.ax = ax
-        self.fig = ax.figure
-
-        self._print_text = print_text
-        self._visible = True
-        self.active = active
-        self.wunit = wunit
-        self.Iunit = Iunit
-
-        self.useblit = useblit and self.canvas.supports_blit
-
-        self._mouse1_pressed = False
-        self._mouse3_pressed = False
-        self._shift_pressed = False
-        self._control_pressed = False
-        self._y0 = None
-        self._x1 = None
-        self._y1 = None
-        self._line_start_coords = None
-        self._line_end_coords = None
-        self._ruler_marker = None
-        self._background = None
-        self._ruler_moving = False
-        self._end_a_lock = False
-        self._end_b_lock = False
-        self._end_c_lock = False
-        self._old_marker_a_coords = None
-        self._old_marker_c_coords = None
-        self._old_mid_coords = None
-
-        if lineprops is None:
-            lineprops = {}
-
-        bbox = dict(facecolor="white", alpha=0.5, boxstyle="round", edgecolor="0.75")
-
-        used_textprops = dict(
-            xy=(0, 1),
-            xytext=(10, -10),
-            xycoords="axes fraction",
-            textcoords="offset points",
-            ha="left",
-            va="center",
-            size=12,
-            bbox=bbox,
-        )
-
-        x0 = np.nan
-        y0 = np.nan
-
-        (self._ruler,) = self.ax.plot([x0, x0], [y0, y0], **lineprops)
-
-        used_markerprops = dict(
-            marker="s",
-            markersize=3,
-            markerfacecolor="white",
-            markeredgecolor="black",
-            markeredgewidth=0.5,
-            picker=True,
-            pickradius=5,
-            visible=False,
-        )
-
-        # If marker or text  props are given as an argument combine with the
-        # default marker props. Don't really want to override the entire props
-        # if a user only gives one value.
-
-        if markerprops is not None:
-            used_markerprops.update(markerprops)
-
-        if textprops is not None:
-            used_textprops.update(used_textprops)
-
-        self._axes_text = self.ax.annotate(text="", **used_textprops)
-        self.ax.add_artist(self._axes_text)
-
-        (self._marker_a,) = self.ax.plot((x0, y0), **used_markerprops)
-        (self._marker_b,) = self.ax.plot((x0, y0), **used_markerprops)
-        (self._marker_c,) = self.ax.plot((x0, y0), **used_markerprops)
-
-        self._artists = [
-            self._axes_text,
-            self._ruler,
-            self._marker_a,
-            self._marker_b,
-            self._marker_c,
-        ]
-
-    def connect_events(self):
-        """
-        Connect all events to the various callbacks
-        """
-        self.connect_event("button_press_event", self._on_press)
-        self.connect_event("button_release_event", self._on_release)
-        self.connect_event("motion_notify_event", self._on_move)
-        self.connect_event("key_press_event", self._on_key_press)
-        self.connect_event("key_release_event", self._on_key_release)
-
-    def ignore(self, event):
-        """
-        Ignore events if the cursor is out of the axes or the widget is locked
-        """
-        if not self.canvas.widgetlock.available(self):
-            return True
-        if event.inaxes != self.ax.axes:
-            return True
-        if not self.active:
-            return True
-
-    def _on_key_press(self, event):
-        """
-        Handle key press events.
-
-        If shift is pressed the ruler will be constrained to horizontal axis
-        If control is pressed the ruler will be constrained to vertical axis
-        If m is pressed the ruler will be toggled on and off
-        If ctrl+m is pressed the visibility of the ruler will be toggled
-        """
-
-        if event.key == "shift":
-            self._shift_pressed = True
-
-        if event.key == "control":
-            self._control_pressed = True
-
-        if event.key == "m":
-            self.toggle_ruler()
-
-        if event.key == "ctrl+m":
-            self.toggle_ruler_visibility()
-
-    def _on_key_release(self, event):
-        """
-        Handle key release event, flip the flags to false.
-        """
-        if event.key == "shift":
-            self._shift_pressed = False
-
-        if event.key == "control":
-            self._control_pressed = False
-
-    def toggle_ruler(self):
-        """
-        Called when the 'm' key is pressed. If ruler is on turn it off, and
-        vise versa
-
-        If off, hide it.
-        """
-
-        self.active = not self.active
-
-        self.canvas.draw_idle()
-
-    def toggle_ruler_visibility(self):
-        """
-        Called when the 'ctl+m' key is pressed. If ruler is visible turn it off
-        , and vise versa
-        """
-        if self._visible is True:
-            for artist in self._artists:
-                artist.set_visible(False)
-            self.active = False
-            self._visible = False
-
-        elif self._visible is False:
-            for artist in self._artists:
-                artist.set_visible(True)
-            self._visible = True
-
-        self.canvas.draw_idle()
-
-    def _on_press(self, event):
-        """
-        On mouse button press check which button has been pressed and handle
-        """
-        if self.ignore(event):
-            return
-        if event.button == 1 and self._mouse3_pressed is False:
-            self._handle_button1_press(event)
-        elif event.button == 3:
-            self._handle_button3_press(event)
-
-    def _handle_button1_press(self, event):
-        """
-        On button 1 press start drawing the ruler line from the initial
-        press position
-        """
-
-        self._mouse1_pressed = True
-        self._x0 = event.xdata
-        self._y0 = event.ydata
-        self._marker_a.set_data((event.xdata, event.ydata))
-        self._marker_a.set_visible(True)
-
-        if self.useblit:
-            self._marker_a.set_data(self._x0, self._y0)
-            for artist in self._artists:
-                artist.set_animated(True)
-            self.canvas.draw()
-            self._background = self.canvas.copy_from_bbox(self.fig.bbox)
-
-    def _handle_button3_press(self, event):
-        """
-        If button 3 is pressed (right click) check if cursor is at one of the
-        ruler markers and the move the ruler accordingly.
-        """
-        contains_a, _ = self._marker_a.contains(event)
-        contains_b, _ = self._marker_b.contains(event)
-        contains_c, _ = self._marker_c.contains(event)
-
-        if not (contains_a or contains_b or contains_c):
-            return
-
-        self._end_a_lock = contains_a
-        self._end_b_lock = contains_b
-        self._end_c_lock = contains_c
-
-        line_coords = self._ruler.get_path().vertices
-        self._x0 = line_coords[0][0]
-        self._y0 = line_coords[0][1]
-        self._x1 = line_coords[1][0]
-        self._y1 = line_coords[1][1]
-
-        self._old_marker_a_coords = self._marker_a.get_path().vertices
-        self._old_marker_c_coords = self._marker_c.get_path().vertices
-        self._old_mid_coords = self.midline_coords
-
-    def _on_move(self, event):
-        """
-        On motion draw the ruler if button 1 is pressed. If one of the markers
-        is locked indicating move the ruler according to the locked marker
-        """
-
-        if event.inaxes != self.ax.axes:
-            return
-
-        # if self._end_a_lock or self._end_b_lock or self._end_c_lock is True:
-        #     self._move_ruler(event)
-
-        if self._mouse1_pressed is True:
-            self._draw_ruler(event)
-
-    # def _move_ruler(self, event):
-    #     """
-    #     If one of the markers is locked move the ruler according the selected
-    #     marker.
-    #     """
-
-    #     # This flag is used to prevent the ruler from clipping when a marker is
-    #     # first selected
-    #     if self._ruler_moving is False:
-    #         if self.useblit:
-    #             for artist in self._artists:
-    #                 artist.set_animated(True)
-    #             self.canvas.draw()
-    #             self._background = self.canvas.copy_from_bbox(self.fig.bbox)
-    #             self._ruler_moving = True
-
-    #     if self._end_a_lock is True:
-    #         # If marker a is locked only move end a.
-    #         pos_a = event.xdata, self._x1
-    #         pos_b = event.ydata, self._y1
-    #         self._marker_a.set_data(event.xdata, event.ydata)
-    #         self._ruler.set_data(pos_a, pos_b)
-    #         self._set_midline_marker()
-
-    #     if self._end_c_lock is True:
-    #         # If marker a is locked only move end c.
-    #         pos_a = self._x0, event.xdata
-    #         pos_b = self._y0, event.ydata
-    #         self._marker_c.set_data(event.xdata, event.ydata)
-    #         self._ruler.set_data(pos_a, pos_b)
-    #         self._set_midline_marker()
-
-    #     if self._end_b_lock is True:
-    #         # If marker b is locked shift the whole ruler.
-    #         b_dx = event.xdata - self._old_mid_coords[0]
-    #         b_dy = event.ydata - self._old_mid_coords[1]
-    #         pos_a = self._x0 + b_dx, self._x1 + b_dx
-    #         pos_b = self._y0 + b_dy, self._y1 + b_dy
-
-    #         marker_a_coords = (
-    #             self._old_marker_a_coords[0][0] + b_dx,
-    #             self._old_marker_a_coords[0][1] + b_dy,
-    #         )
-    #         marker_c_coords = (
-    #             self._old_marker_c_coords[0][0] + b_dx,
-    #             self._old_marker_c_coords[0][1] + b_dy,
-    #         )
-
-    #         self._ruler.set_data(pos_a, pos_b)
-    #         self._marker_a.set_data(marker_a_coords)
-    #         self._marker_b.set_data(event.xdata, event.ydata)
-    #         self._marker_c.set_data(marker_c_coords)
-
-    #     self._update_text()
-    #     self._update_artists()
-
-    # def _set_midline_marker(self):
-    #     self._marker_b.set_visible(True)
-    #     self._marker_b.set_data(self.midline_coords)
-
-    # @property
-    # def midline_coords(self):
-    #     pos0, pos1 = self._ruler.get_path().vertices
-    #     mid_line_coords = (pos0[0] + pos1[0]) / 2, (pos0[1] + pos1[1]) / 2
-    #     return mid_line_coords
-
-    def _draw_ruler(self, event):
-        """
-        If the left mouse button is pressed and held draw the ruler as the
-        mouse is dragged
-        """
-
-        self._x1 = event.xdata
-        self._y1 = event.ydata
-
-        # If shift is pressed ruler is constrained to horizontal axis
-        if self._shift_pressed is True:
-            pos_a = self._x0, self._x1
-            pos_b = self._y0, self._y0
-        # If control is pressed ruler is constrained to vertical axis
-        elif self._control_pressed is True:
-            pos_a = self._x0, self._x0
-            pos_b = self._y0, self._y1
-        # Else the ruler follow the mouse cursor
-        else:
-            pos_a = self._x0, self._x1
-            pos_b = self._y0, self._y1
-
-        self._ruler.set_data([pos_a], [pos_b])
-        x1 = self._ruler.get_path().vertices[1][0]
-        y1 = self._ruler.get_path().vertices[1][1]
-        self._marker_c.set_visible(True)
-        self._marker_c.set_data(x1, y1)
-        # self._set_midline_marker()
-        self._update_text()
-        self._update_artists()
-
-    def _update_artists(self):
-        if self.useblit:
-            if self._background is not None:
-                self.canvas.restore_region(self._background)
-            else:
-                self._background = self.canvas.copy_from_bbox(self.fig.bbox)
-
-            for artist in self._artists:
-                self.ax.draw_artist(artist)
-
-            self.canvas.blit(self.fig.bbox)
-        else:
-            self.canvas.draw_idle()
-
-    def _update_text(self):
-        detail_string = "{:0.4f} {}; {:0.3f} {}".format(
-            self.ruler_dx, self.wunit, self.ruler_dy, self.Iunit
-        )
-
-        self._axes_text.set_text(detail_string)
-        if self._print_text is True:
-            print(detail_string)
-
-    def _on_release(self, event):
-        self._mouse1_pressed = False
-        self._mouse3_pressed = False
-        self._ruler_moving = False
-        self._end_a_lock = False
-        self._end_b_lock = False
-        self._end_c_lock = False
-
-    @property
-    def ruler_dx(self):
-        pos0, pos1 = self._ruler.get_path().vertices
-        return pos1[0] - pos0[0]
-
-    @property
-    def ruler_dy(self):
-        pos0, pos1 = self._ruler.get_path().vertices
-        return pos1[1] - pos0[1]
-
-
-# %% Add in toolbars
-
-
-class RulerTool(ToolToggleBase):
-    """Add a RulerTool to measure spectra
-
-    Based on work from TerranJP
-    https://github.com/terranjp/matplotlib-tools
-    """
-
-    # keyboard shortcut
-    default_keymap = "m"
-    description = "Ruler Tool"
-    default_toggled = False
-    image = "ruler"
-
-    def __init__(self, *args, **kwargs):
-        ax = kwargs.get("ax", plt.gca())
-        self.ruler = None
-        self.ax = ax
-        self.wunit = (None,)  # x-axis unit
-        self.Iunit = (None,)  # y-axis unit
-        super().__init__(*args, **kwargs)
-
-    def enable(self, event):
-        """Connect press/release events and lock the canvas."""
-        pass
-
-    def disable(self, event):
-        """Release the canvas and disconnect press/release events."""
-        pass
-
-    def trigger(self, *args, **kwargs):
-        """ When toolbar button clicked"""
-        super().trigger(*args, **kwargs)
-        if self.ruler is None:
-            self.ruler = Ruler(
-                ax=self.ax,  # TODO UPDATE
-                useblit=True,
-                wunit=self.wunit,
-                Iunit=self.Iunit,
-            )  # , markerprops=markerprops, lineprops=lineprops)
-        else:
-            self.ruler.toggle_ruler()
-
 
 def add_ruler(fig, wunit="", Iunit="", ax=None):
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from matplotlib.backend_tools import ToolToggleBase
+    from matplotlib.widgets import AxesWidget
+
+    # TODO: build it only on demand/ if add_tool called?
+    class Ruler(AxesWidget):
+        """
+        A ruler to measure distances and angles on an axes instance.
+
+        For the ruler to remain responsive you must keep a reference to it.
+
+        Parameters
+        ----------
+        ax  : the  :class:`matplotlib.axes.Axes` instance
+
+        active : bool, default is True
+            Whether the ruler is active or not.
+
+        wunit, Iunit: str
+            unit of spectra
+
+        print_text  : bool, default is False
+            Whether the length measure string is printed to the console
+
+        useblit : bool, default is False
+            If True, use the backend-dependent blitting features for faster
+            canvas updates.
+
+        lineprops : dict, default is None
+          Dictionary of :class:`matplotlib.lines.Line2D` properties
+
+        markerprops : dict, default is None
+          Dictionary of :class:`matplotlib.markers.MarkerStyle` properties
+
+        textprops: dict, default is None
+            Dictionary of :class:`matplotlib.text.Text` properties. To reposition the
+            textbox you can overide the defaults which position the box in the top left
+            corner of the axes.
+
+        Usage:
+        ----------
+
+        1. Hold left click drag and release to draw the ruler in the axes.
+          - Hold shift while dragging to lock the ruler to the horizontal axis.
+          - Hold control while drawing to lock the ruler to the vertical axis.
+
+        2. Right click one of the markers to move the ruler.
+
+        The keyboard can be used to activate and deactivate the ruler and toggle
+        visibility of the line and text:
+
+        'm' : Toggles the ruler on and off.
+
+        'ctl+m' : Toggles the visibility of the ruler and text.
+
+        Example
+        ----------
+
+        >>> xCoord = np.arange(0, 5, 1)
+        >>> yCoord = [0, 1, -3, 5, -3]
+        >>> fig = plt.figure()
+        >>> ax = fig.add_subplot(111)
+
+        >>> markerprops = dict(marker='o', markersize=5, markeredgecolor='red')
+        >>> lineprops = dict(color='red', linewidth=2)
+
+        >>> ax.grid(True)
+        >>> ax.plot(xCoord, yCoord)
+
+        >>> ruler = Ruler(ax=ax,
+                      useblit=True,
+                      markerprops=markerprops,
+                      lineprops=lineprops)
+
+        >>> plt.show()
+
+        """
+
+        def __init__(
+            self,
+            ax,
+            active=True,
+            print_text=False,
+            useblit=False,
+            lineprops=None,
+            textprops=None,
+            markerprops=None,
+            wunit="",
+            Iunit="",
+        ):
+            """
+            Add a ruler to *ax*. If ``ruler_active=True``, the ruler will be
+            activated when the plot is first created. If ``ruler_unit`` is set the
+            string will be appended to the length text annotations.
+
+            """
+            AxesWidget.__init__(self, ax)
+
+            self.connect_events()
+
+            self.ax = ax
+            self.fig = ax.figure
+
+            self._print_text = print_text
+            self._visible = True
+            self.active = active
+            self.wunit = wunit
+            self.Iunit = Iunit
+
+            self.useblit = useblit and self.canvas.supports_blit
+
+            self._mouse1_pressed = False
+            self._mouse3_pressed = False
+            self._shift_pressed = False
+            self._control_pressed = False
+            self._y0 = None
+            self._x1 = None
+            self._y1 = None
+            self._line_start_coords = None
+            self._line_end_coords = None
+            self._ruler_marker = None
+            self._background = None
+            self._ruler_moving = False
+            self._end_a_lock = False
+            self._end_b_lock = False
+            self._end_c_lock = False
+            self._old_marker_a_coords = None
+            self._old_marker_c_coords = None
+            self._old_mid_coords = None
+
+            if lineprops is None:
+                lineprops = {}
+
+            bbox = dict(
+                facecolor="white", alpha=0.5, boxstyle="round", edgecolor="0.75"
+            )
+
+            used_textprops = dict(
+                xy=(0, 1),
+                xytext=(10, -10),
+                xycoords="axes fraction",
+                textcoords="offset points",
+                ha="left",
+                va="center",
+                size=12,
+                bbox=bbox,
+            )
+
+            x0 = np.nan
+            y0 = np.nan
+
+            (self._ruler,) = self.ax.plot([x0, x0], [y0, y0], **lineprops)
+
+            used_markerprops = dict(
+                marker="s",
+                markersize=3,
+                markerfacecolor="white",
+                markeredgecolor="black",
+                markeredgewidth=0.5,
+                picker=True,
+                pickradius=5,
+                visible=False,
+            )
+
+            # If marker or text  props are given as an argument combine with the
+            # default marker props. Don't really want to override the entire props
+            # if a user only gives one value.
+
+            if markerprops is not None:
+                used_markerprops.update(markerprops)
+
+            if textprops is not None:
+                used_textprops.update(used_textprops)
+
+            self._axes_text = self.ax.annotate(text="", **used_textprops)
+            self.ax.add_artist(self._axes_text)
+
+            (self._marker_a,) = self.ax.plot((x0, y0), **used_markerprops)
+            (self._marker_b,) = self.ax.plot((x0, y0), **used_markerprops)
+            (self._marker_c,) = self.ax.plot((x0, y0), **used_markerprops)
+
+            self._artists = [
+                self._axes_text,
+                self._ruler,
+                self._marker_a,
+                self._marker_b,
+                self._marker_c,
+            ]
+
+        def connect_events(self):
+            """
+            Connect all events to the various callbacks
+            """
+            self.connect_event("button_press_event", self._on_press)
+            self.connect_event("button_release_event", self._on_release)
+            self.connect_event("motion_notify_event", self._on_move)
+            self.connect_event("key_press_event", self._on_key_press)
+            self.connect_event("key_release_event", self._on_key_release)
+
+        def ignore(self, event):
+            """
+            Ignore events if the cursor is out of the axes or the widget is locked
+            """
+            if not self.canvas.widgetlock.available(self):
+                return True
+            if event.inaxes != self.ax.axes:
+                return True
+            if not self.active:
+                return True
+
+        def _on_key_press(self, event):
+            """
+            Handle key press events.
+
+            If shift is pressed the ruler will be constrained to horizontal axis
+            If control is pressed the ruler will be constrained to vertical axis
+            If m is pressed the ruler will be toggled on and off
+            If ctrl+m is pressed the visibility of the ruler will be toggled
+            """
+
+            if event.key == "shift":
+                self._shift_pressed = True
+
+            if event.key == "control":
+                self._control_pressed = True
+
+            if event.key == "m":
+                self.toggle_ruler()
+
+            if event.key == "ctrl+m":
+                self.toggle_ruler_visibility()
+
+        def _on_key_release(self, event):
+            """
+            Handle key release event, flip the flags to false.
+            """
+            if event.key == "shift":
+                self._shift_pressed = False
+
+            if event.key == "control":
+                self._control_pressed = False
+
+        def toggle_ruler(self):
+            """
+            Called when the 'm' key is pressed. If ruler is on turn it off, and
+            vise versa
+
+            If off, hide it.
+            """
+
+            self.active = not self.active
+
+            self.canvas.draw_idle()
+
+        def toggle_ruler_visibility(self):
+            """
+            Called when the 'ctl+m' key is pressed. If ruler is visible turn it off
+            , and vise versa
+            """
+            if self._visible is True:
+                for artist in self._artists:
+                    artist.set_visible(False)
+                self.active = False
+                self._visible = False
+
+            elif self._visible is False:
+                for artist in self._artists:
+                    artist.set_visible(True)
+                self._visible = True
+
+            self.canvas.draw_idle()
+
+        def _on_press(self, event):
+            """
+            On mouse button press check which button has been pressed and handle
+            """
+            if self.ignore(event):
+                return
+            if event.button == 1 and self._mouse3_pressed is False:
+                self._handle_button1_press(event)
+            elif event.button == 3:
+                self._handle_button3_press(event)
+
+        def _handle_button1_press(self, event):
+            """
+            On button 1 press start drawing the ruler line from the initial
+            press position
+            """
+
+            self._mouse1_pressed = True
+            self._x0 = event.xdata
+            self._y0 = event.ydata
+            self._marker_a.set_data((event.xdata, event.ydata))
+            self._marker_a.set_visible(True)
+
+            if self.useblit:
+                self._marker_a.set_data(self._x0, self._y0)
+                for artist in self._artists:
+                    artist.set_animated(True)
+                self.canvas.draw()
+                self._background = self.canvas.copy_from_bbox(self.fig.bbox)
+
+        def _handle_button3_press(self, event):
+            """
+            If button 3 is pressed (right click) check if cursor is at one of the
+            ruler markers and the move the ruler accordingly.
+            """
+            contains_a, _ = self._marker_a.contains(event)
+            contains_b, _ = self._marker_b.contains(event)
+            contains_c, _ = self._marker_c.contains(event)
+
+            if not (contains_a or contains_b or contains_c):
+                return
+
+            self._end_a_lock = contains_a
+            self._end_b_lock = contains_b
+            self._end_c_lock = contains_c
+
+            line_coords = self._ruler.get_path().vertices
+            self._x0 = line_coords[0][0]
+            self._y0 = line_coords[0][1]
+            self._x1 = line_coords[1][0]
+            self._y1 = line_coords[1][1]
+
+            self._old_marker_a_coords = self._marker_a.get_path().vertices
+            self._old_marker_c_coords = self._marker_c.get_path().vertices
+            self._old_mid_coords = self.midline_coords
+
+        def _on_move(self, event):
+            """
+            On motion draw the ruler if button 1 is pressed. If one of the markers
+            is locked indicating move the ruler according to the locked marker
+            """
+
+            if event.inaxes != self.ax.axes:
+                return
+
+            # if self._end_a_lock or self._end_b_lock or self._end_c_lock is True:
+            #     self._move_ruler(event)
+
+            if self._mouse1_pressed is True:
+                self._draw_ruler(event)
+
+        # def _move_ruler(self, event):
+        #     """
+        #     If one of the markers is locked move the ruler according the selected
+        #     marker.
+        #     """
+
+        #     # This flag is used to prevent the ruler from clipping when a marker is
+        #     # first selected
+        #     if self._ruler_moving is False:
+        #         if self.useblit:
+        #             for artist in self._artists:
+        #                 artist.set_animated(True)
+        #             self.canvas.draw()
+        #             self._background = self.canvas.copy_from_bbox(self.fig.bbox)
+        #             self._ruler_moving = True
+
+        #     if self._end_a_lock is True:
+        #         # If marker a is locked only move end a.
+        #         pos_a = event.xdata, self._x1
+        #         pos_b = event.ydata, self._y1
+        #         self._marker_a.set_data(event.xdata, event.ydata)
+        #         self._ruler.set_data(pos_a, pos_b)
+        #         self._set_midline_marker()
+
+        #     if self._end_c_lock is True:
+        #         # If marker a is locked only move end c.
+        #         pos_a = self._x0, event.xdata
+        #         pos_b = self._y0, event.ydata
+        #         self._marker_c.set_data(event.xdata, event.ydata)
+        #         self._ruler.set_data(pos_a, pos_b)
+        #         self._set_midline_marker()
+
+        #     if self._end_b_lock is True:
+        #         # If marker b is locked shift the whole ruler.
+        #         b_dx = event.xdata - self._old_mid_coords[0]
+        #         b_dy = event.ydata - self._old_mid_coords[1]
+        #         pos_a = self._x0 + b_dx, self._x1 + b_dx
+        #         pos_b = self._y0 + b_dy, self._y1 + b_dy
+
+        #         marker_a_coords = (
+        #             self._old_marker_a_coords[0][0] + b_dx,
+        #             self._old_marker_a_coords[0][1] + b_dy,
+        #         )
+        #         marker_c_coords = (
+        #             self._old_marker_c_coords[0][0] + b_dx,
+        #             self._old_marker_c_coords[0][1] + b_dy,
+        #         )
+
+        #         self._ruler.set_data(pos_a, pos_b)
+        #         self._marker_a.set_data(marker_a_coords)
+        #         self._marker_b.set_data(event.xdata, event.ydata)
+        #         self._marker_c.set_data(marker_c_coords)
+
+        #     self._update_text()
+        #     self._update_artists()
+
+        # def _set_midline_marker(self):
+        #     self._marker_b.set_visible(True)
+        #     self._marker_b.set_data(self.midline_coords)
+
+        # @property
+        # def midline_coords(self):
+        #     pos0, pos1 = self._ruler.get_path().vertices
+        #     mid_line_coords = (pos0[0] + pos1[0]) / 2, (pos0[1] + pos1[1]) / 2
+        #     return mid_line_coords
+
+        def _draw_ruler(self, event):
+            """
+            If the left mouse button is pressed and held draw the ruler as the
+            mouse is dragged
+            """
+
+            self._x1 = event.xdata
+            self._y1 = event.ydata
+
+            # If shift is pressed ruler is constrained to horizontal axis
+            if self._shift_pressed is True:
+                pos_a = self._x0, self._x1
+                pos_b = self._y0, self._y0
+            # If control is pressed ruler is constrained to vertical axis
+            elif self._control_pressed is True:
+                pos_a = self._x0, self._x0
+                pos_b = self._y0, self._y1
+            # Else the ruler follow the mouse cursor
+            else:
+                pos_a = self._x0, self._x1
+                pos_b = self._y0, self._y1
+
+            self._ruler.set_data([pos_a], [pos_b])
+            x1 = self._ruler.get_path().vertices[1][0]
+            y1 = self._ruler.get_path().vertices[1][1]
+            self._marker_c.set_visible(True)
+            self._marker_c.set_data(x1, y1)
+            # self._set_midline_marker()
+            self._update_text()
+            self._update_artists()
+
+        def _update_artists(self):
+            if self.useblit:
+                if self._background is not None:
+                    self.canvas.restore_region(self._background)
+                else:
+                    self._background = self.canvas.copy_from_bbox(self.fig.bbox)
+
+                for artist in self._artists:
+                    self.ax.draw_artist(artist)
+
+                self.canvas.blit(self.fig.bbox)
+            else:
+                self.canvas.draw_idle()
+
+        def _update_text(self):
+            detail_string = "{:0.4f} {}; {:0.3f} {}".format(
+                self.ruler_dx, self.wunit, self.ruler_dy, self.Iunit
+            )
+
+            self._axes_text.set_text(detail_string)
+            if self._print_text is True:
+                print(detail_string)
+
+        def _on_release(self, event):
+            self._mouse1_pressed = False
+            self._mouse3_pressed = False
+            self._ruler_moving = False
+            self._end_a_lock = False
+            self._end_b_lock = False
+            self._end_c_lock = False
+
+        @property
+        def ruler_dx(self):
+            pos0, pos1 = self._ruler.get_path().vertices
+            return pos1[0] - pos0[0]
+
+        @property
+        def ruler_dy(self):
+            pos0, pos1 = self._ruler.get_path().vertices
+            return pos1[1] - pos0[1]
+
+    # %% Add in toolbars
+
+    class RulerTool(ToolToggleBase):
+        """Add a RulerTool to measure spectra
+
+        Based on work from TerranJP
+        https://github.com/terranjp/matplotlib-tools
+        """
+
+        # keyboard shortcut
+        default_keymap = "m"
+        description = "Ruler Tool"
+        default_toggled = False
+        image = "ruler"
+
+        def __init__(self, *args, **kwargs):
+            ax = kwargs.get("ax", plt.gca())
+            self.ruler = None
+            self.ax = ax
+            self.wunit = (None,)  # x-axis unit
+            self.Iunit = (None,)  # y-axis unit
+            super().__init__(*args, **kwargs)
+
+        def enable(self, event):
+            """Connect press/release events and lock the canvas."""
+            pass
+
+        def disable(self, event):
+            """Release the canvas and disconnect press/release events."""
+            pass
+
+        def trigger(self, *args, **kwargs):
+            """ When toolbar button clicked"""
+            super().trigger(*args, **kwargs)
+            if self.ruler is None:
+                self.ruler = Ruler(
+                    ax=self.ax,  # TODO UPDATE
+                    useblit=True,
+                    wunit=self.wunit,
+                    Iunit=self.Iunit,
+                )  # , markerprops=markerprops, lineprops=lineprops)
+            else:
+                self.ruler.toggle_ruler()
+
+    # %% Build Class
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")

--- a/radis/tools/slit.py
+++ b/radis/tools/slit.py
@@ -43,7 +43,6 @@ recenter_slit, crop_slit):
 
 from warnings import warn
 
-import matplotlib.pyplot as plt
 import numpy as np
 from numpy import exp
 from numpy import log as ln
@@ -1048,6 +1047,7 @@ def plot_slit(
 
     """
 
+    import matplotlib.pyplot as plt
     from publib import set_style
 
     set_style("origin")


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

Improved RADIS import time by delaying the import of packages not necessarily used immediatly (or ever). 
(also added a test for Cantera calculations on the default Travis test environment)


Tested with [tuna](https://github.com/nschloe/tuna)

```
python -X importtime -c "import radis" 2> radimport.log
tuna radimport.log
```

Before : 

![image](https://user-images.githubusercontent.com/16088743/124766446-39bfd280-df37-11eb-913a-eb59e5aa081a.png)
![image](https://user-images.githubusercontent.com/16088743/124766750-78ee2380-df37-11eb-8518-70ed9ff88f26.png)


After:

![image](https://user-images.githubusercontent.com/16088743/124766937-a6d36800-df37-11eb-9fb9-f783da7f0c10.png)



So import is 75% faster (7s -> 4s) ! 


Delayed : 
- [x] Cantera      (rarely used)
- [x] Matplolib    (maybe not necessarily used in the future ; with a Bokeh/Plotly backend #179 )
- [x] Astroquery   (used only if fetching from HITRAN) 

What's left   (not for this PR)
- [ ] Astropy units . ; it's hard to delay Astropy because we need Astropy.units to know if user give Astropy.units. A way would be to "duck-test" it; i.e. evaluate a property. 
- [ ] Numba & underlying llvm  : is used here and there; in particular for Whiting's JIT. Would be a lot of work to delay this ; and may leave some bugs undected.
- [x] Pandas / Scipy / Numpy are required anyway. 

Notice the time it takes Numba to compute Whiting's JIT. 
