### PR TITLE
add on-the-fly-tabulation of calculated (eq/nonequilibrium) partition functions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -33,3 +33,4 @@ dependencies:
   - json-tricks>=3.15.0  # to deal with non jsonable formats
   - mpldatacursor
   - tuna           # to generate visual/interactive performance profiles
+  - vaex    # load HDF5 files

--- a/radis/io/query.py
+++ b/radis/io/query.py
@@ -204,7 +204,12 @@ def fetch_astroquery(
     }
 
     if not empty_range:
-        tbl = Hitran._parse_result(response)
+        try:
+            tbl = Hitran._parse_result(response)
+        except ValueError as err:
+            raise ValueError(
+                "Error while parsing HITRAN output : {}".format(response.text)
+            ) from err
         df = tbl.to_pandas()
         df = df.rename(columns=rename_columns)
     else:

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -2334,36 +2334,50 @@ class BaseFactory(DatabankLoader):
 
             state = self.input.state
             parsum = self.get_partition_function_calculator(molecule, iso, state)
-            Q, Qvib, dfQrot = parsum.at_noneq(
-                Tvib,
-                Trot,
-                vib_distribution=vib_distribution,
-                rot_distribution=rot_distribution,
-                overpopulation=overpopulation,
-                returnQvibQrot=True,
-                update_populations=self.misc.export_populations,
-            )
-            # ... make sure PartitionFunction above is calculated with the same
-            # ... temperatures, rovibrational distributions and overpopulations
-            # ... as the populations of active levels (somewhere below)
-            df.attrs["Qvib"] = Qvib
-            df.attrs["Q"] = Q
-            assert "Qvib" not in df.columns
-            assert "Q" not in df.columns
 
-            # reindexing to get a direct access to Qrot database
-            # create the lookup dictionary
-            # dfQrot index is already 'viblvl'
-            dfQrot_dict = dict(list(zip(dfQrot.index, dfQrot.Qrot)))
+            if self.misc.parsum_mode == 'tabulation':
 
-            dg = df.loc[:]
+                Q = parsum.at_noneq(
+                    Tvib,
+                    Trot,
+                    vib_distribution=vib_distribution,
+                    rot_distribution=rot_distribution,
+                    overpopulation=overpopulation,
+                    returnQvibQrot=False,
+                    update_populations=self.misc.export_populations
+                )
 
-            # Add lower state Qrot
-            dg_sorted = dg.set_index(["viblvl_l"], inplace=False)
-            df.loc[:, "Qrotl"] = dg_sorted.index.map(dfQrot_dict.get).values
-            # Add upper state energy
-            dg_sorted = dg.set_index(["viblvl_u"], inplace=False)
-            df.loc[:, "Qrotu"] = dg_sorted.index.map(dfQrot_dict.get).values
+            else:
+	            Q, Qvib, dfQrot = parsum.at_noneq(
+	                Tvib,
+	                Trot,
+	                vib_distribution=vib_distribution,
+	                rot_distribution=rot_distribution,
+	                overpopulation=overpopulation,
+	                returnQvibQrot=True,
+	                update_populations=self.misc.export_populations,
+	            )
+	            # ... make sure PartitionFunction above is calculated with the same
+	            # ... temperatures, rovibrational distributions and overpopulations
+	            # ... as the populations of active levels (somewhere below)
+	            df.attrs["Qvib"] = Qvib
+	            df.attrs["Q"] = Q
+	            assert "Qvib" not in df.columns
+	            assert "Q" not in df.columns
+
+	            # reindexing to get a direct access to Qrot database
+	            # create the lookup dictionary
+	            # dfQrot index is already 'viblvl'
+	            dfQrot_dict = dict(list(zip(dfQrot.index, dfQrot.Qrot)))
+
+	            dg = df.loc[:]
+
+	            # Add lower state Qrot
+	            dg_sorted = dg.set_index(["viblvl_l"], inplace=False)
+	            df.loc[:, "Qrotl"] = dg_sorted.index.map(dfQrot_dict.get).values
+	            # Add upper state energy
+	            dg_sorted = dg.set_index(["viblvl_u"], inplace=False)
+	            df.loc[:, "Qrotu"] = dg_sorted.index.map(dfQrot_dict.get).values
 
         else:  #  multiple isotopes
             dgb = df.groupby(by=["iso"])
@@ -2372,41 +2386,58 @@ class BaseFactory(DatabankLoader):
                 # Get partition function for all lines
                 state = self.input.state
                 parsum = self.get_partition_function_calculator(molecule, iso, state)
-                Q, Qvib, dfQrot = parsum.at_noneq(
-                    Tvib,
-                    Trot,
-                    vib_distribution=vib_distribution,
-                    rot_distribution=rot_distribution,
-                    overpopulation=overpopulation,
-                    returnQvibQrot=True,
-                    update_populations=self.misc.export_populations,
-                )
 
-                # ... make sure PartitionFunction above is calculated with the same
-                # ... temperatures, rovibrational distributions and overpopulations
-                # ... as the populations of active levels (somewhere below)
-                df.at[idx, "Qvib"] = Qvib
-                df.at[idx, "Q"] = Q
+	            if self.misc.parsum_mode == 'tabulation':
 
-                # reindexing to get a direct access to Qrot database
-                # create the lookup dictionary
-                # dfQrot index is already 'viblvl'
-                dfQrot_dict = dict(list(zip(dfQrot.index, dfQrot.Qrot)))
+	                Q = parsum.at_noneq(
+	                    Tvib,
+	                    Trot,
+	                    vib_distribution=vib_distribution,
+	                    rot_distribution=rot_distribution,
+	                    overpopulation=overpopulation,
+	                    returnQvibQrot=False,
+	                    update_populations=self.misc.export_populations
+	                )
+	                # TODO: add to Qgas dictionary ?
+	                
+	            else:
 
-                dg = df.loc[idx]
 
-                # Add lower state Qrot
-                dg_sorted = dg.set_index(["viblvl_l"], inplace=False)
-                df.loc[idx, "Qrotl"] = dg_sorted.index.map(dfQrot_dict.get).values
-                # Add upper state energy
-                dg_sorted = dg.set_index(["viblvl_u"], inplace=False)
-                df.loc[idx, "Qrotu"] = dg_sorted.index.map(dfQrot_dict.get).values
+	                Q, Qvib, dfQrot = parsum.at_noneq(
+	                    Tvib,
+	                    Trot,
+	                    vib_distribution=vib_distribution,
+	                    rot_distribution=rot_distribution,
+	                    overpopulation=overpopulation,
+	                    returnQvibQrot=True,
+	                    update_populations=self.misc.export_populations,
+	                )
 
-                if radis.DEBUG_MODE:
-                    assert (df.loc[idx, "iso"] == iso).all()
+	                # ... make sure PartitionFunction above is calculated with the same
+	                # ... temperatures, rovibrational distributions and overpopulations
+	                # ... as the populations of active levels (somewhere below)
+	                df.at[idx, "Qvib"] = Qvib
+	                df.at[idx, "Q"] = Q
 
-            Qvib = df.Qvib
-            Q = df.Q
+	                # reindexing to get a direct access to Qrot database
+	                # create the lookup dictionary
+	                # dfQrot index is already 'viblvl'
+	                dfQrot_dict = dict(list(zip(dfQrot.index, dfQrot.Qrot)))
+
+	                dg = df.loc[idx]
+
+	                # Add lower state Qrot
+	                dg_sorted = dg.set_index(["viblvl_l"], inplace=False)
+	                df.loc[idx, "Qrotl"] = dg_sorted.index.map(dfQrot_dict.get).values
+	                # Add upper state energy
+	                dg_sorted = dg.set_index(["viblvl_u"], inplace=False)
+	                df.loc[idx, "Qrotu"] = dg_sorted.index.map(dfQrot_dict.get).values
+
+	                if radis.DEBUG_MODE:
+	                    assert (df.loc[idx, "iso"] == iso).all()
+
+		            Qvib = df.Qvib
+		            Q = df.Q
 
         self.profiler.stop("part_function", "partition functions")
         self.profiler.start("population", 3)
@@ -2414,42 +2445,72 @@ class BaseFactory(DatabankLoader):
         # %%
 
         #  Derive populations
