### PR TITLE
Parallelized downloading and parsing of HITEMP files

### DIFF
--- a/radis/io/dbmanager.py
+++ b/radis/io/dbmanager.py
@@ -314,7 +314,6 @@ class DatabaseManager(object):
 
             return Nlines
         if parallel and len(local_files) > self.minimum_nfiles:
-            pbar_enabled = False
             nJobs = self.nJobs
             batch_size = self.batch_size
             Nlines_total = sum(Parallel(
@@ -323,7 +322,6 @@ class DatabaseManager(object):
                   for urlname, local_file, Ndownload in \
                   zip(urlnames,local_files, range(1,len(local_files)+1))))
         else:
-            pbar_enabled = True
             for urlname, local_file, Ndownload in zip(urlnames, local_files,
                                                       range(1,len(local_files)+1)):
                 download_and_parse_one_file(urlname, local_file, Ndownload)

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -111,7 +111,9 @@ class HITEMPDatabaseManager(DatabaseManager):
         chunksize=100000,
         parallel=True,
     ):
-        super().__init__(name, molecule, local_databases, verbose=verbose, parallel=parallel)
+        super().__init__(
+            name, molecule, local_databases, verbose=verbose, parallel=parallel
+        )
         self.chunksize = chunksize
         self.downloadable = True
         self.base_url = None

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -109,8 +109,9 @@ class HITEMPDatabaseManager(DatabaseManager):
         local_databases,
         verbose=True,
         chunksize=100000,
+        parallel=True,
     ):
-        super().__init__(name, molecule, local_databases, verbose=verbose)
+        super().__init__(name, molecule, local_databases, verbose=verbose, parallel=parallel)
         self.chunksize = chunksize
         self.downloadable = True
         self.base_url = None
@@ -261,6 +262,7 @@ class HITEMPDatabaseManager(DatabaseManager):
         opener,
         urlname,
         local_file,
+        pbar_active=True,
         pbar_t0=0,
         pbar_Ntot_estimate_factor=None,
         pbar_Nlines_already=0,
@@ -282,6 +284,9 @@ class HITEMPDatabaseManager(DatabaseManager):
         verbose = self.verbose
         molecule = self.molecule
 
+        if not verbose:
+            pbar_active = False
+
         linereturnformat = self.get_linereturn_format(opener, urlname, columns)
 
         Nlines = 0
@@ -295,7 +300,7 @@ class HITEMPDatabaseManager(DatabaseManager):
             Ntotal_lines_expected = int(
                 Ntotal_lines_expected * pbar_Ntot_estimate_factor
             )
-        pb = ProgressBar(N=Ntotal_lines_expected, active=verbose, t0=pbar_t0)
+        pb = ProgressBar(N=Ntotal_lines_expected, active=pbar_active, t0=pbar_t0)
         wmin = np.inf
         wmax = 0
 
@@ -430,6 +435,7 @@ def fetch_hitemp(
     clean_cache_files=True,
     return_local_path=False,
     engine="pytables",
+    parallel=True,
 ):
     """Stream HITEMP file from HITRAN website. Unzip and build a HDF5 file directly.
 
@@ -467,6 +473,8 @@ def fetch_hitemp(
         if ``True``, also returns the path of the local database file.
     engine: 'pytables', 'vaex'
         which HDF5 library to use.
+    parallel: bool
+        if ``True``, uses joblib.parallel to load database with multiple processes
 
     Returns
     -------
@@ -517,6 +525,7 @@ def fetch_hitemp(
         local_databases=local_databases,
         verbose=verbose,
         chunksize=chunksize,
+        parallel=parallel,
     )
 
     # Get list of all expected local files for this database:

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -838,6 +838,7 @@ class DatabankLoader(object):
         db_use_cached=True,
         lvl_use_cached=True,
         hdf5_engine="default",
+        parallel=True,
     ):
         """Fetch the latest databank files from HITRAN or HITEMP with the
         https://hitran.org/ API.
@@ -896,6 +897,9 @@ class DatabankLoader(object):
         hdf5_engine: ``'pytables'``, ``'vaex'``
             which library to use to read HDF5 files (they are incompatible: ``'pytables'`` is
             row-major while ``'vaex'`` is column-major)
+        parallel: bool
+            if ``True``, uses joblib.parallel to load database with multiple processes
+            (works only for HITEMP files)
 
         Notes
         -----
@@ -1040,6 +1044,7 @@ class DatabankLoader(object):
                 verbose=self.verbose,
                 return_local_path=True,
                 engine=hdf5_engine,
+                parallel=parallel,
             )
             self.params.dbpath = ",".join(local_paths)
 


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

Uses joblib to download and parse HITEMP files in parallel. Most of the changes are adapted directly from [SpecList's parallel loading](github.com/radis/radis/blob/710cd38f8349fde2db394f4c82e8d78886a1f6e5/radis/tools/database.py#L974).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #360