### PR TITLE
Fixes: Issue322 - update Profiler

### DIFF
--- a/docs/lbl/lbl.rst
+++ b/docs/lbl/lbl.rst
@@ -781,7 +781,7 @@ Profiler
 --------
 
 You may want to track where the calculation is taking some time.
-You can set ``verbose=2`` to print the time spent on different operations. Example::
+You can set ``verbose=3`` or lower to print the time spent on different operations. Example::
 
     s = calc_spectrum(1900, 2300,         # cm-1
                       molecule='CO',
@@ -790,36 +790,97 @@ You can set ``verbose=2`` to print the time spent on different operations. Examp
                       Tvib=1000,          # K
                       Trot=300,           # K
                       mole_fraction=0.1,
-                      verbose=2,
+                      verbose=3,
                       )
 
 ::
 
-    >>> ...
-    >>> Fetching vib / rot energies for all 749 transitions
-    >>> Fetched energies in 0s
-    >>> Calculate weighted transition moment
-    >>> Calculated weighted transition moment in 0.0
-    >>> Calculating nonequilibrium populations
+    >>> 0.00s - Check line databank
+    >>> Fetching Evib & Erot.
+    >>> If using this code several times you should consider updating the database directly. See functions in factory.py
+    >>> 0.01s - Fetched energies for all 749 transitions
+    >>> 0.01s - calculated weighted transition moment
+    >>> 0.04s - Checked nonequilibrium parameters
+    >>> ...... 0.00s - Copying database
+    >>> ...... 0.00s - Check Memory usage of database
+    >>> ...... 0.00s - Reset populations
+    >>> 0.00s - Reinitialize database
     >>> sorting lines by vibrational bands
     >>> lines sorted in 0.0s