-        # ... vibrational distribution
-        if vib_distribution == "boltzmann":
-            # equation generated with @pytexit.py2tex > see docstrings.
-            df["nu_vib"] = df.gvibu / Qvib * exp(-hc_k * df.Evibu / Tvib)
-            df["nl_vib"] = df.gvibl / Qvib * exp(-hc_k * df.Evibl / Tvib)
-        elif vib_distribution == "treanor":
-            df["nu_vib"] = (
-                df.gvibu / Qvib * exp(-hc_k * (df.Evibu_h / Tvib + df.Evibu_a / Trot))
-            )
-            df["nl_vib"] = (
-                df.gvibl / Qvib * exp(-hc_k * (df.Evibl_h / Tvib + df.Evibl_a / Trot))
-            )
-        else:
-            raise ValueError(
-                "Unknown vibrational distribution: {0}".format(vib_distribution)
-            )
+        if self.misc.parsum_mode == 'tabulation':
+            # ... vibrational distribution
+            if vib_distribution == "boltzmann":
+                df["nu_vib_x_Qvib"] = df.gvibu * exp(-hc_k * df.Evibu / Tvib)
+                df["nl_vib_x_Qvib"] = df.gvibl * exp(-hc_k * df.Evibl / Tvib)
+            elif vib_distribution == "treanor":
+                raise NotImplementedError("TO DO!") #!!!TODO 
+            else:
+                raise ValueError(
+                    "Unknown vibrational distribution: {0}".format(vib_distribution)
+                )
+                
+            # ... Rotational distributions
+            if rot_distribution == "boltzmann":
+                df["nu_rot_x_Qrot"] = df.grotu * exp(-df.Erotu * hc_k / Trot)
+                df["nl_rot_x_Qrot"] = df.grotl * exp(-df.Erotl * hc_k / Trot)
+            else:
+                raise ValueError(
+                    "Unknown rotational distribution: {0}".format(rot_distribution)
+                )
+                
+            # ... Total
+            df["nu"] = df.nu_vib_x_Qvib * df.nu_rot_x_Qrot  / df.Q
+            df["nl"] = df.nl_vib_x_Qvib * df.nl_rot_x_Qrot  / df.Q
+            
+        else: #self.misc.parsum_mode == 'full summation':
+            # ... vibrational distribution
+            if vib_distribution == "boltzmann":
+                # equation generated with @pytexit.py2tex > see docstrings.
+                df["nu_vib"] = df.gvibu / Qvib * exp(-hc_k * df.Evibu / Tvib)
+                df["nl_vib"] = df.gvibl / Qvib * exp(-hc_k * df.Evibl / Tvib)
+            elif vib_distribution == "treanor":
+                df["nu_vib"] = (
+                    df.gvibu
+                    / Qvib
+                    * exp(-hc_k * (df.Evibu_h / Tvib + df.Evibu_a / Trot))
+                )
+                df["nl_vib"] = (
+                    df.gvibl
+                    / Qvib
+                    * exp(-hc_k * (df.Evibl_h / Tvib + df.Evibl_a / Trot))
+                )
+            else:
+                raise ValueError(
+                    "Unknown vibrational distribution: {0}".format(vib_distribution)
+                )
 
-        # ... Add vibrational-specific overpopulation factors
-        if overpopulation != {}:
-            for viblvl, ov in overpopulation.items():
-                if ov != 1:
-                    df.loc[df.viblvl_u == viblvl, "nu_vib"] *= ov
-                    df.loc[df.viblvl_l == viblvl, "nl_vib"] *= ov
+            # ... Add vibrational-specific overpopulation factors
+            if overpopulation != {}:
+                for viblvl, ov in overpopulation.items():
+                    if ov != 1:
+                        df.loc[df.viblvl_u == viblvl, "nu_vib"] *= ov
+                        df.loc[df.viblvl_l == viblvl, "nl_vib"] *= ov
 
-        # ... Rotational distributions
-        if rot_distribution == "boltzmann":
-            df["nu_rot"] = df.grotu / df.Qrotu * exp(-df.Erotu * hc_k / Trot)
-            df["nl_rot"] = df.grotl / df.Qrotl * exp(-df.Erotl * hc_k / Trot)
-        else:
-            raise ValueError(
-                "Unknown rotational distribution: {0}".format(rot_distribution)
-            )
+            # ... Rotational distributions
+            if rot_distribution == "boltzmann":
+                df["nu_rot"] = df.grotu / df.Qrotu * exp(-df.Erotu * hc_k / Trot)
+                df["nl_rot"] = df.grotl / df.Qrotl * exp(-df.Erotl * hc_k / Trot)
+            else:
+                raise ValueError(
+                    "Unknown rotational distribution: {0}".format(rot_distribution)
+                )
 
-        # ... Total
-        df["nu"] = df.nu_vib * df.nu_rot * (df.Qrotu * Qvib / Q)
-        df["nl"] = df.nl_vib * df.nl_rot * (df.Qrotl * Qvib / Q)
+            # ... Total
+            df["nu"] = df.nu_vib * df.nu_rot * (df.Qrotu * Qvib / Q)
+            df["nl"] = df.nl_vib * df.nl_rot * (df.Qrotl * Qvib / Q)
 
         if __debug__:
             assert "nu" in self.df1

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -1513,7 +1513,7 @@ class BaseFactory(DatabankLoader):
 
         if "id" in df:
             id_set = df.id.unique()
-            if len(id_set) > 0:
+            if len(id_set) > 1:
                 raise NotImplementedError("> 1 molecules in same DataFrame")
             else:
                 self.warn(
@@ -1593,6 +1593,49 @@ class BaseFactory(DatabankLoader):
         df["gl"] = df.gvibl * df.grotl
 
         return None  # dataframe updated directly
+
+    def get_abundance(self, df):
+        """Returns the isotopic abundance
+
+        Parameters
+        ----------
+        df: dataframe
+
+        Returns
+        -------
+        float or dict: The abundance of all the isotopes in the dataframe
+        """
+
+        molpar = MolParams()
+
+        if "id" in df.columns:
+            id_set = df.id.unique()
+            if len(id_set) > 1:
+                raise NotImplementedError("> 1 molecules in same DataFrame")
+            else:
+                self.warn(
+                    "There shouldn't be a Column 'id' with a unique value",
+                    "PerformanceWarning",
+                )
+                df.attrs["id"] = int(id_set)
+
+        if "iso" in df.columns:
+            iso_set = df.iso.unique()
+            if len(iso_set) == 1:
+                self.warn(
+                    "There shouldn't be a Column 'iso' with a unique value",
+                    "PerformanceWarning",
+                )
+                iso = int(iso_set)
+                return molpar.get(df.attrs["id"], iso, "abundance")
+            else:
+                abundance_dict = {}
+                for iso in iso_set:
+                    abundance_dict[iso] = molpar.get(df.attrs["id"], iso, "abundance")
+                return df["iso"].map(abundance_dict)
+        else:
+            iso = df.attrs["iso"]
+            return molpar.get(df.attrs["id"], iso, "abundance")
 
     def calc_weighted_trans_moment(self):
         """Calculate weighted transition-moment squared :math:`R_s^2` (in ``Debye^2``)
@@ -1678,7 +1721,7 @@ class BaseFactory(DatabankLoader):
         # Get moment
 
         # get abundance
-        abundance = get_abundance(df)
+        abundance = self.get_abundance(df)
 
         gl = df.gl
         El = df.El
@@ -1712,7 +1755,7 @@ class BaseFactory(DatabankLoader):
 
         if "id" in df:
             id_set = df.id.unique()
-            if len(id_set) > 0:
+            if len(id_set) > 1:
                 raise NotImplementedError("> 1 molecules in same DataFrame")
             else:
                 self.warn(
@@ -1864,7 +1907,6 @@ class BaseFactory(DatabankLoader):
         """
 
         self.profiler.start("calc_lineshift", 2)
-        #            printg('> Calculating lineshift')
 
         df = self.df1
 
@@ -1972,31 +2014,36 @@ class BaseFactory(DatabankLoader):
                 )
                 df1.attrs["id"] = int(id_set)
 
-        Qref_Qgas_ratio = {}
-
         if "molecule" in df1.attrs:
             molecule = df1.attrs["molecule"]  # used for ExoMol, which has no HITRAN-id
         else:
             molecule = get_molecule(df1.attrs["id"])
-        iso_set = self._get_isotope_list(molecule)  # df1.iso.unique()
+        state = self.input.state
 
-        # Shortcut if only 1 molecule, 1 isotope. We attribute molar_mass & abundance
-        # as attributes of the line database, instead of columns. Much
-        # faster!
+        def Qref_Qgas_ratio():
 
-        if len(iso_set) == 1:
-            Qref, Qgas = _calc_Q(molecule, iso_set[0], self.input.state)
-            Qref_Qgas_ratio[iso_set[0]] = Qref / Qgas
+            if "iso" in df1:
+                iso_set = df1.iso.unique()  # self._get_isotope_list(molecule)
+                if len(iso_set) == 1:
+                    self.warn(
+                        "There shouldn't be a Column 'iso' with a unique value",
+                        "PerformanceWarning",
+                    )
+                    iso = int(iso_set)
+                    Qref, Qgas = _calc_Q(molecule, iso, state)
+                    return Qref / Qgas
 
-        # Else, parse for all isotopes. Use df.map that is very fast
-        else:
+                else:
+                    Qref_Qgas_ratio = {}
+                    for iso in iso_set:
+                        Qref, Qgas = _calc_Q(molecule, iso, state)
+                        Qref_Qgas_ratio[iso] = Qref / Qgas
+                    return df1["iso"].map(Qref_Qgas_ratio)
 
-            iso_arr = list(range(max(iso_set) + 1))
-
-            for iso in iso_arr:
-                if iso in iso_set:
-                    Qref, Qgas = _calc_Q(molecule, iso, self.input.state)
-                    Qref_Qgas_ratio[iso] = Qref / Qgas
+            else:
+                iso = df1.attrs["iso"]
+                Qref, Qgas = _calc_Q(molecule, iso, state)
+                return Qref / Qgas
 
         # %% Calculate line strength at desired temperature
         # -------------------------------------------------
