### PR TITLE
Add SpecDatabase interpolation

### DIFF
--- a/examples/plot_SpecDatabase.py
+++ b/examples/plot_SpecDatabase.py
@@ -1,14 +1,25 @@
 """
-================================================
+=================
 Spectrum Database
-================================================
-RADIS has :py:class:`~radis.tools.database.SpecDatabase` feature used to store and retrieve calculated Spectrums. A path can be specified for SpecDatabase all Spectrums are stored as .spec files which can be loaded
-from the SpecDatabase object itself.  A csv file is generated which contains all input and conditional parameters of Spectrum.
+=================
 
-RADIS also has :py:meth:`~radis.lbl.loader.DatabankLoader.init_database` feature which initializes the SpecDatabase for the SpectrumFactory and every Spectrum
+RADIS has :py:class:`~radis.tools.database.SpecDatabase` feature used to store
+and retrieve calculated Spectrums. A path can be specified for SpecDatabase all
+Spectrums are stored as .spec files which can be loaded
+from the SpecDatabase object itself.  A csv file is generated which contains all
+input and conditional parameters of Spectrum.
+
+RADIS also has :py:meth:`~radis.lbl.loader.DatabankLoader.init_database` feature
+which initializes the SpecDatabase for the SpectrumFactory and every Spectrum
 generated from it will be stored in the SpecDatabase automatically.
 
-You can use :py:meth:`~radis.tools.database.SpecList.plot_cond` to make a 2D plot using the conditions of the Spectrums in the SpecDatabase and use a z_label to plot a heat map based on it.
+You can use :py:meth:`~radis.tools.database.SpecList.plot_cond` to make a 2D plot
+using the conditions of the Spectrums in the SpecDatabase and use a z_label to plot
+a heat map based on it.
+
+:py:class:`~radis.tools.database.SpecDatabase` also has useful
+:py:meth:`~radis.tools.database.SpecDatabase.fit_spectrum` and
+:py:meth:`~radis.tools.database.SpecDatabase.interpolate` methods.
 
 
 """
@@ -37,7 +48,9 @@ sf.fetch_databank("hitemp")
 s1 = sf.eq_spectrum(Tgas=300, path_length=1)
 
 # Creating SpecDatabase
-my_folder = Path.cwd() / "SpecDatabase_Test"
+from radis.test.utils import getTestFile
+
+my_folder = Path(getTestFile(".")) / "SpecDatabase_Test"
 db = SpecDatabase(my_folder)
 
 # Method 1: Creating .spec file and adding manually to SpecDatabase

--- a/radis/io/dbmanager.py
+++ b/radis/io/dbmanager.py
@@ -493,6 +493,7 @@ class DatabaseManager(object):
     def get_nrows(self, local_file):
         """ Get number of rows (without loading all DataFrame)"""
         engine = self.engine
+        local_file = expanduser(local_file)
         if engine == "pytables":
             with pd.HDFStore(local_file, "r") as store:
                 nrows = store.get_storer("df").nrows

--- a/radis/io/hdf5.py
+++ b/radis/io/hdf5.py
@@ -7,7 +7,7 @@ Created on Tue Jan 26 21:27:15 2021
 
 import os
 import sys
-from os.path import exists, splitext
+from os.path import exists, expanduser, splitext
 from time import time
 
 import h5py
@@ -124,6 +124,7 @@ class HDF5Manager(object):
             only these column names will be searchable directly on disk to
             load certain lines only. See :py:func:`~radis.io.hdf5.hdf2df`
         """
+        file = expanduser(file)
         if self.engine == "pytables":
             if key == "default":
                 key = "df"
@@ -174,6 +175,7 @@ class HDF5Manager(object):
         """Combine all batch files in ``self._temp_batch_files`` into one.
         Removes all batch files.
         """
+        file = expanduser(file)
         if self.engine == "vaex":
             if len(self._temp_batch_files) == 0:
                 raise ValueError(f"No batch temp files were written for {file}")
@@ -235,6 +237,7 @@ class HDF5Manager(object):
         """
 
         if self.engine in ["pytables", "pytables-fixed"]:
+            fname = expanduser(fname)
             if key == "default":
                 key = "df"
             try:
