### PR TITLE
get() automatically computes the spectral array if missing

### DIFF
--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -431,6 +431,11 @@ class SpectrumFactory(BandFactory):
                     + "We recommended, for most cases: `truncation=300, neighbour_lines=0}`"
                 )
             )
+        for boolarg in [self_absorption, save_memory, export_lines]:
+            if boolarg not in [True, False]:
+                raise ValueError(
+                    f"Expected boolean parameter. Got `{boolarg.__repr__()}`. Use `True` or `False`"
+                )
 
         if kwargs0 != {}:
             raise TypeError(

--- a/radis/spectrum/rescale.py
+++ b/radis/spectrum/rescale.py
@@ -649,12 +649,11 @@ def rescale_abscoeff(
         abscoeff_init = None
     else:
         raise ValueError(
-            "Can't rescale abscoeff if transmittance_noslit ({0}) ".format(
+            "Can't rescale abscoeff if not all of the following are given : transmittance_noslit ({0}) ".format(
                 "transmittance_noslit" in initial
             )
             + "or absorbance ({0}), ".format("absorbance" in initial)
-            + "and true_path_length ({0}) ".format(true_path_length)
-            + "are not given. Use optically_thin?"
+            + "and true_path_length ({0}). ".format(true_path_length)
         )
 
     # Then export rescaled value
@@ -1416,7 +1415,15 @@ def _recalculate(
     else:
         _check_quantity = [quantity]
     for k in _check_quantity:
-        assert k in CONVOLUTED_QUANTITIES + NON_CONVOLUTED_QUANTITIES + ["all", "same"]
+        try:
+            assert k in CONVOLUTED_QUANTITIES + NON_CONVOLUTED_QUANTITIES + [
+                "all",
+                "same",
+            ]
+        except AssertionError:
+            raise ValueError(
+                f"Unexpected spectral array `{k}`. Expected one of {CONVOLUTED_QUANTITIES+NON_CONVOLUTED_QUANTITIES}"
+            )
     # ... make sure we're not trying to rescale a Spectrum that has non scalable
     # ... quantities
     if any_in(initial, non_rescalable_keys):

--- a/radis/spectrum/rescale.py
+++ b/radis/spectrum/rescale.py
@@ -482,32 +482,25 @@ def update(
     """Calculate missing quantities that can be derived from the current
     quantities and conditions.
 
-    e.g: if path_length and emisscoeff are given, radiance_noslit can be recalculated
-    if in an optically thin configuration, else if abscoeff is also given
+    e.g: if `path_length` and `emisscoeff` are given, `radiance_noslit` can be recalculated
+    if `abscoeff` is also given, or without `abscoeff` in an optically thin configuration, else
 
 
     Parameters
     ----------
-
     spec: Spectrum
-
     quantity: str, ``'same'``, ``'all'``, or list of str
         name of the spectral quantity to recompute. If ``'same'``, only the quantities
         in the Spectrum are recomputed. If ``'all'``, then all quantities that can
         be derived are recomputed. Default ``'all'``. See
         :py:data:`~radis.spectrum.utils.CONVOLUTED_QUANTITIES`
         and :py:data:`~radis.spectrum.utils.NON_CONVOLUTED_QUANTITIES`
-
     optically_thin: True, False, or ``'default'``
-        determines whether to calculate radiance with or without self absorption.
-        If 'default', the value is determined from the self_absorption key
-        in Spectrum.conditions. If not given, False is taken. Default 'default'
-        Also updates the self_absorption value in conditions (creates it if
+        determines whether to calculate radiance with or without self-absorption.
+        If ``'default'``, the value is determined from the ``'self_absorption'`` key
+        in Spectrum.conditions. If not given, ``False`` is taken. Default ``'default'``
+        Also updates the ``'self_absorption'`` key in conditions (creates it if
         doesnt exist)
-
-    Other Parameters
-    ----------------
-
     assume_equilibrium: boolean
         if ``True``, only absorption coefficient ``abscoeff`` is recomputed
         and all values are derived from a calculation under equilibrium,
@@ -580,6 +573,8 @@ def update(
         # make sure units exist
         if not k in spec.units:
             raise ValueError("{0} added but unit is unknown".format(k))
+
+    return spec
 
 
 # Rescale functions
@@ -846,7 +841,7 @@ def rescale_emisscoeff(
 
     else:
         if optically_thin:
-            msg = "Can't calculate emisscoeff if true path_length ({0})".format(
+            msg = "Can't calculate emisscoeff if path_length ({0})".format(
                 true_path_length
             ) + "and initial radiance_noslit ({0}) are not all given".format(
                 "radiance_noslit" in initial
@@ -859,14 +854,12 @@ def rescale_emisscoeff(
                 raise ValueError(msg)
         else:
             msg = (
-                "Trying to get the emission coefficient (emisscoeff) in non optically "
-                + "thin case. True path_length ({0}), radiance_noslit ({1}) ".format(
+                "Trying to get the emission coefficient (emisscoeff) for a non-optically "
+                + "thin column. Among the following required quantities, not all of them are given : path_length ({0}), radiance_noslit ({1}) ".format(
                     true_path_length, "radiance_noslit" in initial
                 )
-                + "and abscoeff ({0}) are needed but not all given. ".format(
-                    "abscoeff" in initial
-                )
-                + "Try optically_thin? See known Spectrum conditions with "
+                + "and abscoeff ({0}). ".format("abscoeff" in initial)
+                + "See known Spectrum conditions with "
                 + "print(Spectrum)"
             )
             if "emisscoeff" in extra:  # cant calculate this one but let it go
@@ -1251,14 +1244,13 @@ def rescale_radiance_noslit(
                 raise ValueError(msg)
         else:
             msg = (
-                "Missing data to recalculate radiance_noslit. You need at least "
-                + "scaled emisscoeff ({0}), scaled transmittance_noslit ({1}) ".format(
+                "Missing data to recalculate radiance_noslit for a non-optically thin column with thermal_equilibrium={0}. You need at least "
+                + "scaled emisscoeff ({0}), scaled transmittance_noslit ({1}), ".format(
                     "emisscoeff" in rescaled, "transmittance_noslit" in rescaled
                 )
                 + "scaled abscoeff ({0}) and true_path_length ({1}). ".format(
                     "abscoeff" in rescaled, true_path_length
                 )
-                + "Try in optically thin mode"
             )
             if "radiance_noslit" in extra:
                 radiance_noslit = None
@@ -1384,21 +1376,19 @@ def _recalculate(
     and :func:`~radis.spectrum.rescale.update`.
 
     Determines with spectral quantities should be recomputed, then scales
-    them solving the Radiative Transfer Equation in the process.
+    them solving the Radiative Transfer Equation on a 1D-homogeneous column
+    without scattering.
 
 
     Parameters
     ----------
-
     spec: Spectrum
         the Spectrum object to recompute
-
     quantity: str, ``'same'``, ``'all'``, or list of str
         name of the spectral quantity to recompute. If ``'same'``, only the quantities
         in the Spectrum are recomputed. If ``'all'``, then all quantities that can
         be derived are recomputed. See :py:data:`~radis.spectrum.utils.CONVOLUTED_QUANTITIES`
         and :py:data:`~radis.spectrum.utils.NON_CONVOLUTED_QUANTITIES`
-
     true_path_length: boolean
         if ``False``, only relative rescaling (new/old) is allowed. For instance,
         when you dont know the true path_lenth, rescaling absorbance
@@ -1407,12 +1397,10 @@ def _recalculate(
 
     Other Parameters
     ----------------
-
     assume_equilibrium: boolean
         if ``True``, only absorption coefficient ``abscoeff`` is recomputed
         and all values are derived from a calculation under equilibrium,
         using Kirchoff's Law. Default ``False``
-
     """
 
     optically_thin = spec.is_optically_thin()

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -986,7 +986,9 @@ class Spectrum(object):
                 )
             else:
                 raise KeyError(
-                    "{0} not in quantity list: {1}".format(var, self.get_vars())
+                    "{0} not in quantity list: {1}. Try to compute it automatically with s.update('{0}')".format(
+                        var, self.get_vars()
+                    )
                 )
 
         # Get quantity
@@ -1335,9 +1337,22 @@ class Spectrum(object):
 
         Examples
         --------
+        Initialize a spectrum from the absorption coefficient, retrieve the transmittance
+        or the emission coefficient :
         ::
 
+            s = Spectrum.from_array([1900.  , 1900.01, 1900.02, 1900.03, 1900.04, 1900.05, 1900.06,
+                                     1900.07, 1900.08, 1900.09],
+                                    [2.71414065e-06, 2.88341489e-06, 3.06942277e-06, 3.27445689e-06,
+                                     3.50121831e-06, 3.75290756e-06, 4.03334037e-06, 4.34709612e-06,
+                                     4.69971017e-06, 5.09792551e-06],
+                                    'abscoeff', wunit='cm-1', Iunit='cm-1',
+                                    conditions={'path_length':1, # cm
+                                                'thermal_equilibrium':True,
+                                                'Tgas':700,  # K
+                                                })
             s.update('transmittance_noslit')
+            s.update('emisscoeff')
 
         See Also
         --------

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -985,11 +985,13 @@ class Spectrum(object):
                     + ". Have you used .apply_slit()?"
                 )
             else:
-                raise KeyError(
-                    "{0} not in quantity list: {1}. Try to compute it automatically with s.update('{0}')".format(
-                        var, self.get_vars()
-                    )
-                )
+                # Try to compute it automatically :
+                try:
+                    self.update(var)
+                except ValueError as err:
+                    raise ValueError(
+                        f"{var} not in Spectrum arrays {self.get_vars()}. An error occured while trying to recompute it from the available arrays and conditions. See above"
+                    ) from err
 
         # Get quantity
         I = self._q[var]


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

- [x] `s.get()` automatically tries to compute the spectral array if it is not stored in the spectrum .

The following example is now possible : 
```python
s = radis.test_spectrum().take('abscoeff')    #  absorption coefficient only in this spectrum

s.plot("radiance_noslit")   # will still work    
```
Before, an intermediary call to update() was needed
```
s = radis.test_spectrum().take('abscoeff')    #  absorption coefficient only in this spectrum

s.update("radiance_noslit")
s.plot("radiance_noslit")
```

- [x] make update chainable : `s.update(...).something()`
- [x] boolean validator for SpectrumFactory parameters. Avoids problems with the string "false" evaluated as True in Python. https://twitter.com/zz99583643/status/1470350834756374531