@@ -2007,21 +2054,17 @@ class BaseFactory(DatabankLoader):
         # Einstein A coefficient and the populations (see Klarenaar 2017 Eqn. 12)
 
         # correct for Partition Function
-
-        # multiple-isotopes in database
-        if "iso" in df1:
-            line_strength = df1.int * (df1["iso"].map(Qref_Qgas_ratio))
-        else:
-            assert len(Qref_Qgas_ratio) == 1
-            Qref_Qgas_ratio = list(Qref_Qgas_ratio.values())[0]
-            line_strength = df1.int * Qref_Qgas_ratio
-        # ratio of Boltzman populations
-        line_strength *= exp(-hc_k * df1.El * (1 / Tgas - 1 / Tref))
-        # effect of stimulated emission
-        line_strength *= (1 - exp(-hc_k * df1.wav / Tgas)) / (
-            1 - exp(-hc_k * df1.wav / Tref)
-        )
-        df1["S"] = line_strength  # [cm-1/(molecules/cm-2)]
+        df1["S"] = (
+            df1.int
+            * Qref_Qgas_ratio()
+            *
+            # ratio of Boltzman populations
+            exp(-hc_k * df1.El * (1 / Tgas - 1 / Tref))
+            *
+            # effect of stimulated emission
+            (1 - exp(-hc_k * df1.wav / Tgas))
+            / (1 - exp(-hc_k * df1.wav / Tref))
+        )  # [cm-1/(molecules/cm-2)]
 
         assert "S" in self.df1
 
@@ -2068,10 +2111,61 @@ class BaseFactory(DatabankLoader):
         df1 = self.df1
 
         self.profiler.start("calc_eq_population", 2)
-        #            printg('> Calculating equilibrium populations')
 
-        # get Qgas values in the form of a dictionary
-        Qgas_dict = self.get_Qgas(df1, Tgas)
+        # Partition functions
+        def Qgas(Tgas):
+            """Aggregate the values of Qgas
+
+            Parameters
+            ----------
+            Tgas: float (K)
+                gas temperature
+
+            Returns
+            -------
+            float or dict: Returns Qgas as a dictionary with isotope values as its keys
+
+            """
+            if "id" in df1:
+                id_set = df1.id.unique()
+                if len(id_set) > 1:
+                    raise NotImplementedError("> 1 molecules in same DataFrame")
+                else:
+                    self.warn(
+                        "There shouldn't be a Column 'id' with a unique value",
+                        "PerformanceWarning",
+                    )
+                    df1.attrs["id"] = int(id_set)
+
+            molecule = get_molecule(df1.attrs["id"])
+            state = self.input.state
+
+            if "iso" in df1:
+                iso_set = df1.iso.unique()
+                if len(iso_set) == 1:
+                    self.warn(
+                        "There shouldn't be a Column 'iso' with a unique value",
+                        "PerformanceWarning",
+                    )
+                    iso = int(iso_set)
+                    parsum = self.get_partition_function_interpolator(
+                        molecule, iso, state
+                    )
+                    # TODO : use _calc_Q instead ? (which switches to partition function calculator if possible?)
+                    return parsum.at(Tgas)
+                else:
+                    Qgas_dict = {}
+                    for iso in iso_set:
+                        parsum = self.get_partition_function_interpolator(
+                            molecule, iso, state
+                        )
+                        Qgas_dict[iso] = parsum.at(Tgas)
+                return df1["iso"].map(Qgas_dict)
+
+            else:  # "iso" not in df:
+                iso = df1.attrs["iso"]
+                parsum = self.get_partition_function_interpolator(molecule, iso, state)
+                return parsum.at(Tgas)
 
         # Calculate degeneracies
         # ----------------------------------------------------------------------
@@ -2089,115 +2183,13 @@ class BaseFactory(DatabankLoader):
         # Calculate population
         # ----------------------------------------------------------------------
         # equilibrium: Boltzmann in any case
-
-        # multiple-isotopes in database
-
-        # extract Qgas in the required form from the dictionary
-        Qgas = self.getQ_from_dict(df1, Qgas_dict)
-
-        df1["nu"] = df1.gu.values * exp(-hc_k * df1.Eu.values / Tgas) / Qgas
+        df1["nu"] = df1.gu.values * exp(-hc_k * df1.Eu.values / Tgas) / Qgas(Tgas)
 
         assert "nu" in self.df1
 
         self.profiler.stop("calc_eq_population", "Calculated equilibrium populations")
 
         return
-
-    def getQ_from_dict(self, df, Qgas):
-
-        """Returns the required value of Qgas for calculation of linestrength
-        from Qgas dictionary
-
-        Parameters
-        ----------
-        df: dataframe
-        Qgas: dictionary that contais Qgas values of various isotopes
-
-        Returns
-        -------
-        The required value of Qgas either in the form of just a float value or array-like value
-
-        """
-
-        # multiple isotopes
-        if "iso" in df:
-            Q_req = df["iso"].map(Qgas)
-
-        # single isotopes
-        else:
-            Qgas = list(Qgas.values())
-            Q_req = Qgas[0]
-
-        return Q_req
-
-    def get_Qgas(self, df, Tgas):
-
-        """Aggregates the values of Qgas
-
-        Parameters
-        ----------
-        df: dataframe
-        Tgas: float (K)
-            gas temperature
-
-        Returns
-        -------
-        Returns Qgas as a dictionary with isotope values as its keys
-
-        """
-
-        Qgas = {}
-
-        if "id" in df and "iso" in df:
-
-            dgb = df.groupby(by=["id", "iso"])
-
-            for (id, iso), idx in dgb.indices.items():
-                molecule = get_molecule(id)
-                state = self.input.state
-                parsum = self.get_partition_function_interpolator(molecule, iso, state)
-                Qgas[iso] = parsum.at(Tgas)
-
-                if radis.DEBUG_MODE:
-                    assert (df.loc[idx, "id"] == id).all()
-                    assert (df.loc[idx, "iso"] == iso).all()
-
-        elif "id" not in df and "iso" in df:
-
-            dgb = df.groupby(by=["id"])
-
-            id = df.attrs["id"]
-            iso1 = list(dgb.indices.keys())[0]
-            molecule = get_molecule(id)
-            state = self.input.state
-            parsum = self.get_partition_function_interpolator(molecule, iso1, state)
-            Qgas[iso1] = parsum.at(Tgas)
-
-        elif "id" in df and "iso" not in df:
-
-            dgb = df.groupby(by=["id"])
-            iso = df.attrs["iso"]
-
-            for (id), idx in dgb.indices.items():
-                molecule = get_molecule(id)
-                state = self.input.state
-                parsum = self.get_partition_function_interpolator(molecule, iso, state)
-                Qgas[iso] = parsum.at(Tgas)
-
-                if radis.DEBUG_MODE:
-                    assert (df.loc[idx, "id"] == id).all()
-
-        elif "id" not in df and "iso" not in df:
-
-            iso = df.attrs["iso"]
-            id = df.attrs["id"]
-
-            molecule = get_molecule(id)
-            state = self.input.state
-            parsum = self.get_partition_function_interpolator(molecule, iso, state)
-            Qgas[iso] = parsum.at(Tgas)
-
-        return Qgas
 
     # %%
     def calc_populations_noneq(
@@ -2323,122 +2315,140 @@ class BaseFactory(DatabankLoader):
                 )
                 df.attrs["id"] = int(id_set)
         molecule = get_molecule(df.attrs["id"])
+        state = self.input.state
 
-        iso_set = self._get_isotope_list()  # df1.iso.unique()
-        if len(iso_set) == 1:
-            iso = iso_set[0]
+        def Q(Tvib, Trot):
+            """Nonequilibrium partition function
 
-            # Shortcut if only 1 molecule, 1 isotope. We attribute molar_mass & abundance
-            # as attributes of the line database, instead of columns. Much
-            # faster!
+            Returns
+            -------
+            column or float: depending if there are many isotopes or one"""
 
-            state = self.input.state
-            parsum = self.get_partition_function_calculator(molecule, iso, state)
+            if "iso" in df:
+                Q_dict = {}
+                iso_set = df.iso.unique()  #  self._get_isotope_list()
+                if len(iso_set) > 1:
+                    self.warn(
+                        "There shouldn't be a Column 'iso' with a unique value",
+                        "PerformanceWarning",
+                    )
+                for iso in iso_set:
+                    parsum = self.get_partition_function_calculator(
+                        molecule, iso, state
+                    )
+                    Q_dict[iso] = parsum.at_noneq(
+                        Tvib,
+                        Trot,
+                        vib_distribution=vib_distribution,
+                        rot_distribution=rot_distribution,
+                        overpopulation=overpopulation,
+                        update_populations=self.misc.export_populations,
+                    )
+                return df["iso"].map(Q_dict)
 
-            if not self.misc.export_rovib_fraction:
-
-                Q = parsum.at_noneq(
+            else:  # "iso" not in df:
+                iso = df.attrs["iso"]
+                parsum = self.get_partition_function_calculator(molecule, iso, state)
+                return parsum.at_noneq(
                     Tvib,
                     Trot,
                     vib_distribution=vib_distribution,
                     rot_distribution=rot_distribution,
                     overpopulation=overpopulation,
-                    returnQvibQrot=False,
-                    update_populations=self.misc.export_populations
+                    update_populations=self.misc.export_populations,
                 )
 
+        def Q_Qvib_Qrotu_Qrotl(Tvib, Trot):
+            """Nonequilibrium partition function; with the detail of
+            vibrational partition function and rotational partition functions"""
+            # TODO @ dev : implement the map(dict) approach to fill Q Qvib Qrotu Qrotl
+            # note : Qrot already use a map(dict) so we need a map with 2 keys. Is it worth it?
+            if "iso" in df:  #  multiple isotopes
+
+                dgb = df.groupby(by=["iso"])
+                for (iso), idx in dgb.indices.items():
+
+                    # Get partition function for all lines
+                    parsum = self.get_partition_function_calculator(
+                        molecule, iso, state
+                    )
+
+                    Q, Qvib, dfQrot = parsum.at_noneq(
+                        Tvib,
+                        Trot,
+                        vib_distribution=vib_distribution,
+                        rot_distribution=rot_distribution,
+                        overpopulation=overpopulation,
+                        returnQvibQrot=True,
+                        update_populations=self.misc.export_populations,
+                    )
+
+                    # ... make sure PartitionFunction above is calculated with the same
+                    # ... temperatures, rovibrational distributions and overpopulations
+                    # ... as the populations of active levels (somewhere below)
+                    df.at[idx, "Qvib"] = Qvib
+                    df.at[idx, "Q"] = Q
+
+                    # reindexing to get a direct access to Qrot database
+                    # create the lookup dictionary
+                    # dfQrot index is already 'viblvl'
+                    dfQrot_dict = dict(list(zip(dfQrot.index, dfQrot.Qrot)))
+
+                    dg = df.loc[idx]
+
+                    # Add lower state Qrot
+                    dg_sorted = dg.set_index(["viblvl_l"], inplace=False)
+                    df.loc[idx, "Qrotl"] = dg_sorted.index.map(dfQrot_dict.get).values
+                    # Add upper state energy
+                    dg_sorted = dg.set_index(["viblvl_u"], inplace=False)
+                    df.loc[idx, "Qrotu"] = dg_sorted.index.map(dfQrot_dict.get).values
+
+                    if radis.DEBUG_MODE:
+                        assert (df.loc[idx, "iso"] == iso).all()
+
+                return df.Q, df.Qvib, df.Qrotu, df.Qrotl
+
             else:
-	            Q, Qvib, dfQrot = parsum.at_noneq(
-	                Tvib,
-	                Trot,
-	                vib_distribution=vib_distribution,
-	                rot_distribution=rot_distribution,
-	                overpopulation=overpopulation,
-	                returnQvibQrot=True,
-	                update_populations=self.misc.export_populations,
-	            )
-	            # ... make sure PartitionFunction above is calculated with the same
-	            # ... temperatures, rovibrational distributions and overpopulations
-	            # ... as the populations of active levels (somewhere below)
-	            df.attrs["Qvib"] = Qvib
-	            df.attrs["Q"] = Q
-	            assert "Qvib" not in df.columns
-	            assert "Q" not in df.columns
+                iso_set = self._get_isotope_list()  # df1.iso.unique()
+                if len(iso_set) == 1:
+                    iso = iso_set[0]
 
-	            # reindexing to get a direct access to Qrot database
-	            # create the lookup dictionary
-	            # dfQrot index is already 'viblvl'
-	            dfQrot_dict = dict(list(zip(dfQrot.index, dfQrot.Qrot)))
+                    parsum = self.get_partition_function_calculator(
+                        molecule, iso, state
+                    )
 
-	            dg = df.loc[:]
+                    Q, Qvib, dfQrot = parsum.at_noneq(
+                        Tvib,
+                        Trot,
+                        vib_distribution=vib_distribution,
+                        rot_distribution=rot_distribution,
+                        overpopulation=overpopulation,
+                        returnQvibQrot=True,
+                        update_populations=self.misc.export_populations,
+                    )
+                    # ... make sure PartitionFunction above is calculated with the same
+                    # ... temperatures, rovibrational distributions and overpopulations
+                    # ... as the populations of active levels (somewhere below)
+                    df.attrs["Qvib"] = Qvib
+                    df.attrs["Q"] = Q
+                    assert "Qvib" not in df.columns
+                    assert "Q" not in df.columns
 
-	            # Add lower state Qrot
-	            dg_sorted = dg.set_index(["viblvl_l"], inplace=False)
-	            df.loc[:, "Qrotl"] = dg_sorted.index.map(dfQrot_dict.get).values
-	            # Add upper state energy
-	            dg_sorted = dg.set_index(["viblvl_u"], inplace=False)
-	            df.loc[:, "Qrotu"] = dg_sorted.index.map(dfQrot_dict.get).values
+                    # reindexing to get a direct access to Qrot database
+                    # create the lookup dictionary
+                    # dfQrot index is already 'viblvl'
+                    dfQrot_dict = dict(list(zip(dfQrot.index, dfQrot.Qrot)))
 
-        else:  #  multiple isotopes
-            dgb = df.groupby(by=["iso"])
-            for (iso), idx in dgb.indices.items():
+                    dg = df.loc[:]
 
-                # Get partition function for all lines
-                state = self.input.state
-                parsum = self.get_partition_function_calculator(molecule, iso, state)
+                    # Add lower state Qrot
+                    dg_sorted = dg.set_index(["viblvl_l"], inplace=False)
+                    df.loc[:, "Qrotl"] = dg_sorted.index.map(dfQrot_dict.get).values
+                    # Add upper state energy
+                    dg_sorted = dg.set_index(["viblvl_u"], inplace=False)
+                    df.loc[:, "Qrotu"] = dg_sorted.index.map(dfQrot_dict.get).values
 
-	            if self.misc.parsum_mode == 'tabulation':
-
-	                Q = parsum.at_noneq(
-	                    Tvib,
-	                    Trot,
-	                    vib_distribution=vib_distribution,
-	                    rot_distribution=rot_distribution,
-	                    overpopulation=overpopulation,
-	                    returnQvibQrot=False,
-	                    update_populations=self.misc.export_populations
-	                )
-					df.at[idx, "Q"] = Q
-	                # TODO: add to Qgas dictionary ?
-	                
-	            else:
-
-
-	                Q, Qvib, dfQrot = parsum.at_noneq(
-	                    Tvib,
-	                    Trot,
-	                    vib_distribution=vib_distribution,
-	                    rot_distribution=rot_distribution,
-	                    overpopulation=overpopulation,
-	                    returnQvibQrot=True,
-	                    update_populations=self.misc.export_populations,
-	                )
-
-	                # ... make sure PartitionFunction above is calculated with the same
-	                # ... temperatures, rovibrational distributions and overpopulations
-	                # ... as the populations of active levels (somewhere below)
-	                df.at[idx, "Qvib"] = Qvib
-	                df.at[idx, "Q"] = Q
-
-	                # reindexing to get a direct access to Qrot database
-	                # create the lookup dictionary
-	                # dfQrot index is already 'viblvl'
-	                dfQrot_dict = dict(list(zip(dfQrot.index, dfQrot.Qrot)))
-
-	                dg = df.loc[idx]
-
-	                # Add lower state Qrot
-	                dg_sorted = dg.set_index(["viblvl_l"], inplace=False)
-	                df.loc[idx, "Qrotl"] = dg_sorted.index.map(dfQrot_dict.get).values
-	                # Add upper state energy
-	                dg_sorted = dg.set_index(["viblvl_u"], inplace=False)
-	                df.loc[idx, "Qrotu"] = dg_sorted.index.map(dfQrot_dict.get).values
-
-	                if radis.DEBUG_MODE:
-	                    assert (df.loc[idx, "iso"] == iso).all()
-
-		        Qvib = df.Qvib
-		        Q = df.Q
+                    return Q, Qvib, df.Qrotu, df.Qrotl
 
         self.profiler.stop("part_function", "partition functions")
         self.profiler.start("population", 3)
@@ -2472,10 +2482,13 @@ class BaseFactory(DatabankLoader):
                 )
 
             # ... Total
-            df["nu"] = df.nu_vib_x_Qvib * df.nu_rot_x_Qrot / Q
-            df["nl"] = df.nl_vib_x_Qvib * df.nl_rot_x_Qrot / Q
-            
-        else: #self.misc.parsum_mode == 'full summation':
+            df["nu"] = df.nu_vib_x_Qvib * df.nu_rot_x_Qrot / Q(Tvib, Trot)
+            df["nl"] = df.nl_vib_x_Qvib * df.nl_rot_x_Qrot / Q(Tvib, Trot)
+
+        else:  # self.misc.export_rovib_fraction:
+            # ... Partition functions
+            Q, Qvib, Qrotu, Qrotl = Q_Qvib_Qrotu_Qrotl(Tvib, Trot)
+
             # ... vibrational distribution
             if vib_distribution == "boltzmann":
                 # equation generated with @pytexit.py2tex > see docstrings.
@@ -2514,8 +2527,8 @@ class BaseFactory(DatabankLoader):
                 )
 
             # ... Total
