### PR TITLE
fix isotope='all' syntax when fetching HITRAN files

### DIFF
--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -1155,6 +1155,12 @@ class DatabankLoader(object):
                 )
                 self.params.dbpath = ",".join(local_paths)
 
+                # ... explicitely write all isotopes based on isotopes found in the database
+                if isotope == "all":
+                    self.input.isotope = ",".join(
+                        [str(k) for k in self._get_isotope_list(df=df)]
+                    )
+
             elif database == "range":
 
                 # Query one isotope at a time


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

Will fix https://github.com/suzil/radis-app/issues/71  when 0.11.2 is released 
