### PR TITLE
Switch to memory_usage(deep=false)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,7 @@ dependencies:
 - pytest  # to run test suite
 - joblib  # for parallel loading of SpecDatabase
 - numba  # just-in-time compiler
+- psutil
 - pip
 - pip:
   - publib>=0.3.2  # Plotting styles for Matplotlib

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -68,6 +68,7 @@ import numpy as np
 import pandas as pd
 from astropy import units as u
 from numpy import exp, pi
+from psutil import virtual_memory
 
 import radis
 
@@ -3253,11 +3254,22 @@ class BaseFactory(DatabankLoader):
 
         # Check memory size
         try:
+            # Retrieving total user RAM
+            mem = virtual_memory()
+            mem = mem.total  # total physical memory available
             # Checking if object type column exists
             if "O" in self.df1.dtypes.unique():
-                limit = 80e6
+                limit = (
+                    mem / 25  # 4% of user RAM
+                )  # Since the memory_usage(deep=False) will be alot less than actual
+                self.warn(
+                    "'object' type column found in database, calculations and "
+                    + "memory usage would be faster with a numeric type. Possible "
+                    + "solution is to not use 'save_memory' and convert the columns to dtype."
+                )
             else:
-                limit = 500e6
+                limit = mem * 2 / 5  # 40% of User available RAM
+
             df_size = self.df1.memory_usage(deep=False).sum()
 
             if df_size > limit:

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -3259,16 +3259,17 @@ class BaseFactory(DatabankLoader):
             mem = mem.total  # total physical memory available
             # Checking if object type column exists
             if "O" in self.df1.dtypes.unique():
-                limit = (
-                    mem / 25  # 4% of user RAM
-                )  # Since the memory_usage(deep=False) will be alot less than actual
+                limit = mem / 25  # 4% of user RAM
                 self.warn(
                     "'object' type column found in database, calculations and "
                     + "memory usage would be faster with a numeric type. Possible "
-                    + "solution is to not use 'save_memory' and convert the columns to dtype."
+                    + "solution is to not use 'save_memory' and convert the columns to dtype.",
+                    "PerformanceWarning",
                 )
             else:
-                limit = mem * 2 / 5  # 40% of User available RAM
+                limit = (
+                    mem / 25 * 4
+                )  # the difference between deep=True and deep=False is around 4 times
 
             df_size = self.df1.memory_usage(deep=False).sum()
 

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -64,9 +64,6 @@ Most methods are written in inherited class with the following inheritance schem
 """
 # TODO: move all CDSD dependant functions _add_Evib123Erot to a specific file for CO2.
 
-
-import sys
-
 import numpy as np
 import pandas as pd
 from astropy import units as u
@@ -3256,11 +3253,16 @@ class BaseFactory(DatabankLoader):
 
         # Check memory size
         try:
-            if sys.getsizeof(self.df1) > 500e6:
+            # Checking if object type column exists
+            if "O" in self.df1.dtypes.unique():
+                limit = 80e6
+            else:
+                limit = 500e6
+            df_size = self.df1.memory_usage(deep=False).sum()
+
+            if df_size > limit:
                 self.warn(
-                    "Line database is large: {0:.0f} Mb".format(
-                        sys.getsizeof(self.df1) * 1e-6
-                    )
+                    "Line database is large: {0:.0f} Mb".format(df_size * 1e-6)
                     + ". Consider using save_memory "
                     + "option, if you don't need to reuse this factory to calculate new spectra",
                     "MemoryUsageWarning",

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -3267,9 +3267,9 @@ class BaseFactory(DatabankLoader):
                     "PerformanceWarning",
                 )
             else:
-                limit = (
-                    mem / 25 * 4
-                )  # the difference between deep=True and deep=False is around 4 times
+                limit = mem / 2  # 50 % of user RAM
+
+            # Note: the difference between deep=True and deep=False is around 4 times
 
             df_size = self.df1.memory_usage(deep=False).sum()
 


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to change `sys.getsizeof()` with `memory_usage(deep=false)` and checks if `object` type column is present in df, if yes we will have a different threshold to compare with.

On trying to get the relation of the number of lines, calculation time and memory_usage(deep=false) no relation could be derived between time taken to load a line or column. Below is the plot between `N_lines`, ` Time_taken` by memory_usage(deep=false) and size of data frame as heat map:

![Time Taken](https://user-images.githubusercontent.com/44584067/126015593-ec52d1b6-c75d-45b8-80f6-58b0f0edc273.png)
Clearly the computation is so fast that its dependence is negligible on the number of lines and we can expect a constant value for time taken irrespective size of dataframe.

Replacing `sys.getsizeof` with `memory_usage(deep=false)`  saved us around `20-50%` time: A simple comparison below for CH4 for different number of lines
```# Computation parameters
wmin = 2000
wmax = 4200
wstep = 0.01
T = 300.0 #K
p = 1 #bar
broadening_max_width=5
molecule = 'CH4'
```
![Screenshot from 2021-07-17 04-31-11](https://user-images.githubusercontent.com/44584067/126016172-4fdc6959-bd6d-4c20-96a0-1a7acf6b85eb.png)

Also reinitialize is dominated by `self.df1 = self.df0.copy()` (here reinitialize_1):
![Reinitialize_new](https://user-images.githubusercontent.com/44584067/126016532-8dc704fa-c4b3-4ba3-96a9-9a2f7ef3d766.png)
