### PR TITLE
First fix post release

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 - conda-forge
 - astropy
 - cantera
+- plotly
 dependencies:
 - python=3.8
 - astropy  # Unit aware calculations

--- a/radis/default_radis.json
+++ b/radis/default_radis.json
@@ -20,8 +20,8 @@
     "USE_CYTHON": true,                      # use Cython module if available (else, default to Python)
     "GRIDPOINTS_PER_LINEWIDTH_WARN_THRESHOLD": 3,    # raise a warning if less than THIS number of grid points per lineshape
     "GRIDPOINTS_PER_LINEWIDTH_ERROR_THRESHOLD": 1,   # raise an error if less than THIS number of grid points per lineshape
-    "MEMORY_MAPPING_ENGINE": "vaex",         #  warning: on Spyder this may result in freezes. see https://github.com/spyder-ide/spyder/issues/16183.
-    "SPARSE_WAVERANGE": "auto",              # sparse DLM algorithm. May be smaller on dense spectra. If "auto", a scarcity criterion is used (Nlines/Ngrids > 1)
+    "MEMORY_MAPPING_ENGINE": "auto",         # "vaex"/"pytables"/"feather". "auto" uses "vaex" in most cases unless you're using the Spyder IDE (where it may result in freezes). see https://github.com/spyder-ide/spyder/issues/16183.
+    "SPARSE_WAVERANGE": "auto",              # true/false. sparse DLM algorithm. May be smaller on dense spectra. If "auto", a scarcity criterion is used (Nlines/Ngrids > 1)
 
     # molecular parameters
     # --------------------

--- a/radis/io/dbmanager.py
+++ b/radis/io/dbmanager.py
@@ -106,8 +106,6 @@ class DatabaseManager(object):
                 # "auto" uses "vaex" in most cases unless you're using the Spyder IDE (where it may result in freezes).
                 # see https://github.com/spyder-ide/spyder/issues/16183.
                 # and https://github.com/radis/radis/issues/401
-                import os
-
                 if any("SPYDER" in name for name in os.environ):
                     if verbose >= 3:
                         print(

--- a/radis/io/dbmanager.py
+++ b/radis/io/dbmanager.py
@@ -97,6 +97,8 @@ class DatabaseManager(object):
         nJobs=-2,
         batch_size="auto",
     ):
+        from os import environ
+
         if engine == "default":
             from radis import config
 
@@ -106,7 +108,7 @@ class DatabaseManager(object):
                 # "auto" uses "vaex" in most cases unless you're using the Spyder IDE (where it may result in freezes).
                 # see https://github.com/spyder-ide/spyder/issues/16183.
                 # and https://github.com/radis/radis/issues/401
-                if any("SPYDER" in name for name in os.environ):
+                if any("SPYDER" in name for name in environ):
                     if verbose >= 3:
                         print(
                             "Spyder IDE detected. Memory-mapping-engine set to 'pytables' (less powerful than 'vaex' but Spyder user experience freezes). See https://github.com/spyder-ide/spyder/issues/16183. Change this behavior by setting the radis.config['MEMORY_MAPPING_ENGINE'] key"
@@ -116,7 +118,7 @@ class DatabaseManager(object):
                     engine = "vaex"
 
         # vaex processes are stuck if ran from Spyder. See https://github.com/spyder-ide/spyder/issues/16183
-        if engine == "vaex" and any("SPYDER" in name for name in os.environ):
+        if engine == "vaex" and any("SPYDER" in name for name in environ):
             from radis.misc.log import printwarn
 
             printwarn(

--- a/radis/io/dbmanager.py
+++ b/radis/io/dbmanager.py
@@ -101,6 +101,21 @@ class DatabaseManager(object):
             from radis import config
 
             engine = config["MEMORY_MAPPING_ENGINE"]  # 'pytables', 'vaex', 'feather'
+            # Quick fix for #401
+            if engine == "auto":
+                # "auto" uses "vaex" in most cases unless you're using the Spyder IDE (where it may result in freezes).
+                # see https://github.com/spyder-ide/spyder/issues/16183.
+                # and https://github.com/radis/radis/issues/401
+                import os
+
+                if any("SPYDER" in name for name in os.environ):
+                    if verbose >= 3:
+                        print(
+                            "Spyder IDE detected. Memory-mapping-engine set to 'pytables' (less powerful than 'vaex' but Spyder user experience freezes). See https://github.com/spyder-ide/spyder/issues/16183. Change this behavior by setting the radis.config['MEMORY_MAPPING_ENGINE'] key"
+                        )
+                    engine = "pytables"  # for HITRAN and HITEMP databases
+                else:
+                    engine = "vaex"
 
         # vaex processes are stuck if ran from Spyder. See https://github.com/spyder-ide/spyder/issues/16183
         if engine == "vaex" and any("SPYDER" in name for name in os.environ):

--- a/radis/io/dbmanager.py
+++ b/radis/io/dbmanager.py
@@ -7,7 +7,7 @@ Created on Mon Aug  9 19:42:51 2021
 import os
 import shutil
 from io import BytesIO
-from os.path import abspath, exists, splitext
+from os.path import abspath, dirname, exists, splitext
 from zipfile import ZipFile
 
 from radis.misc.config import addDatabankEntries, getDatabankEntries, getDatabankList
@@ -107,16 +107,18 @@ class DatabaseManager(object):
             from radis.misc.log import printwarn
 
             printwarn(
-                "Spyder IDE detected while using memory_mapping_engine='vaex'.\nVaex is the fastest way to read database files in RADIS, but Vaex processes may be stuck if ran from Spyder. See https://github.com/spyder-ide/spyder/issues/16183. You may consider using another IDE, or using a different `memory_mapping_engine` such as 'pytables' or 'feather'. You can change the engine in Spectrum.fetch_databank() calls, or globally by setting the 'MEMORY_MAPPING_ENGINE' key in your ~/radis.json  (note: starting another iPython console somehow releases the freeze in Spyder)  \n"
+                "Spyder IDE detected while using memory_mapping_engine='vaex'.\nVaex is the fastest way to read database files in RADIS, but Vaex processes may be stuck if ran from Spyder. See https://github.com/spyder-ide/spyder/issues/16183. You may consider using another IDE, or using a different `memory_mapping_engine` such as 'pytables' or 'feather'. You can change the engine in Spectrum.fetch_databank() calls, or globally by setting the 'MEMORY_MAPPING_ENGINE' key in your ~/radis.json \n"
             )
 
         self.name = name
         self.molecule = molecule
         self.local_databases = local_databases
         # create folder if needed
-        from radis.misc.basics import make_folders
+        if not exists(local_databases):
+            from radis.misc.basics import make_folders
 
-        make_folders(*split(abspath(local_databases)))
+            make_folders(*split(abspath(dirname(local_databases))))
+            make_folders(*split(abspath(local_databases)))
 
         self.downloadable = False  # by default
         self.format = ""

--- a/radis/io/exomol.py
+++ b/radis/io/exomol.py
@@ -436,6 +436,7 @@ class MdbExomol(object):
         bkgdatm="H2",
         broadf=True,
         engine="vaex",
+        verbose=True,
     ):
         """Molecular database for Exomol form
 
@@ -452,9 +453,24 @@ class MdbExomol(object):
 
         """
         if engine == "default":
-            import radis
+            from radis import config
 
-            engine = radis.config["MEMORY_MAPPING_ENGINE"]
+            engine = config["MEMORY_MAPPING_ENGINE"]
+            # Quick fix for #401
+            if engine == "auto":
+                # "auto" uses "vaex" in most cases unless you're using the Spyder IDE (where it may result in freezes).
+                # see https://github.com/spyder-ide/spyder/issues/16183.
+                # and https://github.com/radis/radis/issues/401
+                import os
+
+                if any("SPYDER" in name for name in os.environ):
+                    if verbose >= 3:
+                        print(
+                            "Spyder IDE detected. Memory-mapping-engine set to 'feather' (less powerful than 'vaex' but Spyder user experience freezes). See https://github.com/spyder-ide/spyder/issues/16183. Change this behavior by setting the radis.config['MEMORY_MAPPING_ENGINE'] key"
+                        )
+                    engine = "feather"  # for ExoMol database
+                else:
+                    engine = "vaex"
 
         if engine == "vaex":
             import vaex

--- a/radis/io/exomol.py
+++ b/radis/io/exomol.py
@@ -546,13 +546,16 @@ class MdbExomol(object):
         # load states
         if engine == "feather":
             if self.states_file.with_suffix(".feather").exists():
-                ndstates = pd.read_feather(self.states_file.with_suffix(".feather"))
+                states = pd.read_feather(self.states_file.with_suffix(".feather"))
             else:
                 print(
                     "Note: Caching states data to the feather format. After the second time, it will become much faster."
                 )
-                ndstates = exomolapi.read_states(self.states_file, dic_def)
-                ndstates.to_feather(self.states_file.with_suffix(".feather"))
+                states = exomolapi.read_states(self.states_file, dic_def, engine="csv")
+                states.to_feather(self.states_file.with_suffix(".feather"))
+            ndstates = states.to_numpy()[
+                :, :4
+            ]  # the i, E, g, J are in the 4 first columns
         elif engine == "vaex":
             if self.states_file.with_suffix(".bz2.hdf5").exists():
                 states = vaex.open(self.states_file.with_suffix(".bz2.hdf5"))
@@ -561,7 +564,7 @@ class MdbExomol(object):
                 print(
                     "Note: Caching states data to the hdf5 format with vaex. After the second time, it will become much faster."
                 )
-                states = exomolapi.read_states(self.states_file, dic_def)
+                states = exomolapi.read_states(self.states_file, dic_def, engine="vaex")
                 ndstates = vaex.array_types.to_numpy(states)
 
         # load pf
@@ -596,20 +599,23 @@ class MdbExomol(object):
                     print(
                         "Note: Caching line transition data to the HDF5 format with vaex. After the second time, it will become much faster."
                     )
-                    trans = exomolapi.read_trans(self.trans_file)
+                    trans = exomolapi.read_trans(self.trans_file, engine="vaex")
                     ndtrans = vaex.array_types.to_numpy(trans)
 
                     # mask needs to be applied
                     mask_needed = True
             elif engine == "feather":
                 if self.trans_file.with_suffix(".feather").exists():
-                    ndtrans = pd.read_feather(self.trans_file.with_suffix(".feather"))
+                    trans = pd.read_feather(self.trans_file.with_suffix(".feather"))
                 else:
                     print(
                         "Note: Caching line transition data to the feather format. After the second time, it will become much faster."
                     )
-                    ndtrans = exomolapi.read_trans(self.trans_file)
-                    ndtrans.to_feather(self.trans_file.with_suffix(".feather"))
+                    trans = exomolapi.read_trans(self.trans_file, engine="csv")
+                    trans.to_feather(self.trans_file.with_suffix(".feather"))
+                ndtrans = trans.to_numpy()
+                # mask needs to be applied   (in feather mode we don't sleect wavneumbers)
+                mask_needed = True
 
             # compute gup and elower
             (
@@ -647,16 +653,24 @@ class MdbExomol(object):
                     T=self.Tref,
                 )
 
-                # exclude the lines whose nu_lines evaluated inside exomolapi.pickup_gE (thus sometimes different from the "nu_lines" column in trans) is not positive
                 trans["nu_positive"] = mask_zeronu
-                trans = trans[trans.nu_positive].extract()
-                trans.drop("nu_positive", inplace=True)
+                if engine == "vaex":
+                    # exclude the lines whose nu_lines evaluated inside exomolapi.pickup_gE (thus sometimes different from the "nu_lines" column in trans) is not positive
+
+                    trans = trans[trans.nu_positive].extract()
+                    trans.drop("nu_positive", inplace=True)
+                else:
+                    if False in mask_zeronu:
+                        raise NotImplementedError(
+                            "some wavenumber is not defined;  masking not impleemtend so far in 'feather' engine"
+                        )
 
                 trans["nu_lines"] = self.nu_lines
                 trans["Sij0"] = self.Sij0
 
                 if engine == "vaex":
                     trans.export(self.trans_file.with_suffix(".hdf5"))
+                #  TODO : implement masking in 'feather' mode
 
         else:  # dic_def["numinf"] is not None
             imin = (
@@ -681,10 +695,13 @@ class MdbExomol(object):
                         print(
                             "Note: Caching line transition data to the feather format. After the second time, it will become much faster."
                         )
-                        ndtrans = exomolapi.read_trans(trans_file)
-                        ndtrans.to_feather(trans_file.with_suffix(".feather"))
+                        trans = exomolapi.read_trans(trans_file, engine="csv")
+                        trans.to_feather(trans_file.with_suffix(".feather"))
                         #!!TODO:restrict NOW the trans size to avoid useless overload of memory and CPU
                         # trans = trans[(trans['nu'] > self.nurange[0] - self.margin) & (trans['nu'] < self.nurange[1] + self.margin)]
+                    ndtrans = trans.to_numpy()
+                    # mask needs to be applied   (in feather mode we don't sleect wavneumbers)
+                    mask_needed = True
                 elif engine == "vaex":
                     if trans_file.with_suffix(".hdf5").exists():
                         trans = vaex.open(trans_file.with_suffix(".hdf5"))
@@ -705,7 +722,7 @@ class MdbExomol(object):
                         print(
                             "Note: Caching line transition data to the HDF5 format with vaex. After the second time, it will become much faster."
                         )
-                        trans = exomolapi.read_trans(trans_file)
+                        trans = exomolapi.read_trans(trans_file, engine="vaex")
                         ndtrans = vaex.array_types.to_numpy(trans)
 
                         # mask needs to be applied

--- a/radis/io/exomol.py
+++ b/radis/io/exomol.py
@@ -452,6 +452,8 @@ class MdbExomol(object):
            The trans/states files can be very large. For the first time to read it, we convert it to the feather-format. After the second-time, we use the feather format instead.
 
         """
+        from os import environ
+
         if engine == "default":
             from radis import config
 
@@ -461,9 +463,7 @@ class MdbExomol(object):
                 # "auto" uses "vaex" in most cases unless you're using the Spyder IDE (where it may result in freezes).
                 # see https://github.com/spyder-ide/spyder/issues/16183.
                 # and https://github.com/radis/radis/issues/401
-                import os
-
-                if any("SPYDER" in name for name in os.environ):
+                if any("SPYDER" in name for name in environ):
                     if verbose >= 3:
                         print(
                             "Spyder IDE detected. Memory-mapping-engine set to 'feather' (less powerful than 'vaex' but Spyder user experience freezes). See https://github.com/spyder-ide/spyder/issues/16183. Change this behavior by setting the radis.config['MEMORY_MAPPING_ENGINE'] key"

--- a/radis/io/exomol.py
+++ b/radis/io/exomol.py
@@ -750,7 +750,7 @@ class MdbExomol(object):
                         jupperx,
                         mask_zeronu,
                         quantumNumbersx,
-                    ) = exomolapi.pickup_gE(ndstates, ndtrans, trans_file)
+                    ) = exomolapi.pickup_gE(ndstates, ndtrans, trans_file, dic_def)
                     if engine == "vaex" and trans_file.with_suffix(".hdf5").exists():
                         Sij0x = ndtrans[:, 4]
                     else:

--- a/radis/io/hdf5.py
+++ b/radis/io/hdf5.py
@@ -262,7 +262,6 @@ class HDF5Manager(object):
             if key == "default":
                 key = r"/table"
 
-            import h5py
             import vaex
 
             # Open file

--- a/radis/io/hdf5.py
+++ b/radis/io/hdf5.py
@@ -299,7 +299,6 @@ class HDF5Manager(object):
             # TODO: define default key ?
             if key == "default":
                 key = None
-            import h5py
 
             with h5py.File(fname, "r") as f:
                 if key is None:  # load from root level

--- a/radis/io/hdf5.py
+++ b/radis/io/hdf5.py
@@ -445,7 +445,9 @@ class HDF5Manager(object):
                             raise err
 
         else:
-            raise NotImplementedError(self.engine)
+            raise NotImplementedError(
+                f"'{self.engine}' is not implemented. Use 'pytables' or 'vaex' ?"
+            )
 
         return metadata
 

--- a/radis/io/hitran.py
+++ b/radis/io/hitran.py
@@ -1073,6 +1073,8 @@ class HITRANDatabaseManager(DatabaseManager):
     def get_filenames(self):
         if self.engine == "vaex":
             return [join(self.local_databases, f"{self.molecule}.hdf5")]
+        elif self.engine == "pytables":
+            return [join(self.local_databases, f"{self.molecule}.h5")]
         else:
             raise NotImplementedError()
 

--- a/radis/io/hitran.py
+++ b/radis/io/hitran.py
@@ -1069,6 +1069,8 @@ class HITRANDatabaseManager(DatabaseManager):
         self.downloadable = True
         self.base_url = None
         self.Nlines = None
+        self.wmin = None
+        self.wmax = None
 
     def get_filenames(self):
         if self.engine == "vaex":
@@ -1213,6 +1215,26 @@ class HITRANDatabaseManager(DatabaseManager):
         from radis.db import MOLECULES_LIST_NONEQUILIBRIUM
 
         local_files = self.get_filenames()
+
+        if self.wmin is None or self.wmax is None:
+            print(
+                "Somehow wmin and wmax was not given for this database. Reading from the files"
+            )
+            ##  fix:
+            # (can happen if database was downloaded & parsed, but registration failed a first time)
+            df_full = self.load(
+                local_files,
+                columns=["wav"],
+                isotope=None,
+                load_wavenum_min=None,
+                load_wavenum_max=None,
+            )
+            self.wmin = df_full.wav.min()
+            self.wmax = df_full.wav.max()
+            print(
+                f"Somehow wmin and wmax was not given for this database. Read {self.wmin}, {self.wmax} directly from the files"
+            )
+
         info = f"HITRAN {self.molecule} lines ({self.wmin:.1f}-{self.wmax:.1f} cm-1) with TIPS-2021 (through HAPI) for partition functions"
 
         dict_entries = {

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -978,7 +978,7 @@ class BroadenFactory(BaseFactory):
             self.warn(
                 "Self-broadening coefficient selbrd not given in database: used airbrd instead",
                 "MissingSelfBroadeningWarning",
-                level=1,  # only appear if verbose>=2
+                level=2,  # only appear if verbose>=2
             )
 
             selbrd = df.airbrd
@@ -1047,6 +1047,7 @@ class BroadenFactory(BaseFactory):
             self.warn(
                 "Self-broadening reference width `selbrd` not given in database: used air broadening reference width `airbrd` instead",
                 "MissingSelfBroadeningWarning",
+                level=2,  # only appear if verbose>=2
             )
             selbrd = df.airbrd
         else:

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -974,10 +974,21 @@ class BroadenFactory(BaseFactory):
 
         molar_mass = self.get_molar_mass(df)
 
+        if not "selbrd" in list(df.keys()):
+            self.warn(
+                "Self-broadening coefficient selbrd not given in database: used airbrd instead",
+                "MissingSelfBroadeningWarning",
+                level=1,  # only appear if verbose>=2
+            )
+
+            selbrd = df.airbrd
+        else:
+            selbrd = df.selbrd
+
         # Calculate broadening FWHM
         wv, wl, wg = voigt_broadening_HWHM(
             df.airbrd,
-            df.selbrd,
+            selbrd,
             df.Tdpair,
             Tdpsel,
             df.wav,

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -49,6 +49,7 @@ key in :py:attr:`radis.config`
 # @dev: (on Spyder IDE navigate between sections easily as # XXX makes a reference
 # (on the slide bar on the right)
 
+import os
 import warnings
 from copy import deepcopy
 from os.path import exists
@@ -1116,10 +1117,15 @@ class DatabankLoader(object):
             if database == "full":
 
                 # quick fix for https://github.com/radis/radis/issues/401
-                if memory_mapping_engine not in ["vaex", "pytables"]:
-                    raise NotImplementedError(
-                        f"{memory_mapping_engine} with HITRAN files. Define radis.config['MEMORY_MAPPING_ENGINE'] = 'vaex' or 'pytables'"
-                    )
+                if memory_mapping_engine == "auto":
+                    if any("SPYDER" in name for name in os.environ):
+                        engine = "pytables"
+                        if self.verbose >= 3:
+                            print(
+                                f"Spyder IDE detected. Memory-mapping-engine set to '{engine}' (less powerful than 'vaex' but Spyder user experience freezes). See https://github.com/spyder-ide/spyder/issues/16183. Change this behavior by setting the radis.config['MEMORY_MAPPING_ENGINE'] key"
+                            )
+                    else:
+                        engine = "vaex"
 
                 if isotope == "all":
                     isotope_list = None
@@ -1186,10 +1192,15 @@ class DatabankLoader(object):
             self.reftracker.add(doi["HITEMP-2010"], "line database")  # [HITEMP-2010]_
 
             # quick fix for https://github.com/radis/radis/issues/401
-            if memory_mapping_engine not in ["vaex", "pytables"]:
-                raise NotImplementedError(
-                    f"{memory_mapping_engine} with HITEMP files. Define radis.config['MEMORY_MAPPING_ENGINE'] = 'vaex' or 'pytables'"
-                )
+            if memory_mapping_engine == "auto":
+                if any("SPYDER" in name for name in os.environ):
+                    engine = "pytables"
+                    if self.verbose >= 3:
+                        print(
+                            f"Spyder IDE detected. Memory-mapping-engine set to '{engine}' (less powerful than 'vaex' but Spyder user experience freezes). See https://github.com/spyder-ide/spyder/issues/16183. Change this behavior by setting the radis.config['MEMORY_MAPPING_ENGINE'] key"
+                        )
+                else:
+                    engine = "vaex"
 
             if database != "full":
                 raise ValueError(
@@ -1225,6 +1236,17 @@ class DatabankLoader(object):
 
         elif source == "exomol":
             self.reftracker.add(doi["ExoMol-2020"], "line database")  # [ExoMol-2020]
+
+            # quick fix for https://github.com/radis/radis/issues/401
+            if memory_mapping_engine == "auto":
+                if any("SPYDER" in name for name in os.environ):
+                    engine = "feather"
+                    if self.verbose >= 3:
+                        print(
+                            f"Spyder IDE detected. Memory-mapping-engine set to '{engine}' (less powerful than 'vaex' but Spyder user experience freezes). See https://github.com/spyder-ide/spyder/issues/16183. Change this behavior by setting the radis.config['MEMORY_MAPPING_ENGINE'] key"
+                        )
+                else:
+                    engine = "vaex"
 
             if database in ["full", "range"]:
                 raise ValueError(

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -49,7 +49,6 @@ key in :py:attr:`radis.config`
 # @dev: (on Spyder IDE navigate between sections easily as # XXX makes a reference
 # (on the slide bar on the right)
 
-import os
 import warnings
 from copy import deepcopy
 from os.path import exists
@@ -1110,6 +1109,8 @@ class DatabankLoader(object):
         # ---------------------
         self._reset_references()  # bibliographic references
 
+        from os import environ
+
         if source == "hitran":
             self.reftracker.add(doi["HITRAN-2016"], "line database")  # [HITRAN-2016]_
             self.reftracker.add(doi["Astroquery"], "data retrieval")  # [Astroquery]_
@@ -1118,7 +1119,7 @@ class DatabankLoader(object):
 
                 # quick fix for https://github.com/radis/radis/issues/401
                 if memory_mapping_engine == "auto":
-                    if any("SPYDER" in name for name in os.environ):
+                    if any("SPYDER" in name for name in environ):
                         engine = "pytables"
                         if self.verbose >= 3:
                             print(
@@ -1193,7 +1194,7 @@ class DatabankLoader(object):
 
             # quick fix for https://github.com/radis/radis/issues/401
             if memory_mapping_engine == "auto":
-                if any("SPYDER" in name for name in os.environ):
+                if any("SPYDER" in name for name in environ):
                     engine = "pytables"
                     if self.verbose >= 3:
                         print(
@@ -1239,7 +1240,7 @@ class DatabankLoader(object):
 
             # quick fix for https://github.com/radis/radis/issues/401
             if memory_mapping_engine == "auto":
-                if any("SPYDER" in name for name in os.environ):
+                if any("SPYDER" in name for name in environ):
                     engine = "feather"
                     if self.verbose >= 3:
                         print(

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -1115,6 +1115,12 @@ class DatabankLoader(object):
 
             if database == "full":
 
+                # quick fix for https://github.com/radis/radis/issues/401
+                if memory_mapping_engine not in ["vaex", "pytables"]:
+                    raise NotImplementedError(
+                        f"{memory_mapping_engine} with HITRAN files. Define radis.config['MEMORY_MAPPING_ENGINE'] = 'vaex' or 'pytables'"
+                    )
+
                 if isotope == "all":
                     isotope_list = None
                 else:
@@ -1179,6 +1185,12 @@ class DatabankLoader(object):
         elif source == "hitemp":
             self.reftracker.add(doi["HITEMP-2010"], "line database")  # [HITEMP-2010]_
 
+            # quick fix for https://github.com/radis/radis/issues/401
+            if memory_mapping_engine not in ["vaex", "pytables"]:
+                raise NotImplementedError(
+                    f"{memory_mapping_engine} with HITEMP files. Define radis.config['MEMORY_MAPPING_ENGINE'] = 'vaex' or 'pytables'"
+                )
+
             if database != "full":
                 raise ValueError(
                     f"Got `database={database}`. When fetching HITEMP, only the `database='full'` option is available."
@@ -1216,12 +1228,14 @@ class DatabankLoader(object):
 
             if database in ["full", "range"]:
                 raise ValueError(
-                    f"Got `database={database}`. When fetching ExoMol, only the `database=` key to retrieve a speciifc database. Use `database='default'` to get the recommended database. See more informatino in radis.io.fetch_exomol()"
+                    f"Got `database={database}`. When fetching ExoMol, use the `database=` key to retrieve a specific database. Use `database='default'` to get the recommended database. See more informatino in radis.io.fetch_exomol()"
                 )
 
             # Download, setup local databases, and fetch (use existing if possible)
             if memory_mapping_engine not in ["vaex", "feather"]:
-                raise NotImplementedError(f"{memory_mapping_engine} with ExoMol files")
+                raise NotImplementedError(
+                    f"{memory_mapping_engine} with ExoMol files. Define radis.config['MEMORY_MAPPING_ENGINE'] = 'vaex' or 'feather'"
+                )
 
             if isotope == "all":
                 raise ValueError(

--- a/radis/levels/partfunc.py
+++ b/radis/levels/partfunc.py
@@ -54,7 +54,6 @@ References
 # TODO: store molecule_data.json in the H5 file metadata. If not done already.
 
 
-import os
 import sys
 from os.path import exists
 from warnings import warn
@@ -223,7 +222,9 @@ class RovibParFuncCalculator(RovibPartitionFunction):
             raise ValueError("Choose mode = one of 'full summation', 'tabulation'")
 
         # vaex processes are stuck if ran from Spyder. See https://github.com/spyder-ide/spyder/issues/16183
-        if mode == "tabulation" and any("SPYDER" in name for name in os.environ):
+        from os import environ
+
+        if mode == "tabulation" and any("SPYDER" in name for name in environ):
             from radis.misc.log import printwarn
 
             printwarn(

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -2935,9 +2935,12 @@ class Spectrum(object):
         spec: Spectrum
             result from SpectrumFactory calculation (see spectrum.py)
         overlay: 'absorbance', 'transmittance', 'radiance', etc... or list of the above, or None
-            overlay Linestrength with specified variable calculated in `spec`.
+            overlay Linestrength with specified variable calculated
+            in `spec`.
             Get the full list with the :meth:`~radis.spectrum.spectrum.Spectrum.get_vars`
-            method. Default ``None``.
+            method. Default ``None`` ::
+
+                s.lineSurvey(overlay='abscoeff')
         wunit: ``'default'``, ``'nm'``, ``'cm-1'``, ``'nm_vac'``,
             wavelength air, wavenumber, or wavelength vacuum. If ``'default'``,
             Spectrum :py:meth:`~radis.spectrum.spectrum.Spectrum.get_waveunit` is used.

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -3252,7 +3252,7 @@ class Spectrum(object):
 
         return spec2hdf(self, file, engine=engine)
 
-    def to_pandas(s, copy=True):
+    def to_pandas(self, copy=True):
         """Convert a Spectrum to a Pandas DataFrame
 
         Returns
@@ -3269,9 +3269,9 @@ class Spectrum(object):
         For the moment, we store units as metadata"""
         import pandas as pd
 
-        df = pd.DataFrame(s._q, copy=copy)
+        df = pd.DataFrame(self._q, copy=copy)
 
-        df.attrs = s.units
+        df.attrs = self.units
 
         return df
 
@@ -3329,8 +3329,6 @@ class Spectrum(object):
         :py:func:`~radis.spectrum.spectrum.Spectrum.from_specutils`
 
         """
-        import astropy.units as u
-
         try:
             from specutils.spectra import Spectrum1D
         except ModuleNotFoundError as err:

--- a/radis/test/io/test_hitemp.py
+++ b/radis/test/io/test_hitemp.py
@@ -54,8 +54,8 @@ def test_relevant_files_filter():
 
 
 @pytest.mark.needs_connection
-def test_fetch_hitemp_OH(verbose=True, *args, **kwargs):
-    """Test proper download of HITEMP OH database.
+def test_fetch_hitemp_OH_pytables(verbose=True, *args, **kwargs):
+    """Test proper download of HITEMP OH database, with two engines.
 
     Good to test fetch_hitemp.
     ``13_HITEMP2020.par.bz2`` is only 900 kb so it can be run on online
@@ -68,14 +68,61 @@ def test_fetch_hitemp_OH(verbose=True, *args, **kwargs):
 
     """
 
-    df = fetch_hitemp("OH", cache="regen", chunksize=20000, verbose=3 * verbose)
+    df = fetch_hitemp(
+        "OH",
+        cache="regen",
+        chunksize=20000,
+        verbose=3 * verbose,
+        databank_name="HITEMP-OH-TEST-ENGINE-PYTABLES",
+        engine="pytables",
+    )
 
-    assert "HITEMP-OH" in getDatabankList()
+    assert "HITEMP-OH-TEST-ENGINE-PYTABLES" in getDatabankList()
 
     assert len(df) == 57019
 
     # Load again and make sure it works (ex: metadata properly loaded etc.):
-    fetch_hitemp("OH")
+    fetch_hitemp(
+        "OH",
+        databank_name="HITEMP-OH-TEST-ENGINE-PYTABLES",
+        engine="pytables",
+    )
+
+
+@pytest.mark.needs_connection
+def test_fetch_hitemp_OH_vaex(verbose=True, *args, **kwargs):
+    """Test proper download of HITEMP OH database, with two engines.
+
+    Good to test fetch_hitemp.
+    ``13_HITEMP2020.par.bz2`` is only 900 kb so it can be run on online
+    tests without burning the planet 🌳
+
+    ⚠️ if using the default `chunksize=100000`, it uncompresses in one pass
+    (only 57k lines for OH) and we cannot test that appending to the same HDF5
+    works. So here we use a smaller chunksize of 20,000.
+    .
+
+    """
+
+    df = fetch_hitemp(
+        "OH",
+        cache="regen",
+        chunksize=20000,
+        verbose=3 * verbose,
+        databank_name="HITEMP-OH-TEST-ENGINE-VAEX",
+        engine="vaex",
+    )
+
+    assert "HITEMP-OH-TEST-ENGINE-VAEX" in getDatabankList()
+
+    assert len(df) == 57019
+
+    # Load again and make sure it works (ex: metadata properly loaded etc.):
+    fetch_hitemp(
+        "OH",
+        databank_name="HITEMP-OH-TEST-ENGINE-VAEX",
+        engine="vaex",
+    )
 
 
 @pytest.mark.needs_connection
@@ -358,7 +405,8 @@ def test_parse_hitemp_missing_labels_issue280(*args, **kwargs):
 
 if __name__ == "__main__":
     test_relevant_files_filter()
-    test_fetch_hitemp_OH()
+    test_fetch_hitemp_OH_pytables()
+    test_fetch_hitemp_OH_vaex()
     test_partial_loading()
     test_calc_hitemp_CO_noneq()
     test_fetch_hitemp_partial_download_CO2()

--- a/radis/test/io/test_query.py
+++ b/radis/test/io/test_query.py
@@ -101,6 +101,43 @@ def test_fetch_astroquery_cache(verbose=True, *args, **kwargs):
 
 # ignored by pytest with argument -m "not needs_connection"
 @pytest.mark.needs_connection
+def test_fetch_hitran_CO_pytables(*args, **kwargs):
+
+    from radis.io.hitran import fetch_hitran
+
+    df = fetch_hitran(
+        "CO",
+        databank_name="HITRAN-CO-TEST-ENGINE-PYTABLES",
+        engine="pytables",
+    )
+
+    assert len(df) == 5381
+    assert df.wav.min() == 3.40191
+    assert df.wav.max() == 14477.377142
+
+
+# TODO : clean database on each new pytest run ?
+
+
+# ignored by pytest with argument -m "not needs_connection"
+@pytest.mark.needs_connection
+def test_fetch_hitran_CO_vaex(*args, **kwargs):
+
+    from radis.io.hitran import fetch_hitran
+
+    df = fetch_hitran(
+        "CO",
+        databank_name="HITRAN-CO-TEST-ENGINE-VAEX",
+        engine="vaex",
+    )
+
+    assert len(df) == 5381
+    assert df.wav.min() == 3.40191
+    assert df.wav.max() == 14477.377142
+
+
+# ignored by pytest with argument -m "not needs_connection"
+@pytest.mark.needs_connection
 def test_fetch_hitran(*args, **kwargs):
 
     from radis.io.hitran import fetch_hitran
@@ -143,6 +180,8 @@ def _run_testcases(verbose=True, *args, **kwargs):
     test_fetch_astroquery(verbose=verbose, *args, **kwargs)
     test_fetch_astroquery_empty(verbose=verbose, *args, **kwargs)
     test_fetch_astroquery_cache(verbose=verbose, *args, **kwargs)
+    test_fetch_hitran_CO_pytables(*args, **kwargs)
+    test_fetch_hitran_CO_vaex(*args, **kwargs)
     test_fetch_hitran(*args, **kwargs)
     test_calc_hitran_spectrum(*args, **kwargs)
 

--- a/radis/tools/line_survey.py
+++ b/radis/tools/line_survey.py
@@ -9,7 +9,6 @@ Functions to plot line surveys
 """
 
 
-import os
 from warnings import warn
 
 import numpy as np
@@ -169,7 +168,9 @@ def LineSurvey(
     assert yscale in ["log", "linear"]
 
     # auto plot in Spyder IDE
-    if writefile is None and any("SPYDER" in name for name in os.environ):
+    from os import environ
+
+    if writefile is None and any("SPYDER" in name for name in environ):
         writefile = "line_survey.html"
 
     try:

--- a/radis/tools/line_survey.py
+++ b/radis/tools/line_survey.py
@@ -9,6 +9,7 @@ Functions to plot line surveys
 """
 
 
+import os
 from warnings import warn
 
 import numpy as np
@@ -77,7 +78,9 @@ def LineSurvey(
         result from SpectrumFactory calculation (see spectrum.py)
     overlay: tuple (w, I, [name], [units]), or list or tuples
         plot (w, I) on a secondary axis. Useful to compare linestrength with
-        calculated / measured data
+        calculated / measured data::
+
+            LineSurvey(overlay='abscoeff')
     wunit: ``'nm'``, ``'cm-1'``
         wavelength / wavenumber units
     Iunit: ``'hitran'``, ``'splot'``
@@ -164,6 +167,10 @@ def LineSurvey(
         warn(DeprecationWarning("yunit replaced with Iunit"))
         Iunit = yunit
     assert yscale in ["log", "linear"]
+
+    # auto plot in Spyder IDE
+    if writefile is None and any("SPYDER" in name for name in os.environ):
+        writefile = "line_survey.html"
 
     try:
         spec.lines

--- a/radis/tools/line_survey.py
+++ b/radis/tools/line_survey.py
@@ -206,7 +206,7 @@ def LineSurvey(
         elif dbformat == "cdsd-4000":
             columndescriptor = cdsd4000columns
         else:
-            warn(NotImplemented(f"unknown dbformat {dbformat}"))
+            warn(f"unknown dbformat {dbformat}")
             columndescriptor = {}
     else:
         columndescriptor = {}


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

- [x] Activate pytables support for new HITRAN full-database format : Fixes #401
- [x] option not to parse local/Global quanta
- [x] fix ~/.radisdb folder not created by default
- [x] automatically show line_survey if run from Spyder (already worked in Jupyter Lab)  @minouHub 
- [x] fix problems with ExoMol parser ( by @minouHub  ) 
- [x] "auto" mode for MEMORY_MAPPING_ENGINE (set by default). -> will use "vaex", unless you're on Spyder IDE, thne will use "pytables" (HITRAN/HITEMP) or "feather" (ExoMol).    (note : we detect we're on Spyder IDE by looking at environment variables; may fail if someone somehow declared a "SPYDER" key in thier environemnet variables)
- [x] test Pytables & vaex modes for HITRAN & HITEMP    (in separate folders)