### PR TITLE
Fast part sum (partial summation)

### DIFF
--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -2391,42 +2391,55 @@ class BaseFactory(DatabankLoader):
                     parsum = self.get_partition_function_calculator(
                         molecule, iso, state
                     )
-                    Q, Qvib, dfQrot = parsum.at_noneq(
-                        Tvib,
-                        Trot,
-                        vib_distribution=vib_distribution,
-                        rot_distribution=rot_distribution,
-                        overpopulation=overpopulation,
-                        returnQvibQrot=True,
-                        update_populations=self.misc.export_populations,
-                    )
-
-                    # ... make sure PartitionFunction above is calculated with the same
-                    # ... temperatures, rovibrational distributions and overpopulations
-                    # ... as the populations of active levels (somewhere below)
-                    df.at[idx, "Qvib"] = Qvib
-                    df.at[idx, "Q"] = Q
-
-                    # reindexing to get a direct access to Qrot database
-                    # create the lookup dictionary
-                    # dfQrot index is already 'viblvl'
-                    dfQrot_dict = dict(list(zip(dfQrot.index, dfQrot.Qrot)))
-
-                    dg = df.loc[idx]
-
-                    # Add lower state Qrot
-                    dg_sorted = dg.set_index(["viblvl_l"], inplace=False)
-                    df.loc[idx, "Qrotl"] = dg_sorted.index.map(dfQrot_dict.get).values
-                    # Add upper state energy
-                    dg_sorted = dg.set_index(["viblvl_u"], inplace=False)
-                    df.loc[idx, "Qrotu"] = dg_sorted.index.map(dfQrot_dict.get).values
-
-                    # ... note: the .map() version is about 3x faster than
-                    # ... dg.groupby('viblvl_l').apply(lambda x: dfQrot_dict[x.name])
-
-                    if radis.DEBUG_MODE:
-                        assert (df.loc[idx, "id"] == id).all()
-                        assert (df.loc[idx, "iso"] == iso).all()
+                    if fast_sum:
+                        Q = parsum.at_noneq(
+                            Tvib,
+                            Trot,
+                            vib_distribution=vib_distribution,
+                            rot_distribution=rot_distribution,
+                            overpopulation=overpopulation,
+                            returnQvibQrot=False,
+                            update_populations=self.misc.export_populations,
+                            fast_sum=fast_sum
+                        )
+                        df.at[idx, "Q"] = Q
+                    else:
+                        Q, Qvib, dfQrot = parsum.at_noneq(
+                            Tvib,
+                            Trot,
+                            vib_distribution=vib_distribution,
+                            rot_distribution=rot_distribution,
+                            overpopulation=overpopulation,
+                            returnQvibQrot=True,
+                            update_populations=self.misc.export_populations,
+                        )
+    
+                        # ... make sure PartitionFunction above is calculated with the same
+                        # ... temperatures, rovibrational distributions and overpopulations
+                        # ... as the populations of active levels (somewhere below)
+                        df.at[idx, "Qvib"] = Qvib
+                        df.at[idx, "Q"] = Q
+    
+                        # reindexing to get a direct access to Qrot database
+                        # create the lookup dictionary
+                        # dfQrot index is already 'viblvl'
+                        dfQrot_dict = dict(list(zip(dfQrot.index, dfQrot.Qrot)))
+    
+                        dg = df.loc[idx]
+    
+                        # Add lower state Qrot
+                        dg_sorted = dg.set_index(["viblvl_l"], inplace=False)
+                        df.loc[idx, "Qrotl"] = dg_sorted.index.map(dfQrot_dict.get).values
+                        # Add upper state energy
+                        dg_sorted = dg.set_index(["viblvl_u"], inplace=False)
+                        df.loc[idx, "Qrotu"] = dg_sorted.index.map(dfQrot_dict.get).values
+    
+                        # ... note: the .map() version is about 3x faster than
+                        # ... dg.groupby('viblvl_l').apply(lambda x: dfQrot_dict[x.name])
+    
+                        if radis.DEBUG_MODE:
+                            assert (df.loc[idx, "id"] == id).all()
+                            assert (df.loc[idx, "iso"] == iso).all()
 
             else:
                 dgb = df.groupby(by=["iso"])
@@ -2440,41 +2453,54 @@ class BaseFactory(DatabankLoader):
                     parsum = self.get_partition_function_calculator(
                         molecule, iso, state
                     )
-                    Q, Qvib, dfQrot = parsum.at_noneq(
-                        Tvib,
-                        Trot,
-                        vib_distribution=vib_distribution,
-                        rot_distribution=rot_distribution,
-                        overpopulation=overpopulation,
-                        returnQvibQrot=True,
-                        update_populations=self.misc.export_populations,
-                    )
-
-                    # ... make sure PartitionFunction above is calculated with the same
-                    # ... temperatures, rovibrational distributions and overpopulations
-                    # ... as the populations of active levels (somewhere below)
-                    df.at[idx, "Qvib"] = Qvib
-                    df.at[idx, "Q"] = Q
-
-                    # reindexing to get a direct access to Qrot database
-                    # create the lookup dictionary
-                    # dfQrot index is already 'viblvl'
-                    dfQrot_dict = dict(list(zip(dfQrot.index, dfQrot.Qrot)))
-
-                    dg = df.loc[idx]
-
-                    # Add lower state Qrot
-                    dg_sorted = dg.set_index(["viblvl_l"], inplace=False)
-                    df.loc[idx, "Qrotl"] = dg_sorted.index.map(dfQrot_dict.get).values
-                    # Add upper state energy
-                    dg_sorted = dg.set_index(["viblvl_u"], inplace=False)
-                    df.loc[idx, "Qrotu"] = dg_sorted.index.map(dfQrot_dict.get).values
-
-                    # ... note: the .map() version is about 3x faster than
-                    # ... dg.groupby('viblvl_l').apply(lambda x: dfQrot_dict[x.name])
-
-                    if radis.DEBUG_MODE:
-                        assert (df.loc[idx, "iso"] == iso).all()
+                    if fast_sum:
+                        Q = parsum.at_noneq(
+                            Tvib,
+                            Trot,
+                            vib_distribution=vib_distribution,
+                            rot_distribution=rot_distribution,
+                            overpopulation=overpopulation,
+                            returnQvibQrot=False,
+                            update_populations=self.misc.export_populations,
+                            fast_sum=fast_sum
+                        )
+                        df.at[idx, "Q"] = Q
+                    else:
+                        Q, Qvib, dfQrot = parsum.at_noneq(
+                            Tvib,
+                            Trot,
+                            vib_distribution=vib_distribution,
+                            rot_distribution=rot_distribution,
+                            overpopulation=overpopulation,
+                            returnQvibQrot=True,
+                            update_populations=self.misc.export_populations,
+                        )
+    
+                        # ... make sure PartitionFunction above is calculated with the same
+                        # ... temperatures, rovibrational distributions and overpopulations
+                        # ... as the populations of active levels (somewhere below)
+                        df.at[idx, "Qvib"] = Qvib
+                        df.at[idx, "Q"] = Q
+    
+                        # reindexing to get a direct access to Qrot database
+                        # create the lookup dictionary
+                        # dfQrot index is already 'viblvl'
+                        dfQrot_dict = dict(list(zip(dfQrot.index, dfQrot.Qrot)))
+    
+                        dg = df.loc[idx]
+    
+                        # Add lower state Qrot
+                        dg_sorted = dg.set_index(["viblvl_l"], inplace=False)
+                        df.loc[idx, "Qrotl"] = dg_sorted.index.map(dfQrot_dict.get).values
+                        # Add upper state energy
+                        dg_sorted = dg.set_index(["viblvl_u"], inplace=False)
+                        df.loc[idx, "Qrotu"] = dg_sorted.index.map(dfQrot_dict.get).values
+    
+                        # ... note: the .map() version is about 3x faster than
+                        # ... dg.groupby('viblvl_l').apply(lambda x: dfQrot_dict[x.name])
+    
+                        if radis.DEBUG_MODE:
+                            assert (df.loc[idx, "iso"] == iso).all()
 
         self.profiler.stop("part_function", "partition functions")
         self.profiler.start("population", 3)

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -1129,6 +1129,7 @@ class SpectrumFactory(BandFactory):
         rot_distribution="boltzmann",
         overpopulation=None,
         name=None,
+        fast_sum=False
     ):
         """Calculate emission spectrum in non-equilibrium case. Calculates
         absorption with broadened linestrength and emission with broadened
@@ -1276,6 +1277,7 @@ class SpectrumFactory(BandFactory):
                 vib_distribution=vib_distribution,
                 rot_distribution=rot_distribution,
                 overpopulation=overpopulation,
+                fast_sum=fast_sum
             )
         else:
             self._calc_populations_noneq_multiTvib(
@@ -1284,6 +1286,7 @@ class SpectrumFactory(BandFactory):
                 vib_distribution=vib_distribution,
                 rot_distribution=rot_distribution,
                 overpopulation=overpopulation,
+                # fast_sum=fast_sum #!!!! TODO
             )
 
         self._calc_linestrength_noneq()

--- a/radis/levels/part_sum_fun.py
+++ b/radis/levels/part_sum_fun.py
@@ -9,11 +9,19 @@ from numba import jit
 from numpy import exp, abs
 from radis.phys.constants import hc_k  # ~ 1.44 cm.K
 
+
 @jit(nopython=True)
 def partial_partition_sum_nargs(
-    gvib_arr, Evib_arr, grot_arr, Erot_arr, Trot, Tvib, 
-    vib_distribution, 
-    rot_distribution, N=1000, rtol=1e-15
+    gvib_arr,
+    Evib_arr,
+    grot_arr,
+    Erot_arr,
+    Trot,
+    Tvib,
+    vib_distribution,
+    rot_distribution,
+    N=1000,
+    rtol=1e-15,
 ):
     """
     Partial sum of the partition function is incremented until convergence. See also: https://github.com/radis/radis-benchmark/blob/master/manual_benchmarks/fast-parsum.ipynb.
