### PR TITLE
Prepare support for NIST extension

### DIFF
--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -674,6 +674,26 @@ class DatabankLoader(object):
 
         See :py:class:`~radis.db.molparam.MolParams`"""
 
+        # Extra paramaters :
+        # HARDCODED molar mass; for WIP ExoMol implementation, until MolParams
+        # is an attribute and can be updated with definitions from ExoMol.
+        # https://github.com/radis/radis/issues/321
+        self._EXTRA_MOLAR_MASS = {
+            "SiO": {1: 43.971842},
+            "CN": {
+                1: 26.0179
+            },  # https://www.chemicalaid.com/tools/molarmass.php?formula=CN%7B-%7D
+        }
+        """Extra molar mass when not found in HITRAN molecular parameter database
+        ::
+            self._EXTRA_MOLAR_MASS[molecule][isotope] = M (g/mol)
+
+        See :py:func:`radis.lbl.base.BaseFactory.get_molar_mass`
+        """
+
+        # Profiler
+        self.profiler = None
+
     def _reset_profiler(self, verbose):
         """Reset :py:class:`~radis.misc.profiler.Profiler`
 

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -2788,9 +2788,15 @@ class Spectrum(object):
 
             Note: if not None, cutoff criteria is applied in this unit.
             Not used if plot is not 'S'
+        barwidth: float or str
+            if float, width of bars, in ``wunit``, as a fraction of full-range; i.e. ::
 
-        barwidth: float
-            With of bars in LineSurvey. Default 0.07
+                barwidth=0.01
+
+            makes bars span 1% of the full range.
+            if ``str``, uses the column as width. Example ::
+
+                barwidth = 'hwhm_voigt'
 
 
 
@@ -2819,7 +2825,7 @@ class Spectrum(object):
             sf.load_databank('HITRAN-CO2-TEST')
             s = sf.eq_spectrum(Tgas=1500)
             s.apply_slit(0.5)
-            s.line_survey(overlay='radiance_noslit', barwidth=0.01)
+            s.line_survey(overlay='radiance_noslit', barwidth=0.01)  # or barwidth='hwhm_voigt'
 
         See the output in :ref:`Examples <label_examples>`
 

--- a/radis/test/tools/test_line_survey.py
+++ b/radis/test/tools/test_line_survey.py
@@ -26,7 +26,7 @@ def test_line_survey(verbose=True, plot=False, warnings=True, *args, **kwargs):
         os.remove(_temp_file)
 
     s = load_spec(getTestFile("CO_Tgas1500K_mole_fraction0.01.spec"), binary=True)
-    s.line_survey(overlay="abscoeff", writefile=_temp_file)
+    s.line_survey(overlay="abscoeff", writefile=_temp_file, barwidth="fwhm_voigt")
 
     assert exists(_temp_file)
 