@@ -267,6 +270,7 @@ class HDF5Manager(object):
             # Open file
             assert len(store_kwargs) == 0
             fname_list = fname if isinstance(fname, list) else [fname]
+            fname_list = [expanduser(f) for f in fname_list]
             # vaex can open several files at the same time
             # First check group exists
             for fname in fname_list:
@@ -296,6 +300,7 @@ class HDF5Manager(object):
             return df
 
         elif self.engine == "h5py":
+            fname = expanduser(fname)
             # TODO: define default key ?
             if key == "default":
                 key = None
@@ -339,6 +344,7 @@ class HDF5Manager(object):
         from radis.io.cache_files import _h5_compatible
 
         if self.engine in ["pytables", "pytables-fixed"]:
+            fname = expanduser(fname)
             if key == "default":
                 key = "df"
             with pd.HDFStore(fname, mode="a", complib="blosc", complevel=9) as f:
@@ -349,6 +355,7 @@ class HDF5Manager(object):
                 f.get_storer(key).attrs.metadata = metadata
 
         elif self.engine == "h5py":
+            fname = expanduser(fname)
             if key == "default":
                 key = None
             with h5py.File(fname, "a") as hf:
@@ -367,6 +374,7 @@ class HDF5Manager(object):
             if isinstance(fname, list):
                 assert isinstance(metadata, list)
                 for f, m in zip(fname, metadata):
+                    f = expanduser(f)
                     with h5py.File(f, "a") as hf:
                         if create_empty_dataset:
                             assert key is not None
@@ -376,6 +384,7 @@ class HDF5Manager(object):
                         else:
                             hf[key].attrs.update(_h5_compatible(m))
             else:
+                fname = expanduser(fname)
                 with h5py.File(fname, "a") as hf:
                     if create_empty_dataset:
                         assert key is not None
@@ -399,6 +408,7 @@ class HDF5Manager(object):
         """
 
         if self.engine in ["pytables", "pytables-fixed"]:
+            fname = expanduser(fname)
             if key == "default":
                 key = "df"
             with pd.HDFStore(fname, mode="r", complib="blosc", complevel=9) as f:
@@ -409,6 +419,7 @@ class HDF5Manager(object):
                     raise err
 
         elif self.engine == "h5py":
+            fname = expanduser(fname)
             if key == "default":
                 key = None
             with h5py.File(fname, "r") as hf:
@@ -427,12 +438,14 @@ class HDF5Manager(object):
             if isinstance(fname, list):
                 metadata = []
                 for f in fname:
+                    f = expanduser(f)
                     with h5py.File(f, "r") as hf:
                         if key is None:  # read metadta at root level
                             metadata.append(dict(hf.attrs))
                         else:
                             metadata.append(dict(hf[key].attrs))
             else:
+                fname = expanduser(fname)
                 with h5py.File(fname, "r") as hf:
                     if key is None:  # add metadta at root level
                         metadata = dict(hf.attrs)
@@ -476,6 +489,7 @@ class HDF5Manager(object):
             engine = "pytables"
         else:
             # Try Vaex
+            file = expanduser(file)
             with h5py.File(file, mode="r") as hf:
                 try:
                     hf[r"/table"]

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -651,7 +651,7 @@ class Spectrum(object):
             # dimensionless
             if wunit is None:
                 raise ValueError(
-                    "``w`` must be a dimensionned array, or ``Iunit=`` must be given."
+                    "``w`` must be a dimensionned array, or ``wunit=`` must be given."
                 )
         else:
             if wunit is not None:

--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -1204,6 +1204,7 @@ class SpecList(object):
         --------
         :meth:`~radis.tools.database.SpecList.get_unique`,
         :meth:`~radis.tools.database.SpecList.get_closest`,
+        ;py:meth:`~radis.tools.database.SpecDatabase.interpolate`,
         :meth:`~radis.tools.database.SpecList.items`
         """
 
@@ -1321,7 +1322,8 @@ class SpecList(object):
         See Also
         --------
         :py:meth:`~radis.tools.database.SpecList.get`,