@@ -55,12 +63,12 @@ def partial_partition_sum_nargs(
         vib = gvib_arr[:N] * exp(-hc_k * (Evib_arr[:N] / Tvib + Evib_arr[:N] / Trot))
     else:
         raise NotImplementedError
-            
+
     if rot_distribution == "boltzmann":
         rot = grot_arr[:N] * exp(-hc_k * Erot_arr[:N] / Trot)
     else:
         raise NotImplementedError
-    
+
     s = (rot * vib).sum()
     i = N
     while abs(slast - s) / s > rtol and i <= len(gvib_arr):

--- a/radis/levels/part_sum_fun.py
+++ b/radis/levels/part_sum_fun.py
@@ -11,11 +11,14 @@ from radis.phys.constants import hc_k  # ~ 1.44 cm.K
 
 @jit(nopython=True)
 def partial_partition_sum_nargs(
-    gvib_arr, Evib_arr, grot_arr, Erot_arr, Trot, Tvib, N=100000, rtol=0.003e-2
+    gvib_arr, Evib_arr, grot_arr, Erot_arr, Trot, Tvib, 
+    vib_distribution, 
+    rot_distribution, N=1000, rtol=1e-15
 ):
     """
     Partial sum of the partition function is incremented until convergence. See also: https://github.com/radis/radis-benchmark/blob/master/manual_benchmarks/fast-parsum.ipynb.
     Parameters must be separated so that @jit can recognize types.
+    
     Parameters
     ----------
     gvib_arr : Array of float.
@@ -30,6 +33,10 @@ def partial_partition_sum_nargs(
         Rotational temperature.
     Tvib : Float.
         Vibrational temperature.
+    vib_distribution: ``'boltzmann'``, ``'treanor'``
+        Distribution of vibrational levels
+    rot_distribution: ``'boltzmann'``
+        Distribution of rotational levels
     N : Float., optional
         Number of states to add per increment. The default is 100000.
     rtol : Float., optional
@@ -42,8 +49,18 @@ def partial_partition_sum_nargs(
 
     """
     slast = 0
-    vib = gvib_arr[:N] * exp(-hc_k * Evib_arr[:N] / Tvib)
-    rot = grot_arr[:N] * exp(-hc_k * Erot_arr[:N] / Trot)
+    if vib_distribution == "boltzmann":
+        vib = gvib_arr[:N] * exp(-hc_k * Evib_arr[:N] / Tvib)
+    elif vib_distribution == "treanor":
+        vib = gvib_arr[:N] * exp(-hc_k * (Evib_arr[:N] / Tvib + Evib_arr[:N] / Trot))
+    else:
+        raise NotImplementedError
+            
+    if rot_distribution == "boltzmann":
+        rot = grot_arr[:N] * exp(-hc_k * Erot_arr[:N] / Trot)
+    else:
+        raise NotImplementedError
+    
     s = (rot * vib).sum()
     i = N
     while abs(slast - s) / s > rtol and i <= len(gvib_arr):

--- a/radis/levels/part_sum_fun.py
+++ b/radis/levels/part_sum_fun.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Jul 12 09:13:51 2021
+
+@author: mines
+"""
+
+from numba import jit
+from numpy import exp, abs
+from radis.phys.constants import hc_k  # ~ 1.44 cm.K
+
+@jit(nopython=True)
+def partial_partition_sum_nargs(
+    gvib_arr, Evib_arr, grot_arr, Erot_arr, Trot, Tvib, N=100000, rtol=0.003e-2
+):
+    """
+    Partial sum of the partition function is incremented until convergence. See also: https://github.com/radis/radis-benchmark/blob/master/manual_benchmarks/fast-parsum.ipynb.
+    Parameters must be separated so that @jit can recognize types.
+    Parameters
+    ----------
+    gvib_arr : Array of float.
+        Degeneracy of vibration.
+    Evib_arr : Array of float.
+        Energy of vibration.
+    grot_arr : Array of float.
+        Degeneracy of rotation.
+    Erot_arr : Array of float.
+        Energy of rotation.
+    Trot : Float.
+        Rotational temperature.
+    Tvib : Float.
+        Vibrational temperature.
+    N : Float., optional
+        Number of states to add per increment. The default is 100000.
+    rtol : Float., optional
+        Relative tolerance for convergence. The default is 0.003e-2.
+
+    Returns
+    -------
+    s : Float.
+        Partition function summed until convergence.
+
+    """
+    slast = 0
+    vib = gvib_arr[:N] * exp(-hc_k * Evib_arr[:N] / Tvib)
+    rot = grot_arr[:N] * exp(-hc_k * Erot_arr[:N] / Trot)
+    s = (rot * vib).sum()
+    i = N
+    while abs(slast - s) / s > rtol and i <= len(gvib_arr):
+        slast = s
+        vib_new = gvib_arr[i : i + N] * exp(-hc_k * Evib_arr[i : i + N] / Tvib)
+        rot_new = grot_arr[i : i + N] * exp(-hc_k * Erot_arr[i : i + N] / Trot)
+        s += (vib_new * rot_new).sum()
+        i += N
+
+    return s

--- a/radis/levels/partfunc.py
+++ b/radis/levels/partfunc.py
@@ -504,6 +504,8 @@ class RovibParFuncCalculator(RovibPartitionFunction):
                     Erot_arr=np.array(df.Erot),
                     Trot=Trot,
                     Tvib=Tvib,
+                    vib_distribution=vib_distribution,
+                    rot_distribution=rot_distribution,
                     N=N,
                     rtol=rtol,
                 )
@@ -521,11 +523,11 @@ class RovibParFuncCalculator(RovibPartitionFunction):
 
                 Q = nQ.sum()
 
-            # Update energy level table with populations (doesnt
-            # cost much and can be used to plot populations afterwards)
-            # ... add: 'n'
-            if update_populations:
-                df["n"] = nQ / Q
+                # Update energy level table with populations (doesnt
+                # cost much and can be used to plot populations afterwards)
+                # ... add: 'n'
+                if update_populations:
+                    df["n"] = nQ / Q
 
             return Q
 

--- a/radis/levels/partfunc.py
+++ b/radis/levels/partfunc.py
@@ -387,7 +387,6 @@ class RovibParFuncCalculator(RovibPartitionFunction):
         gvib = df.gvib  # self.gvib(M, I)
         grot = df.grot
         # Calculate
-
         if returnQvibQrot:
 
             if not "viblvl" in self.df:
@@ -495,8 +494,7 @@ class RovibParFuncCalculator(RovibPartitionFunction):
         # ... mode: Trot, Tvib, no overpopulation, no vib band details
         else:  # slightly faster, but doesnt return nvib nor Qvib
             if fast_sum:
-                
-                rtol, N = 1e-15, 1000  # number found after a few tests on CO2(iso=1)
+                rtol, N = 1e-15, 10000  # number found after a few tests on CO2(iso=1)
                 Q = partial_partition_sum_nargs(
                     gvib_arr=np.array(gvib),
                     Evib_arr=np.array(df.Evib),

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -3488,7 +3488,7 @@ class Spectrum(object):
         wunit=None,
         inplace=False,
         force=False,
-        verbose=True,
+        verbose=False,
     ):
         """Normalise the Spectrum, if only one spectral quantity is available.
 

--- a/radis/test/lbl/test_base.py
+++ b/radis/test/lbl/test_base.py
@@ -62,6 +62,16 @@ def test_populations(plot=True, verbose=True, warnings=True, *args, **kwargs):
     if plot:
         s.plot_populations()
 
+    # Test the fast_sum module
+    s_fast = sf.non_eq_spectrum(300, 300, fast_sum=True)
+    
+    b1 = np.isclose(
+        s.get_integral("abscoeff"),
+        s_fast.get_integral("abscoeff"),
+        rtol=1e-6,
+    )
+    assert b1
+    
     # Compare with factory
     # Plot populations:
     with pytest.raises(ValueError):

--- a/radis/test/lbl/test_base.py
+++ b/radis/test/lbl/test_base.py
@@ -70,7 +70,19 @@ def test_populations(plot=True, verbose=True, warnings=True, *args, **kwargs):
         s_fast.get_integral("abscoeff"),
         rtol=1e-6,
     )