-    >>> Calculated nonequilibrium populations in 0.1s
-    >>> scale nonequilibrium linestrength
-    >>> scaled nonequilibrium linestrength in 0.0s
-    >>> calculated emission integral
-    >>> calculated emission integral in 0.0s
-    >>> Applying linestrength cutoff
-    >>> Applied linestrength cutoff in 0.0s (expected time saved ~ 0.0s)
-    >>> Calculating lineshift
-    >>> Calculated lineshift in 0.0s
-    >>> Calculate broadening FWHM
-    >>> Calculated broadening FWHM in 0.0s
-    >>> Calculating line broadening (695 lines: expect ~ 0.1s on 1 CPU)
-    >>> Calculated line broadening in 0.1s
-    >>> process done in 0.4s
-    >>> ...
+    >>> ...... 0.03s - partition functions
+    >>> ...... 0.01s - populations
+    >>> 0.04s - Calculated nonequilibrium populations
+    >>> ...... 0.00s - map partition functions
+    >>> ...... 0.00s - corrected for populations and stimulated emission
+    >>> 0.00s - scaled nonequilibrium linestrength
+    >>> 0.01s - calculated emission integral
+    >>> Discarded 7.21% of lines (linestrength<1e-27cm-1/(#.cm-2)) Estimated error: 0.00%
+    >>> 0.00s - Applied linestrength cutoff
+    >>> 0.00s - Calculated lineshift
+    >>> 0.01s - Calculate broadening HWHM
+    >>> 0.00s - Generated Wavenumber Arrays
+    >>> Calculating line broadening (695 lines: expect ~ 0.07s on 1 CPU)
+    >>> ...... 0.01s - Precomputed DLM lineshapes (15)
+    >>> ...... 0.00s - Initialized vectors
+    >>> ...... 0.00s - Get closest matching line & fraction
+    >>> ...... 0.00s - Distribute lines over DLM
+    >>> ...... 0.03s - Convolve and sum on spectral range
+    >>> ...... 0.00s - Initialized vectors
+    >>> ...... 0.00s - Get closest matching line & fraction
+    >>> ...... 0.00s - Distribute lines over DLM
+    >>> ...... 0.03s - Convolve and sum on spectral range
+    >>> 0.08s - Calculated line broadening
+    >>> 0.00s - Calculated other spectral quantities
+    >>> 0.19s - Spectrum calculated (before object generation)
+    >>> 0.00s - Generated Spectrum object
+    >>> 0.19s - Spectrum calculated
 
 .. _label_lbl_precompute_spectra:
+
+You can print the the time distribution Spectrum at various levels in a presentable hierarchy using the
+:py:meth:`~radis.lbl.factory.SpectrumFactory.print_perf_profile` method in SpectrumFactory object or
+:py:meth:`~radis.spectrum.spectrum.Spectrum.print_perf_profile` method in the Spectrum object.
+
+For the above example::
+
+    s.print_perf_profile()
+
+::
+
+    >>> spectrum_calculation:
+    >>>   applied_linestrength_cutoff: 0.0024361610412597656
+    >>>   calc_emission_integral: 0.006468772888183594
+    >>>   calc_hwhm: 0.006415128707885742
+    >>>   calc_line_broadening:
+    >>>     DLM_Distribute_lines: 0.0003898143768310547
+    >>>     DLM_Initialized_vectors: 9.775161743164062e-06
+    >>>     DLM_closest_matching_line: 0.0005028247833251953
+    >>>     DLM_convolve: 0.029767990112304688
+    >>>     precompute_DLM_lineshapes: 0.013132810592651367
+    >>>     value: 0.07619166374206543
+    >>>   calc_lineshift: 0.00074005126953125
+    >>>   calc_noneq_population:
+    >>>     part_function: 0.03405046463012695
+    >>>     population: 0.005669832229614258
+    >>>     value: 0.03983640670776367
+    >>>   calc_other_spectral_quan: 0.002928495407104492
+    >>>   calc_weight_trans: 0.008247852325439453
+    >>>   check_line_databank: 0.0002810955047607422
+    >>>   check_non_eq_param: 0.04109525680541992
+    >>>   fetch_energy_5: 0.014983654022216797
+    >>>   generate_spectrum_obj: 0.00032138824462890625
+    >>>   generate_wavenumber_arrays: 0.0010433197021484375
+    >>>   reinitialize:
+    >>>     copy_database: 2.1457672119140625e-06
+    >>>     memory_usage_warning: 0.0018389225006103516
+    >>>     reset_population: 2.6226043701171875e-05
+    >>>     value: 0.001964569091796875
+    >>>   scaled_non_eq_linestrength:
+    >>>     corrected_population_se: 0.002747774124145508
+    >>>     map_part_func: 0.0010590553283691406
+    >>>     value: 0.0038983821868896484
+    >>>   value: 0.1904621124267578
+
 
 Precompute Spectra
 ------------------

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,8 @@ dependencies:
 - pytest  # to run test suite
 - joblib  # for parallel loading of SpecDatabase
 - numba  # just-in-time compiler
-- psutil
+- psutil # for getting user RAM
+- pyyaml # for printing profiler dictionary
 - pip
 - pip:
   - publib>=0.3.2  # Plotting styles for Matplotlib

--- a/radis/lbl/bands.py
+++ b/radis/lbl/bands.py
@@ -62,6 +62,7 @@ from radis.lbl.labels import (
 )
 from radis.lbl.loader import KNOWN_DBFORMAT, KNOWN_LVLFORMAT
 from radis.misc.basics import all_in, is_float
+from radis.misc.profiler import Profiler
 from radis.misc.progress_bar import ProgressBar
 from radis.misc.warning import reset_warnings
 from radis.phys.constants import k_b
@@ -185,6 +186,9 @@ class BandFactory(BroadenFactory):
         path_length = self.input.path_length
         verbose = self.verbose
 
+        # New Profiler object
+        self.profiler = Profiler(verbose)
+
         # %% Retrieve from database if exists
         if self.autoretrievedatabase:
             s = self._retrieve_bands_from_database()
@@ -197,8 +201,6 @@ class BandFactory(BroadenFactory):
             self.print_conditions()
 
         # Start
-        t0 = time()
-
         # %% Make sure database is loaded
         if self.df0 is None:
             raise AttributeError("Load databank first (.load_databank())")
@@ -208,8 +210,8 @@ class BandFactory(BroadenFactory):
 
         # %% Calculate the spectrum
         # ---------------------------------------------------
-        t0 = time()
 
+        self.profiler.start("band_calculation", 1)
         self._reinitialize()
 
         # --------------------------------------------------------------------
@@ -382,8 +384,7 @@ class BandFactory(BroadenFactory):
             pb.update(i)  # progress bar
         pb.done()
 
-        if verbose:
-            print(("... process done in {0:.1f}s".format(time() - t0)))
+        self.profiler.stop("band_calculation", "Bands calculated")
 
         return s_bands
 
@@ -503,6 +504,9 @@ class BandFactory(BroadenFactory):
         pressure_mbar = self.input.pressure_mbar
         verbose = self.verbose
 
+        # New Profiler object
+        self.profiler = Profiler(verbose)
+
         # %% Retrieve from database if exists
         if self.autoretrievedatabase:
             s = self._retrieve_bands_from_database()
@@ -514,6 +518,7 @@ class BandFactory(BroadenFactory):
             print("Calculating Non-Equilibrium bands")
             self.print_conditions()
 
+        self.profiler.start("band_calculation", 1)
         # %% Make sure database is loaded
         self._check_line_databank()
         self._calc_noneq_parameters(vib_distribution, singleTvibmode)
@@ -526,7 +531,6 @@ class BandFactory(BroadenFactory):
 
         # %% Calculate the spectrum
         # ---------------------------------------------------
-        t0 = time()
 
         self._reinitialize()
 
@@ -734,8 +738,7 @@ class BandFactory(BroadenFactory):
             pb.update(i)  # progress bar
         pb.done()
 
-        if verbose:
-            print(("... process done in {0:.1f}s".format(time() - t0)))
+        self.profiler.stop("band_calculation", "Bands calculated")
 
         return s_bands
 

--- a/radis/lbl/bands.py
+++ b/radis/lbl/bands.py
@@ -990,6 +990,7 @@ class BandFactory(BroadenFactory):
         if self.verbose:
             print(("Now processing lines ({0})".format(len(df))))
 
+        self.profiler.start("calc_broadening_eq_bands", 2)
         # Just some tests
         try:
             assert len(df.shape) == 2
@@ -1001,6 +1002,8 @@ class BandFactory(BroadenFactory):
             )
 
         (wavenumber, abscoeff_bands) = self._broaden_lines_bands(df)
+
+        self.profiler.start("calc_broadening_eq_bands", "Calc Broadening Eq Bands")
 
         return wavenumber, abscoeff_bands
 
@@ -1035,6 +1038,7 @@ class BandFactory(BroadenFactory):
         if self.verbose:
             print(("Now processing lines ({0})".format(len(df))))
 
+        self.profiler.start("calc_broadening_noneq_bands", 2)
         # Just some tests
         try:
             assert len(df.shape) == 2
@@ -1050,6 +1054,10 @@ class BandFactory(BroadenFactory):
             abscoeff_bands,
             emisscoeff_bands,
         ) = self._broaden_lines_noneq_bands(df)