--- a/radis/tools/line_survey.py
+++ b/radis/tools/line_survey.py
@@ -62,7 +62,7 @@ def LineSurvey(
     cutoff=None,
     plot="S",
     lineinfo=["int", "A", "El"],
-    barwidth=0.07,
+    barwidth="hwhm_voigt",  # 0.01,
     yscale="log",
     writefile=None,
     xunit=None,
@@ -104,6 +104,15 @@ def LineSurvey(
         If ``None``, use the ``fig`` object returned to show the plot.
     yscale: ``'log'``, ``'linear'``
         Default ``'log'``
+    barwidth: float or str
+        if float, width of bars, in ``wunit``, as a fraction of full-range; i.e. ::
+
+            barwidth=0.01
+
+        makes bars span 1% of the full range.
+        if ``str``, uses the column as width. Example ::
+
+            barwidth = 'hwhm_voigt'
 
     Returns
     -------
@@ -186,6 +195,8 @@ def LineSurvey(
     # Parsers to get units and more details
     if dbformat in ["hitran", "hitemp"]:
         columndescriptor = hitrancolumns
+    elif dbformat in ["nist"]:
+        columndescriptor = hitrancolumns  # Placeholder. TODO replace with NIST (for the moment we copy the names anyway)
     elif dbformat == "cdsd-hitemp":
         columndescriptor = cdsdhitempcolumns
     elif dbformat == "cdsd-4000":
@@ -425,6 +436,25 @@ def LineSurvey(
 
         return label
 
+    def get_label_nist(row, attrs):
+        label = attrs[
+            "molecule"
+        ] + " [{Lower level}] ({El:.2f} eV) -> [{Upper level}] ({Eu:.2f} eV)".format(
+            **dict(
+                [
+                    (k, row[k])
+                    for k in [
+                        "Lower level",  # TODO: have nicer Term Symbol appear
+                        "Upper level",  # TODO: have nicer Term Symbol appear
+                        "El",
+                        "Eu",
+                    ]
+                ]
+            )
+        )
+
+        return label
+
     def get_label_none(row):
         return "unknown databank format. \ndetails cant be read"
 
@@ -452,11 +482,31 @@ def LineSurvey(
             sp["label"] = sp.apply(lambda r: get_label_cdsd_hitran(r, details), axis=1)
         except KeyError:
             sp["label"] = sp.apply(lambda r: get_label_cdsd(r, details), axis=1)
+    elif dbformat in ["nist"]:
+        sp["label"] = sp.apply(lambda r: get_label_nist(r, sp.attrs), axis=1)
     else:
         sp["label"] = sp.apply(get_label_none, axis=1)
 
     # from plotly.graph_objs import Scatter, Figure, Layout
-    #
+
+    if wunit == "nm":
+        xlabel = "Wavelength (nm) [{0}]".format(medium)
+        x_range = spec.get_wavelength()
+    elif wunit == "cm-1":
+        xlabel = "Wavenumber (cm-1)"
+        x_range = spec.get_wavenumber()
+    else:
+        raise ValueError("unknown wunit: {0}".format(wunit))
+
+    # TODO : implement barwidth -->  if ``hwhm_voigt``, bars are one half-width at half-maximum (in cm-1)
+    if isinstance(barwidth, str):
+        if not barwidth in sp.columns:
+            raise ValueError(
+                f"`{barwidth}` not in the lines Dataframe columns. Use one of the column names ({sp.columns}) or set `barwidth=[a 0-1 number]` to plot bars with widths as a fraction of the total range, ex : `barwidth=0.01`"
+            )
+        barwidth = sp[barwidth]
+    else:
+        barwidth = (x_range.max() - x_range.min()) * barwidth
     l = [
         go.Bar(
             x=get_x(sp.shiftwav),
@@ -467,16 +517,9 @@ def LineSurvey(
         )
     ]
 
-    if wunit == "nm":
-        xlabel = "Wavelength (nm) [{0}]".format(medium)
-    elif wunit == "cm-1":
-        xlabel = "Wavenumber (cm-1)"
-    else:
-        raise ValueError("unknown wunit: {0}".format(wunit))
-
     if yscale == "log":
         plot_range = (
-            int(np.log10(max(cutoff, sp[plot].min()))),
+            int(np.log10(max(cutoff, sp[plot].min()))) - 1,
             int(np.log10(sp[plot].max())) + 1,
         )
     else:
@@ -489,6 +532,7 @@ def LineSurvey(
         hovermode="closest",
         xaxis=dict(
             title=xlabel,
+            range=(x_range.min(), x_range.max()),
         ),
         yaxis=dict(
             title=ylabel,


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

Preliminary work to allow for a NIST extension  (see #34 ) 

(this does not include NIST by default in RADIS yet, but it makes the following script work :  


```


molecule = "H I"
isotope = 1
wmin = 650   # nm
wmax = 662
mole_fraction = 0.0001
T = 20000  # K 

from radis.phys.convert import nm2cm

# Auto-download NIST lines using Astroquery

from astroquery.nist import Nist
import astropy.units as u

table = Nist.query(wmin * u.nm, wmax * u.nm, linename=molecule,
                   wavelength_type='vacuum')

# Convert to a Radis-readable format 

df = table.to_pandas()

# Expand upper/lower states
df[["Ei", "Ek"]] = df['Ei           Ek'].str.split("-", expand=True).astype(float)
del df['Ei           Ek']

# Expand upper/lower term symbols
# df["Upper level"].str.split("|", expand=True)
def write_term_symbol(term):
    """
    convert format ::
        3d     | 2D   | 3/2   
        
    to::
        (3d)2D 
        
    """
    orbital, term, spin = term.split("|")
    # Note TODO unicode does not render in plotly label ? 
    # spin = spin.replace("1/2", "½")
    # spin = spin.replace("3/2", "³/²")  # Note: fractinos like 5/2 3/2 do not exist in unicode. TODO find a way to render them nice ?
    # spin = spin.replace("5/2", "⁵/²")  # Note: fractinos like 5/2 3/2 do not exist in unicode. TODO find a way to render them nice ?
    return r"({0}){1} {2}".format(orbital.strip(), term.strip(), spin.strip())

df["Upper level"] = df["Upper level"].apply(write_term_symbol)
df["Lower level"] = df["Lower level"].apply(write_term_symbol)
# TODO: make it a regexp, one pass ?

df.rename(columns={"Aki": "A",  # einstein coefficient
           "Ek": "Eu",  # upper state energy,
           "Ei": "El",  # lower state energy,
           }, inplace=True)
df["wav"] = nm2cm(df["Observed"])  # or Ritz for vacuum ?




#%%
from radis import SpectrumFactory

sf = SpectrumFactory(wavelength_min = wmin,
                     wavelength_max = wmax,
                     isotope=isotope,
                     optimization=None,  # no DIT algorithm
                     wstep='auto',
                     truncation=100,
                     mole_fraction=mole_fraction,
                     path_length=0.1,   # cm 
                     export_lines=True   # for line survey
                     )

df.attrs["molecule"] = molecule
df.attrs["iso"]  = isotope

# Placeholder for Partition functions
from radis.levels.partfunc import RovibParFuncTabulator
class NISTPartFunc(RovibParFuncTabulator):
    
    def __init__(self, atom):

        super(NISTPartFunc, self).__init__()
        
        self.atom = atom

    def at(self, T):
        return 1   # placeholder

sf.parsum_tab[molecule] = {isotope: {"X": NISTPartFunc(molecule)}}

# Placeholder for molar mass
sf._EXTRA_MOLAR_MASS[molecule] = {isotope: 1.00784}   # TODO  add automatically

# Placeholder for broadening coefficients  
df["airbrd"] = 0.01      # TODO calculate (unscaled value, check definnitino in HITRAN 1996 paper)
df["selbrd"] = 0.01      # TODO calculate (unscaled value, check definnitino in HITRAN 1996 paper)
df["Tdpair"] = 1      # TODO fix  (unscaled value, check definnitino in HITRAN 1996 paper)

sf.df0 = df
sf.params["dbformat"] = "nist"

from radis.lbl.base import linestrength_from_Einstein  # TODO: move elsewhere

df["int"] = linestrength_from_Einstein(
    A=df.A,
    gu=1,     # upper state generacy  TODO add
    El=df.El,
    Ia=1,    # isotopic abundance    TODO add
    nu=df.wav,
    Q=1,     # TODO add
    T=296,   # arbitrary (as in HITRAN)
)


df.dropna(subset=["int"], inplace=True)  # Warning this drops lines without Einstein coefficients in NIST. Do we want that ??


# sf._reset_profiler(verbose=True)
# sf.calc_reference_linestrength()
sf._reset_references()

s = sf.eq_spectrum(T, name=molecule)

s.plot(wunit='nm')

s.line_survey(overlay='abscoeff', writefile=molecule+".html", wunit='nm')


```

Plot : 

![image](https://user-images.githubusercontent.com/16088743/138247764-eba7c4b2-fe97-47b6-92f4-34b8e2507cb8.png)



Line survey : 

![image](https://user-images.githubusercontent.com/16088743/138247675-017925f9-5b84-493b-a614-810c604f81dc.png)


Next step (after this is merged) : properly include partition functions ; collsiinol broadening ; and integrate elemetns of the script as functions of SpectrumFactory    