### PR TITLE
use tuna 🐟  to generate visual/interactive performance profiles

### DIFF
--- a/docs/lbl/lbl.rst
+++ b/docs/lbl/lbl.rst
@@ -805,34 +805,34 @@ For the above example::
 
 ::
     # Output:
-        spectrum_calculation  2.163s ████████████████
-        check_line_databank          0.000s
-        check_non_eq_param           0.306s ██
-        fetch_energy_5               0.112s
-        calc_weight_trans            0.063s
-            reinitialize                 0.009s
-            copy_database                0.000s
-            memory_usage_warning         0.008s
-            reset_population             0.000s
-            calc_noneq_population        0.195s █
-            part_function                0.165s █
-            population                   0.031s
-            scaled_non_eq_linestrength   0.021s
-            map_part_func                0.005s
-            corrected_population_se      0.011s
-        calc_emission_integral       0.028s
-        applied_linestrength_cutoff  0.005s
-        calc_lineshift               0.002s
-        calc_hwhm                    0.029s
-        generate_wavenumber_arrays   0.005s
-            calc_line_broadening         1.499s ███████████
-            precompute_DLM_lineshapes    0.032s
-            DLM_Initialized_vectors      0.000s
-            DLM_closest_matching_line    0.000s
-            DLM_Distribute_lines         0.006s
-            DLM_convolve                 0.822s ██████
-        calc_other_spectral_quan     0.024s
-        generate_spectrum_obj        0.001s
+        spectrum_calculation      0.844s ████████████████
+            check_line_databank              0.001s
+            check_non_eq_param               0.070s █
+            fetch_energy_5                   0.027s
+            calc_weight_trans                0.016s
+            reinitialize                     0.003s
+                copy_database                    0.000s
+                memory_usage_warning             0.003s
+                reset_population                 0.000s
+            calc_noneq_population            0.066s █
+                part_function                    0.056s █
+                population                       0.010s
+            scaled_non_eq_linestrength       0.004s
+                map_part_func                    0.001s
+                corrected_population_se          0.003s
+            calc_emission_integral           0.008s
+            applied_linestrength_cutoff      0.003s
+            calc_lineshift                   0.001s
+            calc_hwhm                        0.008s
+            generate_wavenumber_arrays       0.002s
+            calc_line_broadening             0.668s ████████████
+                precompute_DLM_lineshapes        0.020s
+                DLM_Initialized_vectors          0.000s
+                DLM_closest_matching_line        0.001s
+                DLM_Distribute_lines             0.002s
+                DLM_convolve                     0.304s █████
+            calc_other_spectral_quan         0.005s
+            generate_spectrum_obj            0.000s
 
 Finally, you can also use the SpectrumFactory :py:meth:`~radis.lbl.factory.SpectrumFactory.generate_perf_profile`
 Spectrum :py:meth:`~radis.spectrum.spectrum.Spectrum.generate_perf_profile`

--- a/docs/lbl/lbl.rst
+++ b/docs/lbl/lbl.rst
@@ -781,7 +781,8 @@ Profiler
 --------
 
 You may want to track where the calculation is taking some time.
-You can set ``verbose=3`` or lower to print the time spent on different operations. Example::
+You can set ``verbose=1`` or higher to print the time spent on the different
+calculation steps at runtime. Example with ``verbose=3``::
 
     s = calc_spectrum(1900, 2300,         # cm-1
                       molecule='CO',
@@ -793,94 +794,56 @@ You can set ``verbose=3`` or lower to print the time spent on different operatio
                       verbose=3,
                       )
 