+
+        self.profiler.stop(
+            "calc_broadening_noneq_bands", "Calculate broadening noneq bands"
+        )
 
         return wavenumber, abscoeff_bands, emisscoeff_bands
 

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -3231,7 +3231,11 @@ class BaseFactory(DatabankLoader):
         if __debug__:
             printdbg("called ._clean_factory()")
 
+        self.profiler.start("reinitialize", 2)
+
         keep_initial_database = not self.save_memory
+
+        self.profiler.start("copy_database", 3)
 
         if keep_initial_database:
 
@@ -3251,7 +3255,9 @@ class BaseFactory(DatabankLoader):
         else:
             self.df1 = self.df0  # self.df0 will be deleted
             del self.df0  # delete attribute name
+        self.profiler.stop("copy_database", "Copying database")
 
+        self.profiler.start("memory_usage_warning", 3)
         # Check memory size
         try:
             # Retrieving total user RAM
@@ -3283,6 +3289,9 @@ class BaseFactory(DatabankLoader):
         except ValueError:  # had some unexplained ValueError: __sizeof__() should return >= 0
             pass
 
+        self.profiler.stop("memory_usage_warning", "Check Memory usage of database")
+
+        self.profiler.start("reset_population", 3)
         # Reset populations from RovibrationalPartitionFunctions objects
         molecule = self.input.molecule
         state = self.input.state
@@ -3303,6 +3312,9 @@ class BaseFactory(DatabankLoader):
             else:
                 # ... Reset it
                 parsum.reset_populations()
+        self.profiler.stop("reset_population", "Reset populations")
+
+        self.profiler.stop("reinitialize", "Reinitialize database", False)
 
     def _check_inputs(self, mole_fraction, Tmax):
         """Check spectrum inputs, add warnings if suspicious values.

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -2512,7 +2512,7 @@ class BaseFactory(DatabankLoader):
 
         self.profiler.stop("population", "populations")
         self.profiler.stop(
-            "calc_noneq_population", "Calculated nonequilibrium populations", False
+            "calc_noneq_population", "Calculated nonequilibrium populations"
         )
 
         return
@@ -2774,7 +2774,6 @@ class BaseFactory(DatabankLoader):
         self.profiler.stop(
             "calc_noneq_population_multiTvib",
             "Calculated nonequilibrium populations (multiTvib)",
-            False,
         )
 
         return
@@ -3028,7 +3027,7 @@ class BaseFactory(DatabankLoader):
             "corrected for populations and stimulated emission",
         )
         self.profiler.stop(
-            "scaled_non_eq_linestrength", "scaled nonequilibrium linestrength", False
+            "scaled_non_eq_linestrength", "scaled nonequilibrium linestrength"
         )
 
         return  # df1 automatically updated

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -3315,7 +3315,7 @@ class BaseFactory(DatabankLoader):
                 parsum.reset_populations()
         self.profiler.stop("reset_population", "Reset populations")
 
-        self.profiler.stop("reinitialize", "Reinitialize database", False)
+        self.profiler.stop("reinitialize", "Reinitialize database")
 
     def _check_inputs(self, mole_fraction, Tmax):
         """Check spectrum inputs, add warnings if suspicious values.

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -2512,7 +2512,7 @@ class BaseFactory(DatabankLoader):
 
         self.profiler.stop("population", "populations")
         self.profiler.stop(
-            "calc_noneq_population", "Calculated nonequilibrium populations"
+            "calc_noneq_population", "Calculated nonequilibrium populations", False
         )
 
         return
@@ -2774,6 +2774,7 @@ class BaseFactory(DatabankLoader):
         self.profiler.stop(
             "calc_noneq_population_multiTvib",
             "Calculated nonequilibrium populations (multiTvib)",
+            False,
         )
 
         return
@@ -3027,7 +3028,7 @@ class BaseFactory(DatabankLoader):
             "corrected for populations and stimulated emission",
         )
         self.profiler.stop(
-            "scaled_non_eq_linestrength", "scaled nonequilibrium linestrength"
+            "scaled_non_eq_linestrength", "scaled nonequilibrium linestrength", False
         )
 
         return  # df1 automatically updated

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -2500,7 +2500,9 @@ class BroadenFactory(BaseFactory):
                     ),
                 )
 
-            time_spent = self.profiler.dict_time["calc_pseudo_continuum"][0]
+            time_spent = self.profiler.final[list(self.profiler.final)[-1]][
+                "calc_pseudo_continuum"
+            ]
             # Add a warning if it looks like it wasnt worth it
             if time_spent > 3 * expected_broadening_time_gain:
                 self.warn(

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -2226,7 +2226,7 @@ class BroadenFactory(BaseFactory):
             )
 
         (wavenumber, abscoeff) = self._broaden_lines(df)