-            df["nu"] = df.nu_vib * df.nu_rot * (df.Qrotu * Qvib / Q)
-            df["nl"] = df.nl_vib * df.nl_rot * (df.Qrotl * Qvib / Q)
+            df["nu"] = df.nu_vib * df.nu_rot * (Qrotu * Qvib / Q)
+            df["nl"] = df.nl_vib * df.nl_rot * (Qrotl * Qvib / Q)
 
         if __debug__:
             assert "nu" in self.df1
@@ -2601,17 +2614,51 @@ class BaseFactory(DatabankLoader):
         # ... unlike the (tabulated) equilibrium case, here we recalculate it from
         # scratch
 
-        Q_dict = {}
+        if "id" in df:
+            id_set = df.id.unique()
+            if len(id_set) > 0:
+                raise NotImplementedError("> 1 molecules in same DataFrame")
+            else:
+                self.warn(
+                    "There shouldn't be a Column 'id' with a unique value",
+                    "PerformanceWarning",
+                )
+                df.attrs["id"] = int(id_set)
+        molecule = get_molecule(df.attrs["id"])
+        state = self.input.state
 
-        if "id" in df and "iso" in df:
-            dgb = df.groupby(by=["id", "iso"])
+        def Q(Tvib, Trot):
+            """Nonequilibrium partition function
 
-            for (id, iso), idx in dgb.indices.items():
+            Returns
+            -------
+            column or float: depending if there are many isotopes or one"""
+            if "iso" in df:
+                Q_dict = {}
+                iso_set = df.iso.unique()
+                if len(iso_set) > 1:
+                    self.warn(
+                        "There shouldn't be a Column 'iso' with a unique value",
+                        "PerformanceWarning",
+                    )
+                for iso in iso_set:
+                    parsum = self.get_partition_function_calculator(
+                        molecule, iso, state
+                    )
+                    Q_dict[iso] = parsum.at_noneq_3Tvib(
+                        Tvib,
+                        Trot,
+                        vib_distribution=vib_distribution,
+                        rot_distribution=rot_distribution,
+                        overpopulation=overpopulation,
+                        update_populations=self.misc.export_populations,
+                    )
+                return df["iso"].map(Q_dict)
 
-                molecule = get_molecule(id)
-                state = self.input.state
+            else:  # "iso" not in df:
+                iso = df.attrs["iso"]
                 parsum = self.get_partition_function_calculator(molecule, iso, state)
-                Q = parsum.at_noneq_3Tvib(
+                return parsum.at_noneq_3Tvib(
                     Tvib,
                     Trot,
                     vib_distribution=vib_distribution,
@@ -2619,84 +2666,6 @@ class BaseFactory(DatabankLoader):
                     overpopulation=overpopulation,
                     update_populations=self.misc.export_populations,
                 )
-
-                #            df.loc[idx, 'Qvib'] = Qvib
-                Q_dict[iso] = Q
-                #            dg_list.append(dg)
-
-                if radis.DEBUG_MODE:
-                    assert (df.loc[idx, "id"] == id).all()
-                    assert (df.loc[idx, "iso"] == iso).all()
-
-        elif "id" not in df and "iso" in df:
-            dgb = df.groupby(by=["iso"])
-            id = df.attrs["id"]
-            molecule = get_molecule(id)
-
-            for (iso), idx in dgb.indices.items():
-
-                state = self.input.state
-                parsum = self.get_partition_function_calculator(molecule, iso, state)
-                Q = parsum.at_noneq_3Tvib(
-                    Tvib,
-                    Trot,
-                    vib_distribution=vib_distribution,
-                    rot_distribution=rot_distribution,
-                    overpopulation=overpopulation,
-                    update_populations=self.misc.export_populations,
-                )
-
-                #            df.loc[idx, 'Qvib'] = Qvib
-                Q_dict[iso] = Q
-                #            dg_list.append(dg)
-
-                if radis.DEBUG_MODE:
-                    assert (df.loc[idx, "iso"] == iso).all()
-
-        elif "id" in df and "iso" not in df:
-            dgb = df.groupby(by=["id"])
-            iso = df.attrs["iso"]
-
-            for (id), idx in dgb.indices.items():
-
-                state = self.input.state
-                molecule = get_molecule(id)
-                parsum = self.get_partition_function_calculator(molecule, iso, state)
-                Q = parsum.at_noneq_3Tvib(
-                    Tvib,
-                    Trot,
-                    vib_distribution=vib_distribution,
-                    rot_distribution=rot_distribution,
-                    overpopulation=overpopulation,
-                    update_populations=self.misc.export_populations,
-                )
-
-                #            df.loc[idx, 'Qvib'] = Qvib
-                Q_dict[iso] = Q
-                #            dg_list.append(dg)
-
-                if radis.DEBUG_MODE:
-                    assert (df.loc[idx, "id"] == id).all()
-
-        elif "id" not in df and "iso" not in df:
-            iso = df.attrs["iso"]
-            id = df.attrs["id"]
-
-            state = self.input.state
-            molecule = get_molecule(id)
-            parsum = self.get_partition_function_calculator(molecule, iso, state)
-            Q = parsum.at_noneq_3Tvib(
-                Tvib,
-                Trot,
-                vib_distribution=vib_distribution,
-                rot_distribution=rot_distribution,
-                overpopulation=overpopulation,
-                update_populations=self.misc.export_populations,
-            )
-
-            #            df.loc[idx, 'Qvib'] = Qvib
-            Q_dict[iso] = Q
-            #            dg_list.append(dg)
 
         self.profiler.stop("part_function", "partition functions")
         self.profiler.start("populations", 3)
@@ -2734,6 +2703,8 @@ class BaseFactory(DatabankLoader):
                 "Unknown vibrational distribution: {0}".format(vib_distribution)
             )
 
+        if overpopulation != {}:
+            raise NotImplementedError(overpopulation)
         # Not Implemented:
         #        if overpopulation != {}:
         #            if not ('viblvl_u' in df and not 'viblvl_l' in df):
@@ -2752,9 +2723,6 @@ class BaseFactory(DatabankLoader):
         # for 3 temperatures). Let's just get the total
 
         # ... Total
-
-        Q = self.getQ_from_dict(df, Q_dict)
-
         if rot_distribution == "boltzmann":
             # ... total
 
@@ -2764,7 +2732,7 @@ class BaseFactory(DatabankLoader):
                 * nu_vib3Qvib3
                 * df.grotu
                 * exp(-df.Erotu * hc_k / Trot)
-                / Q
+                / Q(Tvib, Trot)
             )
             df["nl"] = (
                 nl_vib1Qvib1
@@ -2772,7 +2740,7 @@ class BaseFactory(DatabankLoader):
                 * nl_vib3Qvib3
                 * df.grotl
                 * exp(-df.Erotl * hc_k / Trot)
-                / Q
+                / Q(Tvib, Trot)
             )
 
         else:
@@ -2941,7 +2909,6 @@ class BaseFactory(DatabankLoader):
             return  # no lines in database, no need to go further
 
         self.profiler.start("scaled_non_eq_linestrength", 2)
-        #            printg('> scale nonequilibrium linestrength')
 
         try:
             df["nl"]
@@ -3075,7 +3042,6 @@ class BaseFactory(DatabankLoader):
         df = self.df1
 
         self.profiler.start("calc_emission_integral", 2)
-        #            printg('> calculated emission integral')
 
         if len(df) == 0:
             return  # no lines in database, no need to go further
@@ -3090,8 +3056,7 @@ class BaseFactory(DatabankLoader):
         # adim. (#/#) (multiplied by n_tot later)
         n_u = df["nu"]
         # correct for abundance
-        abundance = get_abundance(df)
-        n_ua = n_u * abundance
+        n_ua = n_u * self.get_abundance(df)
 
         A_ul = df["Aul"]  # (s-1)
 
@@ -3100,9 +3065,6 @@ class BaseFactory(DatabankLoader):
 
         Ei *= 1e3  # (W/sr) -> (mW/sr)
         df["Ei"] = Ei
-
-        #        # Store lines with emission integrals under df0
-        #        self.df1 = df
 
         self.profiler.stop("calc_emission_integral", "calculated emission integral")
 
@@ -3630,44 +3592,6 @@ def linestrength_from_Einstein(A, gu, El, Ia, nu, Q, T):
         * (1 - np.exp(-hc_k * nu / T))
         / (8 * np.pi * c_CGS * nu ** 2 * Q)
     )
-
-
-def get_abundance(df):
-
-    """Returns the abundance
-
-    Parameters
-    ----------
-    df: dataframe
-
-    Returns
-    -------
-    dict: The abundance of all the isotopes in the dataframe
-    """
-
-    molpar = MolParams()
-
-    if "id" in df.columns:
-        id = df.id.unique()
-        id = id[0]
-
-    else:
-        id = df.attrs["id"]
-
-    if "iso" in df.columns:
-        iso_set = df.iso.unique()
-        abundance = {}
-        for iso in iso_set:
-            abundance[iso] = molpar.get(id, iso, "abundance")
-
-        req = df["iso"].map(abundance)
-    else:
-        iso = df.attrs["iso"]
-        abundance = molpar.get(id, iso, "abundance")
-
-        req = abundance
-
-    return req
 
 
 if __name__ == "__main__":

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -178,6 +178,17 @@ class SpectrumFactory(BandFactory):
         discard linestrengths that are lower that this, to reduce calculation
         times. ``1e-27`` is what is generally used to generate databases such as
         CDSD. If ``0``, no cutoff. Default ``1e-27``.