-        :py:meth:`~radis.tools.database.SpecList.get_closest`
+        :py:meth:`~radis.tools.database.SpecList.get_closest`,
+        ;py:meth:`~radis.tools.database.SpecDatabase.interpolate`
         """
 
         out = self.get(conditions, scale_if_possible=scale_if_possible, **kwconditions)
@@ -1338,7 +1340,7 @@ class SpecList(object):
                 if prevVerbose is not None:
                     kwconditions["verbose"] = prevVerbose
                 raise ValueError(
-                    "Spectrum not found. See closest above. Use get_closest()"
+                    "Spectrum not found. See closest above. Use db.get_closest(). You could also try db.interpolate()"
                 )
         elif len(out) > 1:
             raise ValueError(
@@ -1376,7 +1378,8 @@ class SpecList(object):
         See Also
         --------
         :meth:`~radis.tools.database.SpecList.get`,
-        :meth:`~radis.tools.database.SpecList.get_unique`
+        :meth:`~radis.tools.database.SpecList.get_unique`,
+        ;py:meth:`~radis.tools.database.SpecDatabase.interpolate`
         """
         #        split_columns: list of str.
         #            slits a comma separated column in multiple columns, and number them.

--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -2290,6 +2290,70 @@ class SpecDatabase(SpecList):
 
         return file
 
+    def interpolate(self, **kwconditions):
+        """Interpolate existing spectra from the database to generate a new spectrum with conditions kwargs
+
+        Examples
+        --------
+        ::
+
+            db.interpolate(Tgas=300, mole_fraction=0.3)
+
+        """
+
+        # Not interpolated conditions :
+        not_interpolated_conditions = [
+            c for c in self.conditions() if c not in kwconditions
+        ]
+        not_interpolated_conditions = [
+            c
+            for c in not_interpolated_conditions
+            if c not in ["file", "last_modified", "name"]
+        ]
+        df = self.see(columns=not_interpolated_conditions)
+
+        # assert df values are unique :
+        for c in df.columns:
+            if df[c].nunique() > 1:
+                raise ValueError(
+                    f"Spectra in database {self.name} have different values for `{c}`. All conditions except from the one we are interpolating on should be the same"
+                )
+                # TODO : implement a way to get a subset of a SpecDatabase, so we can do something like db.take(molecule='C2').interpolate(... )
+
+        if len(kwconditions) > 1:
+            raise NotImplementedError(
+                "Interpolation of multiple conditions is not implemented yet"
+            )
+
+        cond = list(kwconditions.keys())[0]
+        val = kwconditions[cond]
+
+        cond_list = self.see(columns=[cond]).values[:, 0]
+        b = np.argsort(cond_list)
+
+        cond_list = cond_list[b]
+        spectra = (self.see().index.values)[b]
+
+        # Interpolate val over cond_list
+        pos = np.interp(val, cond_list, np.arange(cond_list.size))
+        index = pos.astype(int)
+        weight = pos - index
+
+        s_left = self.get_unique(file=spectra[index])
+        s_right = self.get_unique(file=spectra[index + 1])
+
+        # linear algebra on spectra directly :
+        s_interp = (1 - weight) * s_left + weight * s_right
+        # TODO : Will raise an error if multiple values in database. In this
+        # case, use s_left.take(var)   with 'var' given in parameters of interpolate()
+        # Or tell user to generate a subdatabase with only one spectral array
+
+        s_interp.conditions[
+            "interpolated_from"
+        ] = f"{spectra[index]}, {spectra[index+1]}"
+
+        return s_interp
+
     def fit_spectrum(
         self,
         s_exp,


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

Allows the following syntax : 

```python
from radis import SpecDatabase
db = SpecDatabase("/A/FOLDER/WITH/SOME/.spec/FILES")
db.see("Tgas")   # see the temperature of all spectra in this folder

#New : 
s = db.interpolate(Tgas=1200)   # linearly interpolate a Spectrum for this temperature (even if not in the database)

s.plot()
```

Should make fitting very fast ! I can imagine an inner loop with linear-interpolation of existing spectra (avoids recomputing), and an outer loop which recomputes from scratch and updates the database. 


Currently not implemented :  
- [ ] multiple interpolation conditions
- [ ] ability to interpolate only from a subset of the database



<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


May be interested : @gh4ag @CorentinGrimaldi @minouHub @maillardj 