-        self.profiler.stop("calc_line_broadening", "Calculated line broadening", False)
+        self.profiler.stop("calc_line_broadening", "Calculated line broadening")
 
         return wavenumber, abscoeff
 

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -2278,7 +2278,7 @@ class BroadenFactory(BaseFactory):
 
         (wavenumber, abscoeff, emisscoeff) = self._broaden_lines_noneq(df)
 
-        self.profiler.stop("calc_line_broadening", "Calculated line broadening", False)
+        self.profiler.stop("calc_line_broadening", "Calculated line broadening")
         return wavenumber, abscoeff, emisscoeff
 
     # %% Functions to calculate semi-continuum

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -2226,7 +2226,7 @@ class BroadenFactory(BaseFactory):
             )
 
         (wavenumber, abscoeff) = self._broaden_lines(df)
-        self.profiler.stop("calc_line_broadening", "Calculated line broadening")
+        self.profiler.stop("calc_line_broadening", "Calculated line broadening", False)
 
         return wavenumber, abscoeff
 
@@ -2278,7 +2278,7 @@ class BroadenFactory(BaseFactory):
 
         (wavenumber, abscoeff, emisscoeff) = self._broaden_lines_noneq(df)
 
-        self.profiler.stop("calc_line_broadening", "Calculated line broadening")
+        self.profiler.stop("calc_line_broadening", "Calculated line broadening", False)
         return wavenumber, abscoeff, emisscoeff
 
     # %% Functions to calculate semi-continuum

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -1674,6 +1674,8 @@ class SpectrumFactory(BandFactory):
         # New Profiler object
         self.profiler = Profiler(verbose)
 
+        self.profiler.start("optically_thin_power_calculation", 1)
+
         # Make sure database is loaded
         if self.df0 is None:
             if not self.save_memory:
@@ -1737,6 +1739,10 @@ class SpectrumFactory(BandFactory):
 
         # Optically thin case (no self absorption):
         Ptot = Pv * path_length  # (mW/sr/cm2)
+
+        self.profiler.stop(
+            "optically_thin_power_calculation", "Optically thin power calculation"
+        )
 
         return conv2(Ptot, "mW/cm2/sr", unit)
 

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -659,8 +659,9 @@ class SpectrumFactory(BandFactory):
         # %% Start
         # --------------------------------------------------------------------
 
-        self.profiler.start("spectrum_calc_before_obj", 2)
         self.profiler.start("spectrum_calculation", 1)
+        self.profiler.start("spectrum_calc_before_obj", 2)
+
         if verbose:
             self.print_conditions("Calculating Equilibrium Spectrum")
 
@@ -947,8 +948,8 @@ class SpectrumFactory(BandFactory):
         Ia_arr[np.isnan(Ia_arr)] = 0
         molarmass_arr[np.isnan(molarmass_arr)] = 0
 
-        self.profiler.start("spectrum_calc_before_obj", 2)
         self.profiler.start("spectrum_calculation", 1)
+        self.profiler.start("spectrum_calc_before_obj", 2)
 
         # generate the v_arr
         v_arr = np.arange(

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -80,6 +80,7 @@ from warnings import warn
 
 import astropy.units as u
 import numpy as np
+import yaml
 from numpy import arange, exp
 from scipy.constants import N_A, c, k, pi
 
@@ -1736,6 +1737,27 @@ class SpectrumFactory(BandFactory):
         )
 
         return conv2(Ptot, "mW/cm2/sr", unit)
+
+    def print_perf_profile(self):
+        """Prints Profiler output dictionary in a structured manner.
+        example:
+        SpectrumFactory.print_perf_profile()
+        ----------------------------
+        spectrum_calculation:
+            calc_hwhm: 0.007350444793701172
+            calc_line_broadening:
+                DLM_Distribute_lines: 0.005137443542480469
+                DLM_Initialized_vectors: 8.106231689453125e-06
+                DLM_closest_matching_line: 0.0010995864868164062
+                DLM_convolve: 0.6121664047241211
+                precompute_DLM_lineshapes: 0.027348995208740234
+                value: 0.6468849182128906
+            calc_lineshift: 0.0005822181701660156
+            calc_other_spectral_quan: 0.005536317825317383
+            value: 0.6814641952514648
+        """
+        profiler = self.profiler.final
+        print(yaml.dump(profiler, allow_unicode=True, default_flow_style=False))
 
 
 # %% ======================================================================

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -1254,8 +1254,8 @@ class SpectrumFactory(BandFactory):
         # %% Start
         # --------------------------------------------------------------------
 
-        self.profiler.start("spectrum_calc_before_obj", 2)
         self.profiler.start("spectrum_calculation", 1)
+        self.profiler.start("spectrum_calc_before_obj", 2)
         if verbose:
             self.print_conditions("Calculating Non-Equilibrium Spectrum")
 