+    parsum_mode: 'full summation', 'tabulation'
+        how to compute partition functions, at nonequilibrium or when partition
+        function are not already tabulated. ``'full summation'`` : sums over all
+        (potentially millions) of rovibrational levels. ``'tabulation'`` :
+        builds an on-the-fly tabulation of rovibrational levels (500 - 4000x faster
+        and usually accurate within 0.1%). Default ``full summation'``
+
+        .. note::
+            parsum_mode= 'tabulation'  is new in 0.9.30, and makes nonequilibrium
+            calculations of small spectra extremelly fast. Will become the default
+            after 0.9.31.
     pseudo_continuum_threshold: float
         if not ``0``, first calculate a rough approximation of the spectrum, then
         moves all lines whose linestrength intensity is less than this threshold
@@ -337,6 +348,8 @@ class SpectrumFactory(BandFactory):
     # TODO
     # store everything in a self.var class instead of self.[] directly
 
+    # TODO : move Tref in load_databank / fetch_databank only
+
     def __init__(
         self,
         wmin=None,
@@ -363,6 +376,7 @@ class SpectrumFactory(BandFactory):
         zero_padding=-1,
         broadening_method=Default("fft"),
         cutoff=0,
+        parsum_mode="full summation",
         verbose=True,
         warnings=True,
         save_memory=False,
@@ -482,6 +496,7 @@ class SpectrumFactory(BandFactory):
             # If None, use no cutoff : https://github.com/radis/radis/pull/259
             cutoff = 0
         self.params.cutoff = cutoff
+        self.params.parsum_mode = parsum_mode
 
         # Time Based variables
         self.verbose = verbose

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -416,6 +416,7 @@ class Parameters(ConditionDict):
         self.include_neighbouring_lines = True
         """bool: if ``True``, includes the contribution of off-range, neighbouring
         lines because of lineshape broadening. Default ``True``."""
+        self.parsum_mode = "full summation"  #: int : "full summation" or "tabulation"  . calculation mode of parittion function. See :py:class:`~radis.levels.partfunc.RovibParFuncCalculator`
 
 
 class MiscParams(ConditionDict):
@@ -446,12 +447,12 @@ class MiscParams(ConditionDict):
         self.export_populations = (
             None  #: bool: export populations in output Spectrum (takes memory!)
         )
+        self.export_rovib_fraction = False  #: bool: calculate nu_vib, nu_rot in lines
         self.warning_broadening_threshold = (
             None  #: float: [0-1] raise a warning if the lineshape area is different
         )
         self.warning_linestrength_cutoff = None  #: float [0-1]: raise a warning if the sum of linestrength cut is above that
         self.total_lines = 0  #: int : number of lines in database.
-        self.parsum_mode = "full summation"  #: int : "full summation" or "tabulation"  . calculation mode of parittion function. See :py:class:`~radis.levels.partfunc.RovibParFuncCalculator`
 
 
 def format_paths(s):
@@ -1569,7 +1570,7 @@ class DatabankLoader(object):
                     lvl,
                     levelsfmt,
                     isotope=iso,
-                    parsum_mode=self.misc.parsum_mode,
+                    parsum_mode=self.params.parsum_mode,
                 )
                 self.parsum_calc[molecule][iso][state] = ParsumCalc
         # energy levels arent specified in a tabulated file, but we can still
@@ -1581,7 +1582,7 @@ class DatabankLoader(object):
                     None,
                     levelsfmt,
                     isotope=iso,
-                    parsum_mode=self.misc.parsum_mode,
+                    parsum_mode=self.params.parsum_mode,
                 )
                 self.parsum_calc[molecule][iso][state] = ParsumCalc
 

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -268,9 +268,17 @@ class ConditionDict(dict):
     def __getattr__(self, attr):
         if attr == "__getstate__":
             return dict.__getattr__(attr)
+        if not attr in self.__slots__:
+            raise KeyError(
+                f"Undefined attribute `{attr}` for {self.__class__}. Did you mean : {self.__slots__}"
+            )
         return self[attr]
 
     def __setattr__(self, attr, value):
+        if not attr in self.__slots__:
+            raise KeyError(
+                f"Undefined attribute `{attr}` for {self.__class__}. Did you mean : {self.__slots__}"
+            )
         self[attr] = value
 
     # Methods needed for Multiprocessing
@@ -313,12 +321,28 @@ class Input(ConditionDict):
     :py:attr:`~radis.lbl.loader.DatabankLoader.misc`
     """
 
-    #    # hardcode attribute names, to prevent typos and the declaration of unwanted parameters
-    #    __slots__ = [
-    #         'Tgas', 'Tref', 'Tvib', 'Trot', 'isotope', 'medium', 'mole_fraction',
-    #         'molecule', 'overpopulation', 'path_length', 'pressure_mbar', 'rot_distribution',
-    #         'self_absorption', 'state', 'vib_distribution', 'wavelength_max',
-    #         'wavelength_min', 'wavenum_max', 'wavenum_min']
+    # hardcode attribute names, to prevent typos and the declaration of unwanted parameters
+    __slots__ = [
+        "Tgas",
+        "Tref",
+        "Tvib",
+        "Trot",
+        "isotope",
+        "medium",
+        "mole_fraction",
+        "molecule",
+        "overpopulation",
+        "path_length",
+        "pressure_mbar",
+        "rot_distribution",
+        "self_absorption",
+        "state",
+        "vib_distribution",
+        "wavelength_max",
+        "wavelength_min",
+        "wavenum_max",
+        "wavenum_min",
+    ]
 
     def __init__(self):
         super(Input, self).__init__()
@@ -372,15 +396,36 @@ class Parameters(ConditionDict):
     :py:attr:`~radis.lbl.loader.DatabankLoader.misc`
     """
 
-    #    # hardcode attribute names, to prevent typos and the declaration of unwanted parameters
-    #    __slots__ = [
-    #                 'broadening_max_width', 'chunksize', 'cutoff',
-    #                 'db_use_cached', 'dbformat', 'dbpath',
-    #                 'export_lines', 'export_populations', 'levelsfmt', 'lvl_use_cached',
-    #                 'parfuncfmt', 'parfuncpath',
-    #                 'pseudo_continuum_threshold', 'warning_broadening_threshold',
-    #                 'warning_linestrength_cutoff', 'wavenum_max_calc', 'wavenum_min_calc',
-    #                 'waveunit', 'wstep']
+    # hardcode attribute names, to prevent typos and the declaration of unwanted parameters
+    __slots__ = [
+        "add_at_used",
+        "broadening_method",
+        "broadening_max_width",
+        "chunksize",
+        "cutoff",
+        "db_use_cached",
+        "dbformat",
+        "dbpath",
+        "dlm_log_pL",
+        "dlm_log_pG",
+        "export_lines",
+        "export_populations",
+        "folding_thresh",
+        "include_neighbouring_lines",
+        "levelsfmt",
+        "lvl_use_cached",
+        "optimization",
+        "parfuncfmt",
+        "parfuncpath",
+        "parsum_mode",
+        "pseudo_continuum_threshold",
+        "warning_broadening_threshold",
+        "warning_linestrength_cutoff",
+        "wavenum_max_calc",
+        "wavenum_min_calc",
+        "waveunit",
+        "wstep",
+    ]
 
     def __init__(self):
         super(Parameters, self).__init__()
