### PR TITLE
update plot behavior, not showing fig by default. 

### DIFF
--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -1618,6 +1618,7 @@ class Spectrum(object):
         normalize=False,
         force=False,
         plot_by_parts=False,
+        show=False,
         show_ruler=False,
         **kwargs,
     ):
@@ -1667,6 +1668,9 @@ class Spectrum(object):
         force: bool
             plotting on an existing figure is forbidden if labels are not the
             same. Use ``force=True`` to ignore that.
+        show: bool
+            show figure. Default ``False``. Will still show the figure in
+            interactive mode, e.g, `%matplotlib inline` in a Notebook.
         show_ruler: bool
             if `True`, add a ruler tool to the Matplotlib toolbar.
 
@@ -1841,7 +1845,8 @@ class Spectrum(object):
 
             add_ruler(fig, wunit=wunit, Iunit=Iunit)
 
-        plt.show()
+        if show:
+            plt.show()
         return line
 
     def get_populations(self, molecule=None, isotope=None, electronic_state=None):

--- a/radis/test/utils.py
+++ b/radis/test/utils.py
@@ -151,27 +151,36 @@ getValidationCase.__annotations__["file"] = os.listdir(
 # %% Convenience function
 
 
-def test_spectrum():
-    """Generates a spectrum with ::
+def test_spectrum(**kwargs):
+    """Generate the :ref:`first example spectrum <label_first_example>` with ::
 
-    import radis
-    s = radis.test_spectrum()
-    s.plot()
+        import radis
+        s = radis.test_spectrum()
+        s.plot()
+
+    Other Parameters
+    ----------------
+    kwargs: sent to :py:func:`~radis.lbl.calc.calc_spectrum`
+
 
     """
     from radis import calc_spectrum
 
-    s = calc_spectrum(
-        1900,
-        2300,  # cm-1
-        molecule="CO",
-        isotope="1,2,3",
-        pressure=1.01325,  # bar
-        Tgas=700,  # K
-        mole_fraction=0.1,
-        path_length=1,  # cm
-        databank="hitran",  # or use 'hitemp'
-    )
+    conditions = {
+        "wavenum_min": 1900,
+        "wavenum_max": 2300,
+        "molecule": "CO",
+        "isotope": "1,2,3",
+        "pressure": 1.01325,  # bar
+        "Tgas": 700,  # K
+        "mole_fraction": 0.1,
+        "path_length": 1,  # cm
+        "databank": "hitran",
+    }
+
+    conditions.update(kwargs)
+
+    s = calc_spectrum(**conditions)
     return s
 
 


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

Reported by @Springder 

What we want is : 
- minimal code ; not having to import matplotlib to show a picture
- but still be able to overlay two plots as @Springder example #362

Both in : 
- consoles
- Jupyter Notebooks / Radis Lab

Minimal example : 

**testfig.py:**
```python
import radis
radis.test_spectrum().plot()
radis.test_spectrum().apply_slit(10, "nm").plot(nfig='same', lw=2)

# can be exported with  : 
# import matplotlib.pyplot as plt 
# plt.savefig("testfig.png")

# or shown : 
# plt.show()
```

- [x] correctly plot on same figure 
- [x] correctly exported with plt.savefig()
- [x] correctly shown in blocking mode if adding plt.show() . 
- [x] Same behavior can be achieved without matplotlib import by setting show=True  in plot()

Also work in Jupyter Notebook / RADIS-Lab. 
- [x] See demo : https://github.com/radis/radis-benchmark/blob/master/manual_benchmarks/plot_notebook_behavior.ipynb



Fixes #362