-::
-
-    >>> 0.00s - Check line databank
-    >>> Fetching Evib & Erot.
-    >>> If using this code several times you should consider updating the database directly. See functions in factory.py
-    >>> 0.01s - Fetched energies for all 749 transitions
-    >>> 0.01s - calculated weighted transition moment
-    >>> 0.04s - Checked nonequilibrium parameters
-    >>> ...... 0.00s - Copying database
-    >>> ...... 0.00s - Check Memory usage of database
-    >>> ...... 0.00s - Reset populations
-    >>> 0.00s - Reinitialize database
-    >>> sorting lines by vibrational bands
-    >>> lines sorted in 0.0s
-    >>> ...... 0.03s - partition functions
-    >>> ...... 0.01s - populations
-    >>> 0.04s - Calculated nonequilibrium populations
-    >>> ...... 0.00s - map partition functions
-    >>> ...... 0.00s - corrected for populations and stimulated emission
-    >>> 0.00s - scaled nonequilibrium linestrength
-    >>> 0.01s - calculated emission integral
-    >>> Discarded 7.21% of lines (linestrength<1e-27cm-1/(#.cm-2)) Estimated error: 0.00%
-    >>> 0.00s - Applied linestrength cutoff
-    >>> 0.00s - Calculated lineshift
-    >>> 0.01s - Calculate broadening HWHM
-    >>> 0.00s - Generated Wavenumber Arrays
-    >>> Calculating line broadening (695 lines: expect ~ 0.07s on 1 CPU)
-    >>> ...... 0.01s - Precomputed DLM lineshapes (15)
-    >>> ...... 0.00s - Initialized vectors
-    >>> ...... 0.00s - Get closest matching line & fraction
-    >>> ...... 0.00s - Distribute lines over DLM
-    >>> ...... 0.03s - Convolve and sum on spectral range
-    >>> ...... 0.00s - Initialized vectors
-    >>> ...... 0.00s - Get closest matching line & fraction
-    >>> ...... 0.00s - Distribute lines over DLM
-    >>> ...... 0.03s - Convolve and sum on spectral range
-    >>> 0.08s - Calculated line broadening
-    >>> 0.00s - Calculated other spectral quantities
-    >>> 0.19s - Spectrum calculated (before object generation)
-    >>> 0.00s - Generated Spectrum object
-    >>> 0.19s - Spectrum calculated
-
-.. _label_lbl_precompute_spectra:
-
-You can print the the time distribution Spectrum at various levels in a presentable hierarchy using the
-:py:meth:`~radis.lbl.factory.SpectrumFactory.print_perf_profile` method in SpectrumFactory object or
-:py:meth:`~radis.spectrum.spectrum.Spectrum.print_perf_profile` method in the Spectrum object.
+Performance profiles are kept in the output spectrum ``conditions['profiler']`` dictionary.
+You can also use the :py:meth:`~radis.lbl.factory.SpectrumFactory.print_perf_profile`
+method in the SpectrumFactory object or the :py:meth:`~radis.spectrum.spectrum.Spectrum.print_perf_profile`
+method in the Spectrum object to print them in the console :
 
 For the above example::
 
     s.print_perf_profile()
 
 ::
+    # Output:
+        spectrum_calculation  2.163s ████████████████
+        check_line_databank          0.000s
+        check_non_eq_param           0.306s ██
+        fetch_energy_5               0.112s
+        calc_weight_trans            0.063s
+            reinitialize                 0.009s
+            copy_database                0.000s
+            memory_usage_warning         0.008s
+            reset_population             0.000s
+            calc_noneq_population        0.195s █
+            part_function                0.165s █
+            population                   0.031s
+            scaled_non_eq_linestrength   0.021s
+            map_part_func                0.005s
+            corrected_population_se      0.011s
+        calc_emission_integral       0.028s
+        applied_linestrength_cutoff  0.005s
+        calc_lineshift               0.002s
+        calc_hwhm                    0.029s
+        generate_wavenumber_arrays   0.005s
+            calc_line_broadening         1.499s ███████████
+            precompute_DLM_lineshapes    0.032s
+            DLM_Initialized_vectors      0.000s
+            DLM_closest_matching_line    0.000s
+            DLM_Distribute_lines         0.006s
+            DLM_convolve                 0.822s ██████
+        calc_other_spectral_quan     0.024s
+        generate_spectrum_obj        0.001s
 
-    >>> spectrum_calculation:
-    >>>   applied_linestrength_cutoff: 0.0024361610412597656
-    >>>   calc_emission_integral: 0.006468772888183594
-    >>>   calc_hwhm: 0.006415128707885742
-    >>>   calc_line_broadening:
-    >>>     DLM_Distribute_lines: 0.0003898143768310547
-    >>>     DLM_Initialized_vectors: 9.775161743164062e-06
-    >>>     DLM_closest_matching_line: 0.0005028247833251953
-    >>>     DLM_convolve: 0.029767990112304688
-    >>>     precompute_DLM_lineshapes: 0.013132810592651367
-    >>>     value: 0.07619166374206543
-    >>>   calc_lineshift: 0.00074005126953125
-    >>>   calc_noneq_population:
-    >>>     part_function: 0.03405046463012695
-    >>>     population: 0.005669832229614258
-    >>>     value: 0.03983640670776367
-    >>>   calc_other_spectral_quan: 0.002928495407104492
-    >>>   calc_weight_trans: 0.008247852325439453
-    >>>   check_line_databank: 0.0002810955047607422
-    >>>   check_non_eq_param: 0.04109525680541992
-    >>>   fetch_energy_5: 0.014983654022216797
-    >>>   generate_spectrum_obj: 0.00032138824462890625
-    >>>   generate_wavenumber_arrays: 0.0010433197021484375
-    >>>   reinitialize:
-    >>>     copy_database: 2.1457672119140625e-06
-    >>>     memory_usage_warning: 0.0018389225006103516
-    >>>     reset_population: 2.6226043701171875e-05
-    >>>     value: 0.001964569091796875
-    >>>   scaled_non_eq_linestrength:
-    >>>     corrected_population_se: 0.002747774124145508
-    >>>     map_part_func: 0.0010590553283691406
-    >>>     value: 0.0038983821868896484
-    >>>   value: 0.1904621124267578
+Finally, you can also use the SpectrumFactory :py:meth:`~radis.lbl.factory.SpectrumFactory.generate_perf_profile`
+Spectrum :py:meth:`~radis.spectrum.spectrum.Spectrum.generate_perf_profile`
+methods to generate an interactive profiler in the browser.
 
+.. image:: https://user-images.githubusercontent.com/16088743/128018032-6049be72-1881-46ac-9d7c-1ed89f9c4f42.png
+    :alt: https://user-images.githubusercontent.com/16088743/128018032-6049be72-1881-46ac-9d7c-1ed89f9c4f42.png
+    :target: https://user-images.githubusercontent.com/16088743/128018032-6049be72-1881-46ac-9d7c-1ed89f9c4f42.png
+
+
+.. _label_lbl_precompute_spectra:
 
 Precompute Spectra
 ------------------

--- a/environment.yml
+++ b/environment.yml
@@ -30,3 +30,4 @@ dependencies:
   - hitran-api     # HAPI, used to access TIPS partition functions
   - json-tricks>=3.15.0  # to deal with non jsonable formats
   - mpldatacursor
+  - tuna           # to generate visual/interactive performance profiles

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,6 @@ dependencies:
 - joblib  # for parallel loading of SpecDatabase
 - numba  # just-in-time compiler
 - psutil # for getting user RAM
-- pyyaml # for printing profiler dictionary
 - pip
 - pip:
   - publib>=0.3.2  # Plotting styles for Matplotlib

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -1748,34 +1748,34 @@ class SpectrumFactory(BandFactory):
             sf.print_perf_profile()
 
             # output >>
-                        spectrum_calculation  2.163s ████████████████
-                        check_line_databank          0.000s
-                        check_non_eq_param           0.306s ██
-                        fetch_energy_5               0.112s
-                        calc_weight_trans            0.063s
-                            reinitialize                 0.009s
-                            copy_database                0.000s
-                            memory_usage_warning         0.008s
-                            reset_population             0.000s
-                            calc_noneq_population        0.195s █
-                            part_function                0.165s █
-                            population                   0.031s
-                            scaled_non_eq_linestrength   0.021s
-                            map_part_func                0.005s
-                            corrected_population_se      0.011s
-                        calc_emission_integral       0.028s
-                        applied_linestrength_cutoff  0.005s
-                        calc_lineshift               0.002s
-                        calc_hwhm                    0.029s
-                        generate_wavenumber_arrays   0.005s
-                            calc_line_broadening         1.499s ███████████
-                            precompute_DLM_lineshapes    0.032s
-                            DLM_Initialized_vectors      0.000s
-                            DLM_closest_matching_line    0.000s
-                            DLM_Distribute_lines         0.006s
-                            DLM_convolve                 0.822s ██████
-                        calc_other_spectral_quan     0.024s
-                        generate_spectrum_obj        0.001s
+                spectrum_calculation      0.844s ████████████████
+                    check_line_databank              0.001s
+                    check_non_eq_param               0.070s █
+                    fetch_energy_5                   0.027s
+                    calc_weight_trans                0.016s
+                    reinitialize                     0.003s
+                        copy_database                    0.000s
+                        memory_usage_warning             0.003s
+                        reset_population                 0.000s
+                    calc_noneq_population            0.066s █
+                        part_function                    0.056s █
+                        population                       0.010s
+                    scaled_non_eq_linestrength       0.004s
+                        map_part_func                    0.001s
+                        corrected_population_se          0.003s
+                    calc_emission_integral           0.008s
+                    applied_linestrength_cutoff      0.003s
+                    calc_lineshift                   0.001s
+                    calc_hwhm                        0.008s
+                    generate_wavenumber_arrays       0.002s
+                    calc_line_broadening             0.668s ████████████
+                        precompute_DLM_lineshapes        0.020s
+                        DLM_Initialized_vectors          0.000s
+                        DLM_closest_matching_line        0.001s
+                        DLM_Distribute_lines             0.002s
+                        DLM_convolve                     0.304s █████
+                    calc_other_spectral_quan         0.005s
+                    generate_spectrum_obj            0.000s
 
         Other Parameters
         ----------------

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -80,7 +80,6 @@ from warnings import warn
 
 import astropy.units as u
 import numpy as np
-import yaml
 from numpy import arange, exp
 from scipy.constants import N_A, c, k, pi
 
@@ -1738,26 +1737,107 @@ class SpectrumFactory(BandFactory):
 
         return conv2(Ptot, "mW/cm2/sr", unit)
 
-    def print_perf_profile(self):
-        """Prints Profiler output dictionary in a structured manner.
-        example:
-        SpectrumFactory.print_perf_profile()
-        ----------------------------
-        spectrum_calculation:
-            calc_hwhm: 0.007350444793701172
-            calc_line_broadening:
-                DLM_Distribute_lines: 0.005137443542480469
-                DLM_Initialized_vectors: 8.106231689453125e-06
-                DLM_closest_matching_line: 0.0010995864868164062
-                DLM_convolve: 0.6121664047241211
-                precompute_DLM_lineshapes: 0.027348995208740234
-                value: 0.6468849182128906
-            calc_lineshift: 0.0005822181701660156
-            calc_other_spectral_quan: 0.005536317825317383
-            value: 0.6814641952514648
+    def print_perf_profile(self, number_format="{:.3f}", precision=16):
+        """Prints Profiler output dictionary in a structured manner for
+        the last calculated spectrum
+
+        Examples
+        --------
+
+        ::
+            sf.print_perf_profile()
+
+            # output >>
+                        spectrum_calculation  2.163s ████████████████
+                        check_line_databank          0.000s
+                        check_non_eq_param           0.306s ██
+                        fetch_energy_5               0.112s
+                        calc_weight_trans            0.063s
+                            reinitialize                 0.009s
+                            copy_database                0.000s
+                            memory_usage_warning         0.008s
+                            reset_population             0.000s
+                            calc_noneq_population        0.195s █
+                            part_function                0.165s █
+                            population                   0.031s
+                            scaled_non_eq_linestrength   0.021s
+                            map_part_func                0.005s
+                            corrected_population_se      0.011s
+                        calc_emission_integral       0.028s
+                        applied_linestrength_cutoff  0.005s
+                        calc_lineshift               0.002s
+                        calc_hwhm                    0.029s
+                        generate_wavenumber_arrays   0.005s
+                            calc_line_broadening         1.499s ███████████
+                            precompute_DLM_lineshapes    0.032s
+                            DLM_Initialized_vectors      0.000s
+                            DLM_closest_matching_line    0.000s
+                            DLM_Distribute_lines         0.006s
+                            DLM_convolve                 0.822s ██████
+                        calc_other_spectral_quan     0.024s
+                        generate_spectrum_obj        0.001s
+
+        Other Parameters
+        ----------------
+        precision: int, optional
+            total number of blocks. Default 16.
+
+        See Also
+        --------
+
+        :py:meth:`~radis.spectrum.spectrum.Spectrum.print_perf_profile`
         """
+        from radis.spectrum.utils import print_perf_profile
+
         profiler = self.profiler.final
-        print(yaml.dump(profiler, allow_unicode=True, default_flow_style=False))
+        total_time = profiler["spectrum_calculation"]["value"]
+
+        return print_perf_profile(
+            profiler, total_time, number_format=number_format, precision=precision
+        )
+
+    def generate_perf_profile(self):
+        """Generate a visual/interactive performance profile diagram for
+        the last calculated spectrum
+
+        .. note:
+            requires a `profiler` key with in Spectrum.conditions
+
+        Examples
+        --------
+        ::
+            sf = SpectrumFactory(...)
+            sf.eq_spectrum(...)
+            sf.generate_perf_profile()
+
+        See typical output in https://github.com/radis/radis/pull/325
+
+        .. image:: https://user-images.githubusercontent.com/16088743/128018032-6049be72-1881-46ac-9d7c-1ed89f9c4f42.png
+            :alt: https://user-images.githubusercontent.com/16088743/128018032-6049be72-1881-46ac-9d7c-1ed89f9c4f42.png
+            :target: https://user-images.githubusercontent.com/16088743/128018032-6049be72-1881-46ac-9d7c-1ed89f9c4f42.png
+
+
+        .. note::
+            You can also profile with `tuna` directly::
+
+                python -m cProfile -o program.prof your_radis_script.py
+                tuna your_radis_script.py
+
+
+        See Also
+        --------
+        :py:meth:`~radis.spectrum.spectrum.Spectrum.print_perf_profile`
+        """
+        from radis.spectrum.utils import generate_perf_profile
+
+        profiler = self.profiler.final.copy().copy()
+        # Add total calculation time:
+        profiler.update({"value": profiler["spectrum_calculation"]["value"]})
+        # note: in Spectrum.generate_perf_profile the total time is taken as
+        # 'self.conditions["calculation_time"]' which also includes database
+        # loading times.
+
+        return generate_perf_profile(profiler)
 
 
 # %% ======================================================================

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -3597,6 +3597,28 @@ class Spectrum(object):
             print("Normalization factor : {0}".format(norm))
         return out
 
+    def generate_perf_profile(self):
+        """Generate a visual/interactive performance profile diagram using ``tuna``
+
+        .. note:
+            requires a `profiler` key with in Spectrum.conditions
+
+        Examples
+        --------
+        ::
+            s = calc_spectrum(...)
+            s.generate_perf_profile()
+
+        See typical output in https://github.com/radis/radis/pull/324
+
+        See Also
+        --------
+        :py:func:`~radis.spectrum.utils.generate_perf_profile`
+        """
+        from radis.spectrum.utils import generate_perf_profile
+
+        generate_perf_profile(self)
+
     # %% Define Spectrum Algebra
     # +, -, *, ^  operators
 

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -3586,34 +3586,34 @@ class Spectrum(object):
             Spectrum.print_perf_profile()
 
             # output >>
-                        spectrum_calculation  2.163s ████████████████
-                        check_line_databank          0.000s
-                        check_non_eq_param           0.306s ██
-                        fetch_energy_5               0.112s
-                        calc_weight_trans            0.063s
-                            reinitialize                 0.009s
-                            copy_database                0.000s
-                            memory_usage_warning         0.008s
-                            reset_population             0.000s
-                            calc_noneq_population        0.195s █
-                            part_function                0.165s █
-                            population                   0.031s
-                            scaled_non_eq_linestrength   0.021s
-                            map_part_func                0.005s
-                            corrected_population_se      0.011s
-                        calc_emission_integral       0.028s
-                        applied_linestrength_cutoff  0.005s
-                        calc_lineshift               0.002s
-                        calc_hwhm                    0.029s
-                        generate_wavenumber_arrays   0.005s
-                            calc_line_broadening         1.499s ███████████
-                            precompute_DLM_lineshapes    0.032s
-                            DLM_Initialized_vectors      0.000s
-                            DLM_closest_matching_line    0.000s
-                            DLM_Distribute_lines         0.006s
-                            DLM_convolve                 0.822s ██████
-                        calc_other_spectral_quan     0.024s
-                        generate_spectrum_obj        0.001s
+                spectrum_calculation      0.844s ████████████████
+                    check_line_databank              0.001s
+                    check_non_eq_param               0.070s █
+                    fetch_energy_5                   0.027s
+                    calc_weight_trans                0.016s
+                    reinitialize                     0.003s
+                        copy_database                    0.000s
+                        memory_usage_warning             0.003s
+                        reset_population                 0.000s
+                    calc_noneq_population            0.066s █
+                        part_function                    0.056s █
+                        population                       0.010s
+                    scaled_non_eq_linestrength       0.004s
+                        map_part_func                    0.001s
+                        corrected_population_se          0.003s
+                    calc_emission_integral           0.008s
+                    applied_linestrength_cutoff      0.003s
+                    calc_lineshift                   0.001s
+                    calc_hwhm                        0.008s
+                    generate_wavenumber_arrays       0.002s
+                    calc_line_broadening             0.668s ████████████
+                        precompute_DLM_lineshapes        0.020s
+                        DLM_Initialized_vectors          0.000s
+                        DLM_closest_matching_line        0.001s
+                        DLM_Distribute_lines             0.002s
+                        DLM_convolve                     0.304s █████
+                    calc_other_spectral_quan         0.005s
+                    generate_spectrum_obj            0.000s
 
         Other Parameters
         ----------------

--- a/radis/spectrum/utils.py
+++ b/radis/spectrum/utils.py
@@ -428,8 +428,6 @@ def dict_to_tree(pro, name):
     else:
         return {"value": pro, "name": name}
 
-    return new_dict
-
 
 #%%
 
@@ -466,34 +464,34 @@ def print_perf_profile(
         Spectrum.print_perf_profile()
 
         # output >>
-                    spectrum_calculation  2.163s ████████████████
-                    check_line_databank          0.000s
-                    check_non_eq_param           0.306s ██
-                    fetch_energy_5               0.112s
-                    calc_weight_trans            0.063s
-                        reinitialize                 0.009s
-                        copy_database                0.000s
-                        memory_usage_warning         0.008s
-                        reset_population             0.000s
-                        calc_noneq_population        0.195s █
-                        part_function                0.165s █
-                        population                   0.031s
-                        scaled_non_eq_linestrength   0.021s
-                        map_part_func                0.005s
-                        corrected_population_se      0.011s
-                    calc_emission_integral       0.028s
-                    applied_linestrength_cutoff  0.005s
-                    calc_lineshift               0.002s
-                    calc_hwhm                    0.029s
-                    generate_wavenumber_arrays   0.005s
-                        calc_line_broadening         1.499s ███████████
-                        precompute_DLM_lineshapes    0.032s
-                        DLM_Initialized_vectors      0.000s
-                        DLM_closest_matching_line    0.000s
-                        DLM_Distribute_lines         0.006s
-                        DLM_convolve                 0.822s ██████
-                    calc_other_spectral_quan     0.024s
-                    generate_spectrum_obj        0.001s
+            spectrum_calculation      0.844s ████████████████
+                check_line_databank              0.001s
+                check_non_eq_param               0.070s █
+                fetch_energy_5                   0.027s
+                calc_weight_trans                0.016s
+                reinitialize                     0.003s
+                    copy_database                    0.000s
+                    memory_usage_warning             0.003s
+                    reset_population                 0.000s
+                calc_noneq_population            0.066s █
+                    part_function                    0.056s █
+                    population                       0.010s
+                scaled_non_eq_linestrength       0.004s
+                    map_part_func                    0.001s
+                    corrected_population_se          0.003s
+                calc_emission_integral           0.008s
+                applied_linestrength_cutoff      0.003s
+                calc_lineshift                   0.001s
+                calc_hwhm                        0.008s
+                generate_wavenumber_arrays       0.002s
+                calc_line_broadening             0.668s ████████████
+                    precompute_DLM_lineshapes        0.020s
+                    DLM_Initialized_vectors          0.000s
+                    DLM_closest_matching_line        0.001s
+                    DLM_Distribute_lines             0.002s
+                    DLM_convolve                     0.304s █████
+                calc_other_spectral_quan         0.005s
+                generate_spectrum_obj            0.000s
 
     See Also
     --------
@@ -513,7 +511,7 @@ def print_perf_profile(
 
     def walk_print_tree(prof, name, level, write_number_column):
         if "value" in prof:
-            text = " " * TAB * (level + 1) + name
+            text = " " * TAB * level + name
             fill_spaces = " " * (write_number_column - len(text))
             print(
                 text,
@@ -525,6 +523,7 @@ def print_perf_profile(
         write_number_column = max(
             write_number_column, len(" " * TAB * (level + 1)) + max_name_length
         )
+        write_number_column += TAB
         for k, v in prof.items():
             if k == "value":
                 pass
@@ -533,7 +532,7 @@ def print_perf_profile(
                     v,
                     name=k,
                     level=level + 1,
-                    write_number_column=write_number_column + TAB,
+                    write_number_column=write_number_column,
                 )
             elif isinstance(v, float):
                 text = " " * TAB * (level + 1) + k

--- a/radis/spectrum/utils.py
+++ b/radis/spectrum/utils.py
@@ -524,11 +524,13 @@ def print_perf_profile(
             write_number_column, len(" " * TAB * (level + 1)) + max_name_length
         )
         write_number_column += TAB
+
+        total_time = 0
         for k, v in prof.items():
             if k == "value":
                 pass
             elif isinstance(v, dict):
-                walk_print_tree(
+                total_time += walk_print_tree(
                     v,
                     name=k,
                     level=level + 1,
@@ -538,8 +540,25 @@ def print_perf_profile(
                 text = " " * TAB * (level + 1) + k
                 fill_spaces = " " * (write_number_column - len(text))
                 print(text, fill_spaces, "" + number_format.format(v) + "s", scale(v))
+                total_time += v
             else:
                 raise ValueError(type(v))
+
+        # print missing time / self-time
+        if "value" in prof:
+            missing_time = prof["value"] - total_time
+            if float(number_format.format(missing_time)) != 0:
+                # we dont add 0 numbers
+                text = " " * TAB * (level + 1) + "others"
+                fill_spaces = " " * (write_number_column - len(text))
+                print(
+                    text,
+                    fill_spaces,
+                    "" + number_format.format(missing_time) + "s",
+                    scale(missing_time),
+                )
+
+        return total_time
 
     print(first_line)
     walk_print_tree(profiler, name="", level=0, write_number_column=0)

--- a/radis/spectrum/utils.py
+++ b/radis/spectrum/utils.py
@@ -418,7 +418,7 @@ def dict_to_tree(pro, name):
 def generate_perf_profile(s):
     """Visual/interactive performance profile
 
-    See typical output in https://github.com/radis/radis/pull/324
+    See typical output in https://github.com/radis/radis/pull/325
 
     Parameters
     ----------
@@ -505,7 +505,7 @@ def generate_perf_profile(s):
         # Store value
         st.stats[func_name] = (1, 0, tt, ct, {parent: parent_time} if parent else {})
 
-    profiler = s.conditions["profiler"].copy()
+    profiler = s.conditions["profiler"]["spectrum_calculation"].copy()
     # Add total calculation time:
     profiler.update({"value": s.conditions["calculation_time"]})
 
@@ -522,3 +522,9 @@ def generate_perf_profile(s):
     st.dump_stats("spectrum.prof")
 
     subprocess.Popen(["tuna", "spectrum.prof"])
+
+
+if __name__ == "__main__":
+    from radis.test.spectrum.test_utils import test_perf_profile
+
+    test_perf_profile()

--- a/radis/test/spectrum/test_utils.py
+++ b/radis/test/spectrum/test_utils.py
@@ -20,35 +20,34 @@ def test_perf_profile(*args, **kwargs):
         s.print_perf_profile()
 
         # output >>
-                    spectrum_calculation  2.163s ████████████████
-                    check_line_databank          0.000s
-                    check_non_eq_param           0.306s ██
-                    fetch_energy_5               0.112s
-                    calc_weight_trans            0.063s
-                        reinitialize                 0.009s
-                        copy_database                0.000s
-                        memory_usage_warning         0.008s
-                        reset_population             0.000s
-                        calc_noneq_population        0.195s █
-                        part_function                0.165s █
-                        population                   0.031s
-                        scaled_non_eq_linestrength   0.021s
-                        map_part_func                0.005s
-                        corrected_population_se      0.011s
-                    calc_emission_integral       0.028s
-                    applied_linestrength_cutoff  0.005s
-                    calc_lineshift               0.002s
-                    calc_hwhm                    0.029s
-                    generate_wavenumber_arrays   0.005s
-                        calc_line_broadening         1.499s ███████████
-                        precompute_DLM_lineshapes    0.032s
-                        DLM_Initialized_vectors      0.000s
-                        DLM_closest_matching_line    0.000s
-                        DLM_Distribute_lines         0.006s
-                        DLM_convolve                 0.822s ██████
-                    calc_other_spectral_quan     0.024s
-                    generate_spectrum_obj        0.001s
-
+            spectrum_calculation      0.844s ████████████████
+                check_line_databank              0.001s
+                check_non_eq_param               0.070s █
+                fetch_energy_5                   0.027s
+                calc_weight_trans                0.016s
+                reinitialize                     0.003s
+                    copy_database                    0.000s
+                    memory_usage_warning             0.003s
+                    reset_population                 0.000s
+                calc_noneq_population            0.066s █
+                    part_function                    0.056s █
+                    population                       0.010s
+                scaled_non_eq_linestrength       0.004s
+                    map_part_func                    0.001s
+                    corrected_population_se          0.003s
+                calc_emission_integral           0.008s
+                applied_linestrength_cutoff      0.003s
+                calc_lineshift                   0.001s
+                calc_hwhm                        0.008s
+                generate_wavenumber_arrays       0.002s
+                calc_line_broadening             0.668s ████████████
+                    precompute_DLM_lineshapes        0.020s
+                    DLM_Initialized_vectors          0.000s
+                    DLM_closest_matching_line        0.001s
+                    DLM_Distribute_lines             0.002s
+                    DLM_convolve                     0.304s █████
+                calc_other_spectral_quan         0.005s
+                generate_spectrum_obj            0.000s
     ::
         s.generate_perf_profile()
 
@@ -122,4 +121,4 @@ def test_perf_profile_from_factory(*args, **kwargs):
 
 if __name__ == "__main__":
     test_perf_profile()
-    test_perf_profile_from_factory()
+    # test_perf_profile_from_factory()

--- a/radis/test/spectrum/test_utils.py
+++ b/radis/test/spectrum/test_utils.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Jul 27 02:04:14 2021
+
+@author: erwan
+"""
+
+
+def test_perf_profile(*args, **kwargs):
+    """Test visual/interactive performance profile
+
+    Examples
+    --------
+    ::
+        s = calc_spectrum(...)
+        s.generate_perf_profile()
+
+    See output in https://github.com/radis/radis/pull/324
+
+    """
+    from radis.lbl.calc import calc_spectrum
+    from radis.test.utils import setup_test_line_databases
+
+    setup_test_line_databases()
+
+    s = calc_spectrum(
+        2000,
+        2300,
+        molecule="CO",
+        Tgas=3000,
+        databank="HITRAN-CO-TEST",
+        verbose=3,
+    )
+    s.generate_perf_profile()
+
+
+if __name__ == "__main__":
+    test_perf_profile()

--- a/radis/test/spectrum/test_utils.py
+++ b/radis/test/spectrum/test_utils.py
@@ -15,7 +15,10 @@ def test_perf_profile(*args, **kwargs):
         s = calc_spectrum(...)
         s.generate_perf_profile()
 
-    See output in https://github.com/radis/radis/pull/324
+    See output in https://github.com/radis/radis/pull/325
+
+    See Also
+    --------
 
     """
     from radis.lbl.calc import calc_spectrum
@@ -27,10 +30,12 @@ def test_perf_profile(*args, **kwargs):
         2000,
         2300,
         molecule="CO",
-        Tgas=3000,
+        Tvib=3000,
+        Trot=2000,
         databank="HITRAN-CO-TEST",
         verbose=3,
     )
+    s.print_perf_profile()
     s.generate_perf_profile()
 
 

--- a/radis/test/spectrum/test_utils.py
+++ b/radis/test/spectrum/test_utils.py
@@ -5,6 +5,10 @@ Created on Tue Jul 27 02:04:14 2021
 @author: erwan
 """
 
+import os
+import os.path
+import time
+
 
 def test_perf_profile(*args, **kwargs):
     """Test visual/interactive performance profile
@@ -13,13 +17,48 @@ def test_perf_profile(*args, **kwargs):
     --------
     ::
         s = calc_spectrum(...)
+        s.print_perf_profile()
+
+        # output >>
+                    spectrum_calculation  2.163s ████████████████
+                    check_line_databank          0.000s
+                    check_non_eq_param           0.306s ██
+                    fetch_energy_5               0.112s
+                    calc_weight_trans            0.063s
+                        reinitialize                 0.009s
+                        copy_database                0.000s
+                        memory_usage_warning         0.008s
+                        reset_population             0.000s
+                        calc_noneq_population        0.195s █
+                        part_function                0.165s █
+                        population                   0.031s
+                        scaled_non_eq_linestrength   0.021s
+                        map_part_func                0.005s
+                        corrected_population_se      0.011s
+                    calc_emission_integral       0.028s
+                    applied_linestrength_cutoff  0.005s
+                    calc_lineshift               0.002s
+                    calc_hwhm                    0.029s
+                    generate_wavenumber_arrays   0.005s
+                        calc_line_broadening         1.499s ███████████
+                        precompute_DLM_lineshapes    0.032s
+                        DLM_Initialized_vectors      0.000s
+                        DLM_closest_matching_line    0.000s
+                        DLM_Distribute_lines         0.006s
+                        DLM_convolve                 0.822s ██████
+                    calc_other_spectral_quan     0.024s
+                    generate_spectrum_obj        0.001s
+
+    ::
         s.generate_perf_profile()
 
-    See output in https://github.com/radis/radis/pull/325
+    See output of :py:meth:`~radis.spectrum.spectrum.Spectrum.generate_perf_profile`
+    in https://github.com/radis/radis/pull/325
 
     See Also
     --------
-
+    :py:meth:`~radis.spectrum.spectrum.Spectrum.print_perf_profile`,
+    :py:meth:`~radis.spectrum.spectrum.Spectrum.generate_perf_profile`
     """
     from radis.lbl.calc import calc_spectrum
     from radis.test.utils import setup_test_line_databases
@@ -35,9 +74,52 @@ def test_perf_profile(*args, **kwargs):
         databank="HITRAN-CO-TEST",
         verbose=3,
     )
+
+    # Test Console profiler
     s.print_perf_profile()
+
+    # Test interactive profiler
+    if os.path.exists("spectrum.prof"):
+        os.remove("spectrum.prof")
     s.generate_perf_profile()
+    time.sleep(
+        5
+    )  # note @dev: would be better to wait for the subprocess to end; however it won't even if the window is closed
+    with open("spectrum.prof", "rb") as f:
+        assert "calculation_time" in str(f.read())
+
+
+def test_perf_profile_from_factory(*args, **kwargs):
+    """ See :py:func:`radis.test.spectrum.test_utils.test_perf_profile`"""
+
+    from radis import SpectrumFactory
+    from radis.test.utils import setup_test_line_databases
+
+    setup_test_line_databases()
+
+    sf = SpectrumFactory(
+        2000,
+        2300,
+        molecule="CO",
+        verbose=3,
+    )
+    sf.load_databank("HITRAN-CO-TEST")
+    sf.non_eq_spectrum(3000, 2000)
+
+    # Test Console profiler
+    sf.print_perf_profile()
+
+    # Test interactive profiler
+    if os.path.exists("spectrum.prof"):
+        os.remove("spectrum.prof")
+    sf.generate_perf_profile()
+    time.sleep(
+        5
+    )  # note @dev: would be better to wait for the subprocess to end; however it won't even if the window is closed
+    with open("spectrum.prof", "rb") as f:
+        assert "calculation_time" in str(f.read())
 
 
 if __name__ == "__main__":
     test_perf_profile()
+    test_perf_profile_from_factory()

--- a/setup.py
+++ b/setup.py
@@ -260,7 +260,6 @@ def run_setup(with_binary):
             "joblib",  # for parallel loading of SpecDatabase
             "numba",  # just-in-time compiler
             "psutil",  # for getting user RAM
-            "pyyaml",  # for printing profiler dictionary
             "tuna",  # to generate visual/interactive performance profiles
         ],
         extras_require={

--- a/setup.py
+++ b/setup.py
@@ -261,6 +261,7 @@ def run_setup(with_binary):
             "numba",  # just-in-time compiler
             "psutil",  # for getting user RAM
             "pyyaml",  # for printing profiler dictionary
+            "tuna",  # to generate visual/interactive performance profiles
         ],
         extras_require={
             "dev": [


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

use [tuna](https://github.com/nschloe/tuna) to generate visual/interactive performance profiles; and the update the console profiler:


Syntax : 

```
s = calc_spectrum(...)
s.generate_perf_profile()
```


Typical output (opens a local web page) : 

![image](https://user-images.githubusercontent.com/16088743/128018032-6049be72-1881-46ac-9d7c-1ed89f9c4f42.png)

Console profiler:

```
s = calc_spectrum(...)
s.print_perf_profile()
```

Typical output : 

```
        spectrum_calculation      0.844s ████████████████
            check_line_databank              0.001s
            check_non_eq_param               0.070s █
            fetch_energy_5                   0.027s
            calc_weight_trans                0.016s
            reinitialize                     0.003s
                copy_database                    0.000s
                memory_usage_warning             0.003s
                reset_population                 0.000s
            calc_noneq_population            0.066s █
                part_function                    0.056s █
                population                       0.010s
            scaled_non_eq_linestrength       0.004s
                map_part_func                    0.001s
                corrected_population_se          0.003s
            calc_emission_integral           0.008s
            applied_linestrength_cutoff      0.003s
            calc_lineshift                   0.001s
            calc_hwhm                        0.008s
            generate_wavenumber_arrays       0.002s
            calc_line_broadening             0.668s ████████████
                precompute_DLM_lineshapes        0.020s
                DLM_Initialized_vectors          0.000s
                DLM_closest_matching_line        0.001s
                DLM_Distribute_lines             0.002s
                DLM_convolve                     0.304s █████
            calc_other_spectral_quan         0.005s
            generate_spectrum_obj            0.000s
```

### Implementation

- [x] Proof of concept
- [x] Test
- [x] update "profiler" format consistently : @anandxkumar see below 
- [x] mention in docs/performances


@anandxkumar this expects the `conditions["profiler"]` dict to be of the format:  
```python
prof = {'scaled_eq_linestrength': 0.02393484115600586, 'calc_lineshift': 0.002992868423461914, 'calc_hwhm': 0.04986977577209473, 'precompute_DLM_lineshapes': 0.06680488586425781, 'calc_line_broadening': {'value': 1.423218011856079, 'DLM_Initialized_vectors': 0.0, 'DLM_closest_matching_line': 0.048909902572631836, 'DLM_Distribute_lines': 0.052854061126708984, 'DLM_convolve': 1.2426400184631348}, 'calc_other_spectral_quan': 0.03287649154663086, 'spectrum_calc_before_obj': 1.560823678970337, 'value': 1.560823678970337}
```
i.e. (more human-readable with `print(yaml.dump(prof, allow_unicode=True, default_flow_style=False))`
```
calc_hwhm: 0.04986977577209473
calc_line_broadening:
  DLM_Distribute_lines: 0.052854061126708984
  DLM_Initialized_vectors: 0.0
  DLM_closest_matching_line: 0.048909902572631836
  DLM_convolve: 1.2426400184631348
  value: 1.423218011856079              👈  notice the "value"
calc_lineshift: 0.002992868423461914
calc_other_spectral_quan: 0.03287649154663086
precompute_DLM_lineshapes: 0.06680488586425781
scaled_eq_linestrength: 0.02393484115600586
spectrum_calc_before_obj: 1.560823678970337
value: 1.560823678970337          👈  notice the "value"
```

This PR generates the corresponding Python Tree. 

I suggest that you use this PR to also close #332 ; 

- [x] maybe also add a Spectrum method using the `yaml.dump` function above to nicely print the profiler dictionary, adding % etc ? 