### PR TITLE
Make line_survey more flexible for extenral codes

### DIFF
--- a/radis/test/test_examples.py
+++ b/radis/test/test_examples.py
@@ -10,7 +10,9 @@ from pathlib import Path
 
 import pytest
 
-EXAMPLE_FOLDER = abspath(join(dirname(__file__), "..", "..", "examples"))
+EXAMPLE_FOLDER = join(
+    abspath(join(dirname(__file__), os.pardir, os.pardir)), "examples"
+)
 
 scripts = [
     join(EXAMPLE_FOLDER, k) for k in os.listdir(EXAMPLE_FOLDER) if k.endswith(".py")

--- a/radis/tools/line_survey.py
+++ b/radis/tools/line_survey.py
@@ -175,34 +175,41 @@ def LineSurvey(
         )
 
     # Get input
-    T = spec.conditions["Tgas"]
-    P = spec.conditions["pressure_mbar"] / 1000  # bar1013.25 # atm
-    Xi = spec.conditions["mole_fraction"]
+    # T = spec.conditions["Tgas"]
+    # P = spec.conditions["pressure_mbar"] / 1000  # bar1013.25 # atm
+    # Xi = spec.conditions["mole_fraction"]
     sp = spec.lines.copy()
-    dbformat = spec.conditions["dbformat"]
 
     if not plot in list(sp.keys()):
         raise KeyError(
-            "Key {0} is not in line database: {1}".format(plot, list(sp.keys()))
+            "Key {0} is not in line database: {1}. Change `plot=` parameter of line_survey".format(
+                plot, list(sp.keys())
+            )
         )
 
-    def hitran2splot(S):
+    def hitran2splot(S, T):
         """convert Linestrength in HITRAN units (cm-1/(molecules.cm-2)) to
         SpectraPlot units (cm-2/atm)"""
 
         return S / (k_b * T) / 10
 
-    # Parsers to get units and more details
-    if dbformat in ["hitran", "hitemp", "hitemp-radisdb"]:
-        columndescriptor = hitrancolumns
-    elif dbformat in ["nist"]:
-        columndescriptor = hitrancolumns  # Placeholder. TODO replace with NIST (for the moment we copy the names anyway)
-    elif dbformat == "cdsd-hitemp":
-        columndescriptor = cdsdhitempcolumns
-    elif dbformat == "cdsd-4000":
-        columndescriptor = cdsd4000columns
+    # Known parsers to get units and more details
+    dbformat = None
+    if "dbformat" in spec.conditions:
+        dbformat = spec.conditions["dbformat"]
+        if dbformat in ["hitran", "hitemp", "hitemp-radisdb"]:
+            columndescriptor = hitrancolumns
+        elif dbformat in ["nist"]:
+            columndescriptor = hitrancolumns  # Placeholder. TODO replace with NIST (for the moment we copy the names anyway)
+        elif dbformat == "cdsd-hitemp":
+            columndescriptor = cdsdhitempcolumns
+        elif dbformat == "cdsd-4000":
+            columndescriptor = cdsd4000columns
+        else:
+            warn(NotImplemented(f"unknown dbformat {dbformat}"))
+            columndescriptor = {}
     else:
-        raise NotImplementedError(f"unknown dbformat {dbformat}")
+        columndescriptor = {}
 
     # Apply cutoff, get ylabel
     if plot == "S":
@@ -217,7 +224,8 @@ def LineSurvey(
                 # if None, use default cutoff expressed in Hitran units
                 sp = sp[(sp.S > cutoff)]
             else:
-                sp["S"] = hitran2splot(sp.S)
+                Tgas = spec.conditions["Tgas"]
+                sp["S"] = hitran2splot(sp.S, Tgas)
                 sp = sp[(sp.S > cutoff)]
             Iunit_str = "cm-1/atm"
         else:
@@ -225,7 +233,7 @@ def LineSurvey(
         ylabel = "Linestrength ({0})".format(Iunit_str)
     else:
         cutoff = 0
-        try:  # to find units and real name (if exists in initial databank)
+        try:  # to find units and real name (if columndescriptor is known exists in initial databank)
             _, _, name, unit = columndescriptor[plot]
             ylabel = "{0} - {1} [{2}]".format(name, plot, unit)
         except KeyError:
@@ -455,6 +463,14 @@ def LineSurvey(
 
         return label
 
+    def get_label_all(row):
+        """ print all lines details """
+        # label = row.__repr__()
+        label = "\n".join(
+            [f"{k}: {v}" for k, v in row.items() if k not in ["wav", "shiftwav"]]
+        )
+        return label
+
     def get_label_none(row):
         return "unknown databank format. \ndetails cant be read"
 
@@ -485,7 +501,10 @@ def LineSurvey(
     elif dbformat in ["nist"]:
         sp["label"] = sp.apply(lambda r: get_label_nist(r, sp.attrs), axis=1)
     else:
-        sp["label"] = sp.apply(get_label_none, axis=1)
+        sp["label"] = sp.apply(get_label_all, axis=1)
+        # TODO: add an option to print only certain columns?
+
+        # sp["label"] = sp.apply(get_label_none, axis=1)
 
     # from plotly.graph_objs import Scatter, Figure, Layout
 
@@ -526,9 +545,11 @@ def LineSurvey(
         plot_range = (max(cutoff, sp[plot].min()), sp[plot].max() + 1)
 
     layout = go.Layout(
-        title="Line Survey ({T}K, {P:.3f}bar, Mfrac={Xi:.3f})".format(
-            **{"T": T, "P": P, "Xi": Xi}
-        ),
+        title="Line Survey",
+        # TODO : re-add some parameters in the title (if they exist)
+        # ({T}K, {P:.3f}bar, Mfrac={Xi:.3f})".format(
+        #    **{"T": T, "P": P, "Xi": Xi}
+        # ),
         hovermode="closest",
         xaxis=dict(
             title=xlabel,


### PR DESCRIPTION
update line_survey for work more easily with output from other LBL coes (like pySpecair)

<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->