@@ -435,6 +480,19 @@ class MiscParams(ConditionDict):
     :py:attr:`~radis.lbl.loader.DatabankLoader.input`,
     :py:attr:`~radis.lbl.loader.DatabankLoader.params`,
     """
+
+    # hardcode attribute names, to prevent typos and the declaration of unwanted parameters
+    __slots__ = [
+        "chunksize",
+        "export_lines",
+        "export_populations",
+        "export_rovib_fraction",
+        "load_energies",
+        "warning_broadening_threshold",
+        "warning_linestrength_cutoff",
+        "total_lines",
+        "zero_padding",
+    ]
 
     def __init__(self):
         super(MiscParams, self).__init__()

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -270,14 +270,14 @@ class ConditionDict(dict):
             return dict.__getattr__(attr)
         if not attr in self.__slots__:
             raise KeyError(
-                f"Undefined attribute `{attr}` for {self.__class__}. Did you mean : {self.__slots__}"
+                f"Undefined attribute `{attr}` for {self.__class__}. Allowed attributes: {self.__slots__}"
             )
         return self[attr]
 
     def __setattr__(self, attr, value):
         if not attr in self.__slots__:
             raise KeyError(
-                f"Undefined attribute `{attr}` for {self.__class__}. Did you mean : {self.__slots__}"
+                f"Undefined attribute `{attr}` for {self.__class__}. Allowed attributes: {self.__slots__}"
             )
         self[attr] = value
 

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -2290,6 +2290,10 @@ class DatabankLoader(object):
         # helps IDE find methods
         assert isinstance(parsum, RovibParFuncCalculator)
 
+        # Update partition sum calculation mode (if has been reset by user)
+        if parsum.mode != self.params.parsum_mode:
+            parsum.mode = self.params.parsum_mode
+
         return parsum
 
     def get_partition_function_molecule(self, molecule):

--- a/radis/levels/partfunc.py
+++ b/radis/levels/partfunc.py
@@ -413,7 +413,7 @@ class RovibParFuncCalculator(RovibPartitionFunction):
         #                               'rot_distribution={0}'.format(rot_distribution)
 
         # Check inputs, initialize
-        if overpopulation is None:
+        if overpopulation is None or overpopulation == {}:
             overpopulation = {}
         else:
             if not returnQvibQrot:

--- a/radis/levels/partfunc.py
+++ b/radis/levels/partfunc.py
@@ -409,20 +409,15 @@ class RovibParFuncCalculator(RovibPartitionFunction):
                 + "(Tvib={0}K, Trot={1}K, ... )".format(Tvib, Trot)
                 + "update_populations={0})".format(update_populations)
             )
-        #                               'overpopulation={0}, vib_distribution={1}'.format(overpopulation, vib_distribution)+\
-        #                               'rot_distribution={0}'.format(rot_distribution)
 
         # Check inputs, initialize
         if overpopulation is None:
             overpopulation = {}
-            
-        #sometimes overpopulation is already equal to {} 
-        #!!!Todo - resolve this minor inconsistency where sometimes overpopulation == None or == {} which means the same
-        if overpopulation != {}: 
+        if overpopulation != {}:
             if not returnQvibQrot:
                 raise ValueError(
                     "When using overpopulation, partition function "
-                    + "must be calculated with returnQvibQrot=True"
+                    + "must be calculated with returnQvibQrot=True. Set ``PartitionFunctionCalculator.at_noneq(..., returnQvibQrot=True)``, or ``SpectrumFactory.misc.export_rovib_fraction = True``"
                 )
         assert vib_distribution in ["boltzmann", "treanor"]
         assert rot_distribution in ["boltzmann"]

--- a/radis/levels/partfunc.py
+++ b/radis/levels/partfunc.py
@@ -450,7 +450,7 @@ class RovibParFuncCalculator(RovibPartitionFunction):
                 vib_distribution=vib_distribution,
                 rot_distribution=rot_distribution,
                 returnQvibQrot=returnQvibQrot,
-                update_populations=False,
+                update_populations=update_populations,
             )
         elif self.mode == "tabulation":
             if update_populations:

--- a/radis/levels/partfunc_cdsd.py
+++ b/radis/levels/partfunc_cdsd.py
@@ -135,14 +135,11 @@ class PartFuncCO2_CDSDcalc(RovibParFuncCalculator):
 
     Parameters
     ----------
-
     energy_levels: filename
         path to energy levels (to calculate Partition Function) for ``isotope``
-
     isotope: int
         which isotope we're dealing with. Default ``1``. In the current implementation
         only isotope 1 and 2 are defined.
-
     levelsfmt: ``'cdsd-p'``, ``'cdsd-pc'``, ``'cdsd-pcN'``, ``'cdsd-hamil'``, or ``None``
         the format of the Energy Database, and in particular how ``Evib`` and ``Erot``
         have been calculated. A vibrational level in the CDSD (p,c,J,N) nomenclature
@@ -156,12 +153,13 @@ class PartFuncCO2_CDSDcalc(RovibParFuncCalculator):
 
     Other Parameters
     ----------------
-
     use_cached: ``True``, ``False``, or ``'regen'``, ``'force'``
         if ``True``, use (and generate if doesnt exist) a ``.h5`` file.
         If ``'regen'``, regenerate cache file. If ``'force'``, raise an error
         if file doesnt exist. Default ``True``
-
+    mode: 'full summation', 'tabulation'
+        calculation mode. ``'tabulation'`` is much faster but not all possible
+        distributions are implemented. Default ``'full-summation'``
     use_json: boolean
         deprecated. Better use h5 now.
 
@@ -218,15 +216,16 @@ class PartFuncCO2_CDSDcalc(RovibParFuncCalculator):
         isotope,
         levelsfmt,  # ='cdsd-pc',
         use_cached=True,
-        use_json=None,
+        use_json=None,  # TODO: Deprecated, remove
         verbose=True,
+        mode="full summation",
     ):
 
         # %% Init
 
         # Initialize PartitionFunctionCalculator for this electronic state
         ElecState = ElectronicState("CO2", isotope, "X", "1Σu+")
-        super(PartFuncCO2_CDSDcalc, self).__init__(ElecState)
+        super(PartFuncCO2_CDSDcalc, self).__init__(ElecState, mode=mode)
 
         # Check inputs ('return' is not mentionned in signature. it will just return
         # after cache name is given)

--- a/radis/test/lbl/test_base.py
+++ b/radis/test/lbl/test_base.py
@@ -326,9 +326,6 @@ def test_optically_thick_limit_1iso(verbose=True, plot=True, *args, **kwargs):
         radis.DEBUG_MODE = DEBUG_MODE
 
 
-# @pytest.mark.needs_connection
-# @pytest.mark.needs_db_HITEMP_CO2_DUNHAM
-# @pytest.mark.needs_connection
 def test_optically_thick_limit_2iso(verbose=True, plot=True, *args, **kwargs):
     """Test that we find Planck in the optically thick limit
 

--- a/radis/test/lbl/test_spectrum.py
+++ b/radis/test/lbl/test_spectrum.py
@@ -34,30 +34,9 @@ def test_populations(verbose=True, *args, **kwargs):
 
     from radis.lbl import SpectrumFactory
     from radis.misc.basics import all_in
+
     export = ["vib", "rovib"]
-    
-    sf0 = SpectrumFactory(
-        2000,
-        2300,
-        export_populations=export,
-        cutoff=1e-25,
-        isotope="1",
-    )
-    sf0.warnings.update(
-        {"MissingSelfBroadeningWarning": "ignore", "VoigtBroadeningWarning": "ignore"}
-    )
-    sf0.load_databank("HITRAN-CO-TEST")
-    sf0.misc.export_rovib_fraction = True
-    #we test that "tabulation" and "export_population" are incompatible
-    try:
-        sf0.params.parsum_mode = "tabulation"  
-        s = sf0.non_eq_spectrum(2000, 2000)
-    except ValueError as e:
-        #we expect this message
-        print("Following error is expected: {}".format(e))
-        assert e.args[0] == "Cannot update populations of individual levels with `tabulation` mode. Choose `update_populations=False` or `mode='full summation'`"
-        
-    
+
     sf = SpectrumFactory(
         2000,
         2300,
@@ -70,8 +49,16 @@ def test_populations(verbose=True, *args, **kwargs):
     )
     sf.load_databank("HITRAN-CO-TEST")
     sf.misc.export_rovib_fraction = True
-    
-    sf.params.parsum_mode = "full summation"  #won't be default at some point
+    # we test that "tabulation" and "export_population" are incompatible
+    sf.params.parsum_mode = "tabulation"
+    with pytest.raises(ValueError) as err:
+        s = sf.non_eq_spectrum(2000, 2000)
+        assert (
+            err.args[0]
+            == "Cannot update populations of individual levels with `tabulation` mode. Choose `update_populations=False` or `mode='full summation'`"
+        )
+
+    sf.params.parsum_mode = "full summation"  # won't be default at some point
     s = sf.non_eq_spectrum(2000, 2000)
 
     pops = sf.get_populations(export)

--- a/radis/test/lbl/test_spectrum.py
+++ b/radis/test/lbl/test_spectrum.py
@@ -34,8 +34,30 @@ def test_populations(verbose=True, *args, **kwargs):
 
     from radis.lbl import SpectrumFactory
     from radis.misc.basics import all_in
-
     export = ["vib", "rovib"]
+    
+    sf0 = SpectrumFactory(
+        2000,
+        2300,
+        export_populations=export,
+        cutoff=1e-25,
+        isotope="1",
+    )
+    sf0.warnings.update(
+        {"MissingSelfBroadeningWarning": "ignore", "VoigtBroadeningWarning": "ignore"}
+    )
+    sf0.load_databank("HITRAN-CO-TEST")
+    sf0.misc.export_rovib_fraction = True
+    #we test that "tabulation" and "export_population" are incompatible
+    try:
+        sf0.params.parsum_mode = "tabulation"  
+        s = sf0.non_eq_spectrum(2000, 2000)
+    except ValueError as e:
+        #we expect this message
+        print("Following error is expected: {}".format(e))
+        assert e.args[0] == "Cannot update populations of individual levels with `tabulation` mode. Choose `update_populations=False` or `mode='full summation'`"
+        
+    
     sf = SpectrumFactory(
         2000,
         2300,
@@ -47,7 +69,9 @@ def test_populations(verbose=True, *args, **kwargs):
         {"MissingSelfBroadeningWarning": "ignore", "VoigtBroadeningWarning": "ignore"}
     )
     sf.load_databank("HITRAN-CO-TEST")
-
+    sf.misc.export_rovib_fraction = True
+    
+    sf.params.parsum_mode = "full summation"  #won't be default at some point
     s = sf.non_eq_spectrum(2000, 2000)
 
     pops = sf.get_populations(export)

--- a/radis/test/levels/test_partfunc.py
+++ b/radis/test/levels/test_partfunc.py
@@ -798,7 +798,7 @@ def test_tabulated_partition_functions(verbose=True, plot=True, *args, **kwargs)
     assert np.isclose(
         Z_sum.at_noneq_3Tvib((1000, 1000, 3500), 3000),
         Z_tab.at_noneq_3Tvib((1000, 1000, 3500), 3000),
-        rtol=0.5e-3,
+        rtol=0.6e-3,
     )
 
     # ... change Grid :

--- a/radis/test/levels/test_partfunc.py
+++ b/radis/test/levels/test_partfunc.py
@@ -23,7 +23,6 @@ Run only fast tests (i.e: tests that a 'fast' label)::
 import os
 from os.path import basename, exists, getmtime
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from numpy import exp
@@ -232,7 +231,11 @@ def test_calculatedQ_match_HAPI_CO(
         us.append(db.at(Ti))
         hap.append(hapi.at(Ti))
 
-    if plot:
+    if plot:  # Make sure matplotlib is interactive so that test are not stuck in pytest
+        import matplotlib.pyplot as plt
+
+        plt.ion()
+
         plt.figure(fig_prefix + "Partition function Dunham vs Precomputed")
         plt.plot(T, us, "ok", label="NeQ")
         plt.plot(T, hap, "or", label="HAPI")
@@ -785,7 +788,11 @@ def test_tabulated_partition_functions(verbose=True, plot=True, *args, **kwargs)
     )
 
     # ... change Grid :
-    if plot:
+    if plot:  # Make sure matplotlib is interactive so that test are not stuck in pytest
+        import matplotlib.pyplot as plt
+
+        plt.ion()
+
         Tvib = 3000
         Trot_arr = np.linspace(300, 3000, 10)
         plt.figure()

--- a/radis/test/levels/test_partfunc.py
+++ b/radis/test/levels/test_partfunc.py
@@ -787,6 +787,20 @@ def test_tabulated_partition_functions(verbose=True, plot=True, *args, **kwargs)
         Z_sum.at_noneq(1000, 3000), Z_tab.at_noneq(1000, 3000), rtol=0.3e-3
     )
 
+    # Nonequilibrium 3 Tvib (same << 0.1%)
+
+    #  ... Compare with Partition function computed from PartFunc_Dunham
+    assert np.isclose(
+        Z_sum.at_noneq_3Tvib((1000, 1000, 2000), 300),
+        Z_tab.at_noneq_3Tvib((1000, 1000, 2000), 300),
+        rtol=1e-3,
+    )
+    assert np.isclose(
+        Z_sum.at_noneq_3Tvib((1000, 1000, 3500), 3000),
+        Z_tab.at_noneq_3Tvib((1000, 1000, 3500), 3000),
+        rtol=0.5e-3,
+    )
+
     # ... change Grid :
     if plot:  # Make sure matplotlib is interactive so that test are not stuck in pytest
         import matplotlib.pyplot as plt
@@ -926,9 +940,9 @@ def _run_testcases(verbose=True, warnings=True, *args, **kwargs):
 
 
 if __name__ == "__main__":
-    printm("Testing parfunc: {0}".format(_run_testcases()))
+    # printm("Testing parfunc: {0}".format(_run_testcases()))
 
-    # test_tabulated_partition_functions()
+    test_tabulated_partition_functions()
 #    test_CDSD_calc_vs_tab(verbose=verbose, warnings=warnings)
 #    test_recompute_Q_from_QvibQrot_CDSD_PC(verbose=verbose, warnings=warnings)
 #    test_recompute_Q_from_QvibQrot_CDSD_PCN(verbose=verbose, warnings=warnings)

--- a/setup.py
+++ b/setup.py
@@ -267,6 +267,7 @@ def run_setup(with_binary):
             "numba",  # just-in-time compiler
             "psutil",  # for getting user RAM
             "tuna",  # to generate visual/interactive performance profiles
+            "vaex",  # HDF5
         ],
         extras_require={
             "dev": [


### PR DESCRIPTION
## Description

choosing mode='tabulation' or (still default) mode='full summation' 'tabulation' is ~3500x faster at eq, ~500x faster at noneq (tested on CO2)

For a first working version:
- [x] on-the-fly tabulation implemented in PartitionFunction calculators  at equilibrium
- [x] on-the-fly tabulation implemented in PartitionFunction calculators  at non equilibrium (2T)
- [x] added unitary tests for PartitionFunctions
- [x] added a parameter, temporarily named `SpectrumFactory.misc.parsum_mode`
- [x] make it possible to compute Q without returnQvibQrot  in noneq mode 
- [x] compare (see Test below) tabulated parititon function & full summation on a noneq spectrum

For later: 
- [x] on-the-fly tabulation implemented in PartitionFunction calculators  at non equilibrium (3Tvib)
- [ ] implemnt on-the-fly tabulation with returnQvibQrot option
- [ ] implemnt on-the-fly tabulation with overpopulation option
- [ ] change default `parsum_mode` to 'tabulation' (wait for 0.9.31)
- [ ] mention on the docs in "Performance" section 

<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

## Test
<!-- Provide a general description of what your pull request does. -->

```python

from radis import SpectrumFactory

wmin, wmax = 2383.8, 2384.9
sf = SpectrumFactory(wavenum_min=wmin,
                     wavenum_max=wmax,
                      molecule='CO2',
                     isotope='1',
                     broadening_max_width=5,  # cm-1
                     medium='air',   
                     path_length=10.32, #cm
                     wstep=0.001, 
                     )
conditions = {'mole_fraction':0.2, 'pressure':1,
              'Ttrans':2000, 'Trot':2100, 'Tvib':1500}


sf.verbose = 0
sf.load_databank("HITEMP-CO2-DUNHAM") # my personal database
_  = sf.non_eq_spectrum(**conditions)  # initialize energies, etc.

# Now show times : 
sf.verbose = 3
sf.misc.parsum_mode = 'full summation'   # default
s_HITEMP = sf.non_eq_spectrum(**conditions)


# Now, again with tabulation:

sf.misc.parsum_mode = 'tabulation'
sf.verbose = 0
sf.load_databank("HITEMP-CO2-DUNHAM") # my personal database

_  = sf.non_eq_spectrum(**conditions)  # initialize energies, first tabulation

sf.verbose= 3
s_HITEMP2 = sf.non_eq_spectrum(**conditions)
```

Output : 
```
  warnings.warn(WarningType(message))
... 0.00s - Checked nonequilibrium parameters
... sorting lines by vibrational bands
... lines sorted in 0.1s
...... 0.60s - partition functions
...... 0.03s - populations
... 0.64s - Calculated nonequilibrium populations
...... 0.00s - map partition functions
...... 0.01s - corrected for populations and stimulated emission
... 0.02s - scaled nonequilibrium linestrength
... 0.03s - calculated emission integral
... 0.00s - Calculated lineshift
... 0.03s - Calculate broadening HWHM
... Calculating line broadening (4117 lines: expect ~ 2.06s on 1 CPU)
...... 0.01s - Precomputed DLM lineshapes (8)
...... 0.00s - Initialized vectors
...... 0.00s - Get closest matching line & fraction
...... 0.00s - Distribute lines over DLM
...... 0.01s - Convolve and sum on spectral range
...... 0.00s - Initialized vectors
...... 0.00s - Get closest matching line & fraction
...... 0.00s - Distribute lines over DLM
...... 0.02s - Convolve and sum on spectral range
... 0.07s - Calculated line broadening
... 0.01s - Calculated other spectral quantities
... 0.96s - Spectrum calculated (before object generation)
... 0.00s - Generated Spectrum object
0.96s - Spectrum calculated

# THEN BECOMES : 

... 0.00s - Checked nonequilibrium parameters
... sorting lines by vibrational bands
... lines sorted in 0.1s
...... 0.06s - partition functions
...... 0.01s - populations
... 0.08s - Calculated nonequilibrium populations
...... 0.00s - map partition functions
...... 0.00s - corrected for populations and stimulated emission
... 0.01s - scaled nonequilibrium linestrength
... 0.01s - calculated emission integral
... 0.00s - Calculated lineshift
... 0.02s - Calculate broadening HWHM
... Calculating line broadening (4117 lines: expect ~ 2.06s on 1 CPU)
...... 0.00s - Precomputed DLM lineshapes (8)
...... 0.00s - Initialized vectors
...... 0.00s - Get closest matching line & fraction
...... 0.00s - Distribute lines over DLM
...... 0.01s - Convolve and sum on spectral range
...... 0.00s - Initialized vectors
...... 0.00s - Get closest matching line & fraction
...... 0.00s - Distribute lines over DLM
...... 0.00s - Convolve and sum on spectral range
... 0.03s - Calculated line broadening
... 0.01s - Calculated other spectral quantities
... 0.22s - Spectrum calculated (before object generation)
... 0.00s - Generated Spectrum object
0.22s - Spectrum calculated


```
So about 4 faster for the total spectrum 


## Fixes 

A way to fix #45 without tabulating on-disk. 