@@ -1468,6 +1468,8 @@ class SpectrumFactory(BandFactory):
         `SpectrumFactory.wavenumber` is the output spectral range and
         ``SpectrumFactory.wavenumber_calc`` the spectral range used for calculation, that
         includes neighbour lines within ``broadening_max_width`` distance."""
+
+        self.profiler.start("generate_wavenumber_arrays", 2)
         # calculates minimum FWHM of lines
         self._calc_min_width(self.df1)
 
@@ -1497,6 +1499,8 @@ class SpectrumFactory(BandFactory):
 
         # AccuracyWarning. Check there are enough gridpoints per line.
         self._check_accuracy(self.params.wstep)
+
+        self.profiler.stop("generate_wavenumber_arrays", "Generated Wavenumber Arrays")
 
         return
 

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -740,21 +740,15 @@ class SpectrumFactory(BandFactory):
         conditions = self.get_conditions()
         conditions.update(
             {
-                "calculation_time": self.profiler.dict_time["spectrum_calc_before_obj"][
-                    0
+                "calculation_time": self.profiler.final[list(self.profiler.final)[-1]][
+                    "spectrum_calc_before_obj"
                 ],
                 "lines_calculated": self._Nlines_calculated,
                 "lines_cutoff": self._Nlines_cutoff,
                 "lines_in_continuum": self._Nlines_in_continuum,
                 "thermal_equilibrium": True,
                 "radis_version": version,
-            }
-        )
-        conditions.update(
-            {
-                "profiler": {
-                    i: self.profiler.dict_time[i][0] for i in self.profiler.dict_time
-                }
+                "profiler": self.profiler.final,
             }
         )
 
@@ -809,7 +803,7 @@ class SpectrumFactory(BandFactory):
         self.profiler.stop("spectrum_calculation", "Spectrum calculated")
 
         # For calculating time distribution and storing it
-        self.profiler.percentage_distribution()
+        # self.profiler.percentage_distribution()
 
         return s
 
@@ -1060,19 +1054,13 @@ class SpectrumFactory(BandFactory):
         conditions = self.get_conditions()
         conditions.update(
             {
-                "calculation_time": self.profiler.dict_time["spectrum_calc_before_obj"][
-                    0
+                "calculation_time": self.profiler.final[list(self.profiler.final)[-1]][
+                    "spectrum_calc_before_obj"
                 ],
                 "lines_calculated": _Nlines_calculated,
                 "thermal_equilibrium": True,
                 "radis_version": version,
-            }
-        )
-        conditions.update(
-            {
-                "profiler": {
-                    i: self.profiler.dict_time[i][0] for i in self.profiler.dict_time
-                }
+                "profiler": self.profiler.final,
             }
         )
 
@@ -1114,7 +1102,7 @@ class SpectrumFactory(BandFactory):
         self.profiler.stop("spectrum_calculation", "Spectrum calculated")
 
         # For calculating time distribution and storing it
-        self.profiler.percentage_distribution()
+        # self.profiler.percentage_distribution()
 
         return s
 
@@ -1385,21 +1373,15 @@ class SpectrumFactory(BandFactory):
         conditions = self.get_conditions()
         conditions.update(
             {
-                "calculation_time": self.profiler.dict_time["spectrum_calc_before_obj"][
-                    0
+                "calculation_time": self.profiler.final[list(self.profiler.final)[-1]][
+                    "spectrum_calc_before_obj"
                 ],
                 "lines_calculated": self._Nlines_calculated,
                 "lines_cutoff": self._Nlines_cutoff,
                 "lines_in_continuum": self._Nlines_in_continuum,
                 "thermal_equilibrium": False,  # dont even try to guess if it's at equilibrium
                 "radis_version": version,
-            }
-        )
-        conditions.update(
-            {
-                "profiler": {
-                    i: self.profiler.dict_time[i][0] for i in self.profiler.dict_time
-                }
+                "profiler": self.profiler.final,
             }
         )
 
@@ -1458,7 +1440,7 @@ class SpectrumFactory(BandFactory):
         self.profiler.stop("spectrum_calculation", "Spectrum calculated")
 
         # For calculating time distribution and storing it
-        self.profiler.percentage_distribution()
+        # self.profiler.percentage_distribution()
 
         return s
 

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -748,9 +748,12 @@ class SpectrumFactory(BandFactory):
                 "lines_in_continuum": self._Nlines_in_continuum,
                 "thermal_equilibrium": True,
                 "radis_version": version,
-                "profiler": self.profiler.final,
+                "profiler": dict(self.profiler.final),
             }
         )
+        del self.profiler.final[list(self.profiler.final)[-1]][
+            "spectrum_calc_before_obj"
+        ]
 
         # Get populations of levels as calculated in RovibrationalPartitionFunctions
         # ... Populations cannot be calculated at equilibrium (needs energies).
@@ -1060,9 +1063,12 @@ class SpectrumFactory(BandFactory):
                 "lines_calculated": _Nlines_calculated,
                 "thermal_equilibrium": True,
                 "radis_version": version,
-                "profiler": self.profiler.final,
+                "profiler": dict(self.profiler.final),
             }
         )
+        del self.profiler.final[list(self.profiler.final)[-1]][
+            "spectrum_calc_before_obj"
+        ]
 
         # Spectral quantities
         quantities = {
@@ -1381,9 +1387,12 @@ class SpectrumFactory(BandFactory):
                 "lines_in_continuum": self._Nlines_in_continuum,
                 "thermal_equilibrium": False,  # dont even try to guess if it's at equilibrium
                 "radis_version": version,
-                "profiler": self.profiler.final,
+                "profiler": dict(self.profiler.final),
             }
         )
+        del self.profiler.final[list(self.profiler.final)[-1]][
+            "spectrum_calc_before_obj"
+        ]
 
         # Get populations of levels as calculated in RovibrationalPartitionFunctions
         populations = self.get_populations(self.misc.export_populations)

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -1461,7 +1461,7 @@ class DatabankLoader(object):
         Databank has been initialized by
         :meth:`~radis.lbl.loader.DatabankLoader._init_databank`
         """