+    
+    
+    s_fast2 = sf.non_eq_spectrum(3000, 1500, fast_sum=True)
+    #we finish by one with the populations exported so that the next tests can run
+    s_slow = sf.non_eq_spectrum(3000, 1500, fast_sum=False) 
+    
+    b2 = np.isclose(
+        s_fast2.get_integral("abscoeff"),
+        s_slow.get_integral("abscoeff"),
+        rtol=1e-6,
+    )
     assert b1
+    assert b2
     
     # Compare with factory
     # Plot populations:


### PR DESCRIPTION
Hi guys,

I'm trying to implement @dcmvdbekerom and @erwanp ideas to accelerate the computation of non-eq spectra: https://github.com/radis/radis-benchmark/blob/master/manual_benchmarks/fast-parsum.ipynb

So far the calculation of a spectra significantly accelerated. On my side, I switched from 0.26s to 0.08s in this specific example with CO2. Couldn't see improvement for CO though.

**Example:**   (mind the first call is always longer)
```python
from radis import SpectrumFactory

wmin, wmax = 2383.8, 2384.9
sf = SpectrumFactory(wavenum_min=wmin,
                     wavenum_max=wmax,
                     # molecule='CO',
                      molecule='CO2',
                     isotope='1',
                     broadening_max_width=5,  # cm-1
                     medium='air', 
                     verbose=3,    
                     path_length=10.32, #cm
                       wstep=0.001, 
                     )
sf.fetch_databank()
sf.df0.dropna(subset=['v1u'], inplace=True)
Ttrans, Trot, Tvib = 2000, 2100, 1500
s_HITEMP = sf.non_eq_spectrum(
                            mole_fraction=0.2, 
                            pressure = 1,
                            Ttrans = Ttrans,
                            Trot = Trot,
                            Tvib = Tvib,
                            name='CO2 - Ts = ({:.0f}, {:.0f}) K'.format(Ttrans, Tvib),
                            fast_sum = False
                            )
s_HITEMP2 = sf.non_eq_spectrum(
                            mole_fraction=0.2, 
                            pressure = 1,
                            Ttrans = Ttrans,
                            Trot = Trot,
                            Tvib = Tvib,
                            name='CO2 - Ts = ({:.0f}, {:.0f}) K'.format(Ttrans, Tvib),
                            fast_sum = True
                            )
```
**Output:**
```python
----------------------------------------
0.00s - Checked nonequilibrium parameters
sorting lines by vibrational bands
lines sorted in 0.0s
...... 0.21s - partition functions
...... 0.01s - populations
0.21s - Calculated nonequilibrium populations
...... 0.00s - map partition functions
...... 0.00s - corrected for populations and stimulated emission
0.00s - scaled nonequilibrium linestrength
0.00s - calculated emission integral
0.00s - Calculated lineshift
0.00s - Calculate broadening HWHM
Calculating line broadening (133 lines: expect ~ 0.07s on 1 CPU)
...... 0.00s - Precomputed DLM lineshapes (8)
...... 0.00s - Initialized vectors
...... 0.00s - Get closest matching line & fraction
...... 0.00s - Distribute lines over DLM
...... 0.00s - Convolve and sum on spectral range
...... 0.00s - Initialized vectors
...... 0.00s - Get closest matching line & fraction
...... 0.00s - Distribute lines over DLM
...... 0.00s - Convolve and sum on spectral range
0.01s - Calculated line broadening
0.00s - Calculated other spectral quantities
0.26s - Spectrum calculated (before object generation)
0.00s - Generated Spectrum object
0.26s - Spectrum calculated
--------------
---
--------------
0.00s - Checked nonequilibrium parameters
sorting lines by vibrational bands
lines sorted in 0.0s
...... 0.03s - partition functions
...... 0.00s - populations
0.04s - Calculated nonequilibrium populations
...... 0.00s - map partition functions
...... 0.00s - corrected for populations and stimulated emission
0.00s - scaled nonequilibrium linestrength
0.00s - calculated emission integral
0.00s - Calculated lineshift
0.00s - Calculate broadening HWHM
Calculating line broadening (133 lines: expect ~ 0.07s on 1 CPU)
...... 0.00s - Precomputed DLM lineshapes (8)
...... 0.00s - Initialized vectors
...... 0.00s - Get closest matching line & fraction
...... 0.00s - Distribute lines over DLM
...... 0.00s - Convolve and sum on spectral range
...... 0.00s - Initialized vectors
...... 0.00s - Get closest matching line & fraction
...... 0.00s - Distribute lines over DLM
...... 0.00s - Convolve and sum on spectral range
0.01s - Calculated line broadening
0.00s - Calculated other spectral quantities
0.08s - Spectrum calculated (before object generation)
0.00s - Generated Spectrum object
0.08s - Spectrum calculated
```
What is weird in the function `partial_partition_sum_nargs ` is that the N parameter, the number of states we include at each iteration, does not have an impact on the speed of the computation, which I found weird.

Also:
- [ ] need to add a function for 3 Tvib for CO2.

Related to issue #313 