### PR TITLE
hard coded isotopologue name and mass of CN

### DIFF
--- a/radis/db/classes.py
+++ b/radis/db/classes.py
@@ -281,6 +281,7 @@ def get_molecule(molecule_id):
 KNOWN_EXOMOL_ISOTOPES_NAMES = {
     ("FeH", 1): "56Fe-1H",
     ("SiO", 1): "28Si-16O",  # Placeholder until all molecules parsed from website TODO
+    ("CN", 1): "12C-14N",  # Placeholder until all molecules parsed from website TODO
 }
 """All :py:data:`~radis.db.classes.HITRAN_MOLECULES` are also converted to their ExoMol full-name format
 in :py:func:`~radis.io.exomol.get_exomol_full_isotope_name`

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -269,6 +269,7 @@ class BaseFactory(DatabankLoader):
         plt.xlabel("log10({0})".format(what))
         plt.ylabel("Count")
         plt.show()
+
     # %% ======================================================================
     # PRIVATE METHODS - CALCULATE SPECTROSCOPIC PARAMETERS
     # (everything that doesnt depend on populations / temperatures)
@@ -1664,9 +1665,12 @@ class BaseFactory(DatabankLoader):
             # HARDCODED molar mass; for WIP ExoMol implementation, until MolParams
             # is an attribute and can be updated with definitions from ExoMol.
             # https://github.com/radis/radis/issues/321
-            HARCODED_MOLAR_MASS = {"SiO": {1: 43.971842},
-                                   "CN": {1: 26.0179}, #https://www.chemicalaid.com/tools/molarmass.php?formula=CN%7B-%7D
-                                   }
+            HARCODED_MOLAR_MASS = {
+                "SiO": {1: 43.971842},
+                "CN": {
+                    1: 26.0179
+                },  # https://www.chemicalaid.com/tools/molarmass.php?formula=CN%7B-%7D
+            }
             try:
                 return HARCODED_MOLAR_MASS[df.attrs["molecule"]][df.attrs["iso"]]
             except KeyError:

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -268,7 +268,7 @@ class BaseFactory(DatabankLoader):
         plt.hist(np.round(a[~np.isnan(a)]))
         plt.xlabel("log10({0})".format(what))
         plt.ylabel("Count")
-
+        plt.show()
     # %% ======================================================================
     # PRIVATE METHODS - CALCULATE SPECTROSCOPIC PARAMETERS
     # (everything that doesnt depend on populations / temperatures)
@@ -1664,7 +1664,9 @@ class BaseFactory(DatabankLoader):
             # HARDCODED molar mass; for WIP ExoMol implementation, until MolParams
             # is an attribute and can be updated with definitions from ExoMol.
             # https://github.com/radis/radis/issues/321
-            HARCODED_MOLAR_MASS = {"SiO": {1: 43.971842}}
+            HARCODED_MOLAR_MASS = {"SiO": {1: 43.971842},
+                                   "CN": {1: 26.0179}, #https://www.chemicalaid.com/tools/molarmass.php?formula=CN%7B-%7D
+                                   }
             try:
                 return HARCODED_MOLAR_MASS[df.attrs["molecule"]][df.attrs["iso"]]
             except KeyError:


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
This pull request is to address the spectrum of CN which listed in the "known molecules" of RADIS.

After the merge, the following code should be working for you:

```python
from radis import calc_spectrum

T = 3000
s = calc_spectrum(
    wavelength_min=700,     #nm
    wavelength_max=1300,    #nm
    molecule="CN",
    isotope="1",
    pressure=0.1,  # bar
    Tgas=T,  # K
    mole_fraction=0.01,
    path_length=1,  # cm
    broadening_method="fft",  # @ dev: Doesn't work with 'voigt'
    databank="exomol", 
)
s.plot("absorbance", wunit='nm')
```


### Long term
@erwanp mentioned that the mass of molecules could be directly retrieved from ExoMol definition file, but this issue #321 is closed. I am not sure that #342 fixed it completely. 