-
+        self.profiler.start("check_line_databank", 2)
         # Make sure database is loaded
         if self.df0 is None:
             # Either we're in a save memory mode, i.e, database has been
@@ -1530,6 +1530,8 @@ class DatabankLoader(object):
                     )
                 )
                 self.df0[k] = self.df0[k].astype(np.int64)
+
+        self.profiler.stop("check_line_databank", "Check line databank")
 
     def _load_databank(
         self,

--- a/radis/misc/profiler.py
+++ b/radis/misc/profiler.py
@@ -15,6 +15,7 @@ Routine Listing
 -------------------------------------------------------------------------------
 """
 
+from collections import OrderedDict
 from time import time
 
 from radis.misc.printer import printg
@@ -42,7 +43,7 @@ class Profiler(object):
         self.initial = {}
         self.verbose = verbose
         self.current_verbose2_counter = ""  # Holds current Verbose level 2 key
-        self.final = {}
+        self.final = OrderedDict()
         self.flag = False  # For checking transit between verbose level 3 to 2
         self.relative_time_percentage = {}
 
@@ -73,6 +74,8 @@ class Profiler(object):
             time_calculated = time() - items["start_time"]
             if items["verbose_level"] == 1:
                 self.final[key]["value"] = time_calculated
+                # Profiler ends; Deserializing to Dictionary format
+                self.final = dict(self.final)
             else:
 
                 if items["verbose_level"] == 2:

--- a/radis/misc/profiler.py
+++ b/radis/misc/profiler.py
@@ -3,7 +3,7 @@
 calculation under :py:class:`~radis.lbl.factory.SpectrumFactory` based on verbose level.
 
 Also stores Spectrum calculation time dependent parameters, under the attribute
-    :py:attr:`~radis.misc.profiler.Profiler.dict_time`
+    :py:attr:`~radis.misc.profiler.Profiler.final`
 
 Routine Listing
 ---------------
@@ -22,7 +22,7 @@ from radis.misc.printer import printg
 
 class Profiler(object):
     """A class to store Spectrum calculation time dependent parameters, under the attribute
-    :py:attr:`~radis.misc.profiler.Profiler.dict_time` of
+    :py:attr:`~radis.misc.profiler.Profiler.final` of
     :py:class:`~radis.lbl.factory.SpectrumFactory`.
 
     It also hold functions to print all the entities based on verbose value.
@@ -130,13 +130,13 @@ class Profiler(object):
             for i in range(1, upper_limit):
                 temp_sum = 0
                 first = 1
-                for j in self.dict_time:
-                    if i in self.dict_time[j]:
+                for j in self.final:
+                    if i in self.final[j]:
                         if first == 1:
                             verbose_distribution[i] = {}
                             first = 0
-                        verbose_distribution[i][j] = [self.dict_time[j][0]]
-                        temp_sum += self.dict_time[j][0]
+                        verbose_distribution[i][j] = [self.final[j][0]]
+                        temp_sum += self.final[j][0]
                 total_sum_verbose_wise[i] = temp_sum
 
             # Adding percentage of time taken by each key

--- a/radis/misc/profiler.py
+++ b/radis/misc/profiler.py
@@ -53,29 +53,16 @@ class Profiler(object):
                 "verbose_level": verbose_level,
             }
             self.stack[verbose_level].append(key)
-            print(self.final)
-            print("    ")
+
         if verbose_level == 1:
             self.final[key] = {"value": None}
         else:
             if verbose_level == 2:
                 self.final[self.stack[verbose_level - 1][-1]].update({key: {}})
             else:
-                # print(self.stack[verbose_level-2])
-                # print(self.final[self.stack[verbose_level-2][-1]][self.stack[2][-1]])
                 self.final[self.stack[verbose_level - 2][-1]][self.stack[2][-1]].update(
                     {key: {}}
                 )
-            """
-            if len(index_key) == 1:
-                pass
-                #index_key.update({key:None})
-            else:
-                pass
-                #index_key.update({key:None})
-            #print("INDEX KEY ", index_key)
-            #self.final[self.stack[verbose_level-1][-1]]['subtasks'].update({key:None})
-            """
         if len(optional) != 0 and self.verbose >= verbose_level:
             print(optional)
 
@@ -85,9 +72,7 @@ class Profiler(object):
             # Storing time with verbose level
             self.dict_time[key] = [time() - items["start_time"], items["verbose_level"]]
             if items["verbose_level"] == 1:
-                # print("HIIIIIIIIIIIIIIIIIIII",items)
                 self.final[key]["value"] = self.dict_time[key][0]
-                pass
             else:
                 if end == False:
                     if items["verbose_level"] == 2:

--- a/radis/misc/profiler.py
+++ b/radis/misc/profiler.py
@@ -42,6 +42,8 @@ class Profiler(object):
         self.initial = {}
         self.dict_time = {}
         self.verbose = verbose
+        self.stack = {1: [], 2: [], 3: []}
+        self.final = {}
         self.relative_time_percentage = {}
 
     def start(self, key, verbose_level, optional=""):
@@ -50,14 +52,60 @@ class Profiler(object):
                 "start_time": time(),
                 "verbose_level": verbose_level,
             }
+            self.stack[verbose_level].append(key)
+            print(self.final)
+            print("    ")
+        if verbose_level == 1:
+            self.final[key] = {"value": None}
+        else:
+            if verbose_level == 2:
+                self.final[self.stack[verbose_level - 1][-1]].update({key: {}})
+            else:
+                # print(self.stack[verbose_level-2])
+                # print(self.final[self.stack[verbose_level-2][-1]][self.stack[2][-1]])
+                self.final[self.stack[verbose_level - 2][-1]][self.stack[2][-1]].update(
+                    {key: {}}
+                )
+            """
+            if len(index_key) == 1:
+                pass
+                #index_key.update({key:None})
+            else:
+                pass
+                #index_key.update({key:None})
+            #print("INDEX KEY ", index_key)
+            #self.final[self.stack[verbose_level-1][-1]]['subtasks'].update({key:None})
+            """
         if len(optional) != 0 and self.verbose >= verbose_level:
             print(optional)
 
-    def stop(self, key, details=""):
+    def stop(self, key, details, end=False):
         if __debug__:
             items = self.initial.pop(key)
             # Storing time with verbose level
             self.dict_time[key] = [time() - items["start_time"], items["verbose_level"]]
+            if items["verbose_level"] == 1:
+                # print("HIIIIIIIIIIIIIIIIIIII",items)
+                self.final[key]["value"] = self.dict_time[key]
+                pass
+            else:
+                """value_key = self.stack[items["verbose_level"] - 1][
+                    -1
+                ]"""  # Last verbose -1 entry
+                new_dict = {"value": self.dict_time[key]}
+                if end:
+                    if items["verbose_level"] == 2:
+                        self.final[self.stack[1][-1]][key].update(new_dict)
+                    else:
+                        self.final[self.stack[1][-1]][self.stack[2][-1]][key].update(
+                            new_dict
+                        )
+                else:
+                    if items["verbose_level"] == 2:
+                        self.final[self.stack[1][-1]][key] = new_dict
+                    else:
+                        self.final[self.stack[1][-1]][self.stack[2][-1]][key] = new_dict
+
             if self.verbose >= items["verbose_level"]:
                 self._print(items["verbose_level"], details, key)
 

--- a/radis/misc/profiler.py
+++ b/radis/misc/profiler.py
@@ -79,22 +79,19 @@ class Profiler(object):
         if len(optional) != 0 and self.verbose >= verbose_level:
             print(optional)
 
-    def stop(self, key, details, end=False):
+    def stop(self, key, details, end=True):
         if __debug__:
             items = self.initial.pop(key)
             # Storing time with verbose level
             self.dict_time[key] = [time() - items["start_time"], items["verbose_level"]]
             if items["verbose_level"] == 1:
                 # print("HIIIIIIIIIIIIIIIIIIII",items)
-                self.final[key]["value"] = self.dict_time[key]
+                self.final[key]["value"] = self.dict_time[key][0]
                 pass
             else:
-                """value_key = self.stack[items["verbose_level"] - 1][
-                    -1
-                ]"""  # Last verbose -1 entry
-                new_dict = {"value": self.dict_time[key]}
-                if end:
+                if end == False:
                     if items["verbose_level"] == 2:
+                        new_dict = {"value": self.dict_time[key][0]}
                         self.final[self.stack[1][-1]][key].update(new_dict)
                     else:
                         self.final[self.stack[1][-1]][self.stack[2][-1]][key].update(
@@ -102,9 +99,11 @@ class Profiler(object):
                         )
                 else:
                     if items["verbose_level"] == 2:
-                        self.final[self.stack[1][-1]][key] = new_dict
+                        self.final[self.stack[1][-1]][key] = self.dict_time[key][0]
                     else:
-                        self.final[self.stack[1][-1]][self.stack[2][-1]][key] = new_dict
+                        self.final[self.stack[1][-1]][self.stack[2][-1]][
+                            key
+                        ] = self.dict_time[key][0]
 
             if self.verbose >= items["verbose_level"]:
                 self._print(items["verbose_level"], details, key)

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -54,6 +54,7 @@ from warnings import warn
 
 import astropy.units as u
 import numpy as np
+import yaml
 from numpy import abs, diff
 
 # from radis.lbl.base import print_conditions
@@ -3034,6 +3035,25 @@ class Spectrum(object):
                 + "`self_absorption` is not defined in conditions. Please add the "
                 + "value manually with s.conditions['self_absorption']=..."
             )
+
+    def print_struct(self):
+        """Prints Profiler output dictionary in a structured manner.
+        example:
+        spectrum_calculation:
+            calc_hwhm: 0.007350444793701172
+            calc_line_broadening:
+                DLM_Distribute_lines: 0.005137443542480469
+                DLM_Initialized_vectors: 8.106231689453125e-06
+                DLM_closest_matching_line: 0.0010995864868164062
+                DLM_convolve: 0.6121664047241211
+                precompute_DLM_lineshapes: 0.027348995208740234
+                value: 0.6468849182128906
+            calc_lineshift: 0.0005822181701660156
+            calc_other_spectral_quan: 0.005536317825317383
+            value: 0.6814641952514648
+        """
+        profiler = self.get_conditions()["profiler"]
+        print(yaml.dump(profiler, allow_unicode=True, default_flow_style=False))
 
     def copy(self, copy_lines=True, quantity="all"):
         """Returns a copy of this Spectrum object (performs a smart deepcopy)

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -3036,9 +3036,11 @@ class Spectrum(object):
                 + "value manually with s.conditions['self_absorption']=..."
             )
 
-    def print_struct(self):
+    def print_perf_profile(self):
         """Prints Profiler output dictionary in a structured manner.
         example:
+        Spectrum.print_perf_profile()
+        ----------------------------
         spectrum_calculation:
             calc_hwhm: 0.007350444793701172
             calc_line_broadening:

--- a/radis/test/misc/test_profiler.py
+++ b/radis/test/misc/test_profiler.py
@@ -1,0 +1,1 @@
+# import pytest

--- a/radis/test/misc/test_profiler.py
+++ b/radis/test/misc/test_profiler.py
@@ -1,1 +1,36 @@
-# import pytest
+import pytest
+
+from radis.lbl.factory import SpectrumFactory
+from radis.test.utils import setup_test_line_databases
+
+
+@pytest.mark.fast
+def test_print_perf_profile(verbose=True, *args, **kwargs):
+
+    setup_test_line_databases()  # add HITRAN-CO-TEST in ~/radis.json if not there
+
+    sf = SpectrumFactory(
+        wavelength_min=4400,
+        wavelength_max=4800,
+        mole_fraction=0.01,
+        cutoff=1e-25,
+        wstep="auto",
+        isotope=[1],
+        db_use_cached=True,
+        self_absorption=True,
+        verbose=verbose,
+    )
+
+    sf.warnings["MissingSelfBroadeningWarning"] = "ignore"
+    sf.warnings["NegativeEnergiesWarning"] = "ignore"
+    sf.warnings["HighTemperatureWarning"] = "ignore"
+
+    sf.load_databank("HITRAN-CO-TEST")
+
+    s1 = sf.eq_spectrum(300, pressure=1)
+
+    # printing performance profiler from Spectrum object
+    s1.print_perf_profile()
+
+    # printing performance profiler from SpectrumFactory object
+    sf.print_perf_profile()

--- a/setup.py
+++ b/setup.py
@@ -259,6 +259,8 @@ def run_setup(with_binary):
             "pytest",  # to run test suite
             "joblib",  # for parallel loading of SpecDatabase
             "numba",  # just-in-time compiler
+            "psutil",  # for getting user RAM"
+            "pyyaml",  # for printing profiler dictionary"
         ],
         extras_require={
             "dev": [

--- a/setup.py
+++ b/setup.py
@@ -259,8 +259,8 @@ def run_setup(with_binary):
             "pytest",  # to run test suite
             "joblib",  # for parallel loading of SpecDatabase
             "numba",  # just-in-time compiler
-            "psutil",  # for getting user RAM"
-            "pyyaml",  # for printing profiler dictionary"
+            "psutil",  # for getting user RAM
+            "pyyaml",  # for printing profiler dictionary
         ],
         extras_require={
             "dev": [


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request modifies the profiler to store time in a tree structure form. 

```
sf = SpectrumFactory(wavenum_min=2900,
                     wavenum_max=4200,
                     molecule='CO',
                     broadening_max_width=10,  # cm-1
                     medium='vacuum',
                     verbose=0,    # more for more details
                     pressure = 10,
                     wstep = 0.01,
                     )

sf.fetch_databank('hitemp')
s1 = sf.eq_spectrum(Tgas=300, path_length=1)

c = sf.profiler.final
print(yaml.dump(c,allow_unicode=True, default_flow_style=False))
```

Output:
```
spectrum_calculation:
  calc_hwhm: 0.011423110961914062
  calc_line_broadening:
    DLM_Distribute_lines: 0.018210649490356445
    DLM_Initialized_vectors: 1.2159347534179688e-05
    DLM_closest_matching_line: 0.0053594112396240234
    DLM_convolve: 1.6507983207702637
    precompute_DLM_lineshapes: 0.05847477912902832
    value: 1.7343709468841553
  calc_lineshift: 0.0011224746704101562
  calc_other_spectral_quan: 0.0058553218841552734
  check_line_databank: 0.0006852149963378906
  generate_spectrum_obj: 0.0006301403045654297
  generate_wavenumber_arrays: 0.004528522491455078
  reinitialize:
    copy_database: 0.0014543533325195312
    memory_usage_warning: 0.0031118392944335938
    reset_population: 8.177757263183594e-05
    value: 0.0046651363372802734
  scaled_eq_linestrength: 0.013865232467651367
  spectrum_calc_before_obj: 1.7766413688659668
  value: 1.777277946472168
  ```

Fixes #322 <Issue Number>