### PR TITLE
Add support for cross-sections

### DIFF
--- a/docs/spectrum/spectrum.rst
+++ b/docs/spectrum/spectrum.rst
@@ -255,6 +255,7 @@ is sometimes confusingly called *spectral intensity*.
 - ``'abscoeff'``: spectral absorption coefficient (typically in :math:``'cm^{-1}'``), also called *opacity*.
   This is sometimes found as the *extinction coefficient* in the literature (strictly speaking, *extinction*
   is *absorption* + *diffusion*, the latter being negligible in the infrared).
+- ``'xsection'``: absorption cross-section, typically in cm2
 
 Additionally, RADIS may calculate extra quantities such as:
 

--- a/examples/plot_compare_CO_exomol_hitemp.py
+++ b/examples/plot_compare_CO_exomol_hitemp.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """
-==============================================
-Compare CO from the ExoMol and HITEMP database
-==============================================
+=========================================================
+Compare CO xsections from the ExoMol and HITEMP database
+=========================================================
 
 Auto-download and calculate CO spectrum from the HITEMP database, and the
 ExoMol database. ExoMol references multiple databases for CO. Here we do not
@@ -44,11 +44,11 @@ s_hitemp = calc_spectrum(
     databank="hitemp",
     name="HITEMP (Air broadened)",
 )
-plot_diff(s_exomol, s_hitemp, "abscoeff")
+plot_diff(s_exomol, s_hitemp, "xsection")
 
 #%% Broadening coefficients are different but areas under the lines should be the same :
 import numpy as np
 
 assert np.isclose(
-    s_exomol.get_integral("abscoeff"), s_hitemp.get_integral("abscoeff"), rtol=0.001
+    s_exomol.get_integral("xsection"), s_hitemp.get_integral("xsection"), rtol=0.001
 )

--- a/radis/io/cdsd.py
+++ b/radis/io/cdsd.py
@@ -125,7 +125,7 @@ def cdsd2df(
 ):
     """Convert a CDSD-HITEMP [1]_ or CDSD-4000 [2]_ file to a Pandas dataframe.
 
-    Parameter
+    Parameters
     ----------
     fname: str
         CDSD file name

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -819,7 +819,7 @@ class SpectrumFactory(BandFactory):
         self.profiler.start("generate_spectrum_obj", 2)
 
         # Get conditions
-        conditions = self.get_conditions()
+        conditions = self.get_conditions(add_config=True)
         conditions.update(
             {
                 "calculation_time": self.profiler.final[list(self.profiler.final)[-1]][
@@ -1145,7 +1145,7 @@ class SpectrumFactory(BandFactory):
 
         # Get lines (intensities + populations)
 
-        conditions = self.get_conditions()
+        conditions = self.get_conditions(add_config=True)
         conditions.update(
             {
                 "calculation_time": self.profiler.final[list(self.profiler.final)[-1]][
@@ -1494,7 +1494,7 @@ class SpectrumFactory(BandFactory):
         self.profiler.start("generate_spectrum_obj", 2)
 
         # Get conditions
-        conditions = self.get_conditions()
+        conditions = self.get_conditions(add_config=True)
         conditions.update(
             {
                 "calculation_time": self.profiler.final[list(self.profiler.final)[-1]][

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -2864,9 +2864,10 @@ class DatabankLoader(object):
 
         if add_config:
             import radis
+            from radis.spectrum.utils import CONFIG_PARAMS
 
             vardict.update(
-                {k: v for k, v in radis.config.items() if not isinstance(v, dict)}
+                {k: v for k, v in radis.config.items() if k in CONFIG_PARAMS}
             )
 
         return vardict

--- a/radis/phys/units.py
+++ b/radis/phys/units.py
@@ -15,6 +15,7 @@ def Unit(st, *args, **kwargs):
     Changes compare to Astropy standards:
 
     - "µm" is accepted and converted to "um"
+    - "/molecule" or "/molec" are removed, but do not raise an error
     - we do not raise a warning if multiple slashes, e.g. "mW/cm2/sr/nm"
 
     Examples
@@ -31,6 +32,8 @@ def Unit(st, *args, **kwargs):
 
     try:
         st = st.replace("µ", "u")
+        st = st.replace("/molecule", "")
+        st = st.replace("/molec", "")
     except AttributeError:
         pass
 

--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -511,19 +511,11 @@ def get_default_units(
             var = list(params)[0]
             if var.replace("_noslit", "") in params:
                 var = var.replace("_noslit", "")
-    # ... check variable exist
+    # ... create variable if it doesnt exist
     if var not in s1.get_vars():
-        raise ValueError(
-            "{0} not defined in Spectrum {1}. Use one of : {2}".format(
-                var, s1.get_name(), s1.get_vars()
-            )
-        )
+        s1.get(var)
     if var not in s2.get_vars():
-        raise ValueError(
-            "{0} not defined in Spectrum {1}. Use one of : {2}".format(
-                var, s2.get_name(), s2.get_vars()
-            )
-        )
+        s2.get(var)
     if Iunit == "default":
         try:
             Iunit = s1.units[var]

--- a/radis/spectrum/rescale.py
+++ b/radis/spectrum/rescale.py
@@ -7,6 +7,8 @@ Most of these are binded as methods to the Spectrum class, but stored here to
 unload the spectrum.py file
 
 
+Equations derived from the code using `pytexit <https://pytexit.readthedocs.io/en/latest/>`__
+
 -------------------------------------------------------------------------------
 """
 
@@ -33,6 +35,7 @@ ordered_keys = [
     "emissivity_noslit",
     "radiance",
     "transmittance",
+    "xsection",
 ]
 """list: List of all spectral variables sorted by priority during recomputation
 (ex: first get abscoeff, then try to calculate emisscoeff, etc.)
@@ -56,7 +59,12 @@ assert (
 
 
 def _build_update_graph(
-    spec, optically_thin=None, equilibrium=None, path_length=None, no_change=False
+    spec,
+    optically_thin=None,
+    equilibrium=None,
+    path_length=None,
+    p_T_x=None,
+    no_change=False,
 ):
     """Find inheritances properties (dependencies and equivalences) between all
     spectral variables based on the spectrum conditions (equilibrium, optically
@@ -64,27 +72,25 @@ def _build_update_graph(
 
     Parameters
     ----------
-
     spec: Spectrum
         a :class:`~radis.spectrum.spectrum.Spectrum` object
 
     Other Parameters
     ----------------
-
     optically_thin: boolean
         know whether the Spectrum should be considered optically thin to build
         the equivalence graph tree. If None, the value stored in the Spectrum is used.
         Default ``None``
-
     equilibrium: boolean
         know whether the Spectrum should be considered at equilibrium to build
         the equivalence graph tree. If None, the value stored in the Spectrum is used.
         Default ``None``
-
     path_length: boolean
         know whether the path length is given to build the equivalence graph tree.
         If None, ``path_length`` is looked up in the Spectrum condition. Default ``None``
-
+    p_T_x: boolean
+        whether all of the temperature, pressure and mole fractions are known. If None,
+        they are looked up in the Spectrum conditions. Default ``None``
     no_change: boolean
         if True, signals that we are somehow rescaling without changing path length
         nor mole fractions, i.e, all quantities can be recomputed from themselves...
@@ -141,6 +147,12 @@ def _build_update_graph(
         path_length = "path_length" in spec.conditions
     if optically_thin is None:
         optically_thin = spec.is_optically_thin()
+    if p_T_x is None:
+        p_T_x = (
+            "Tgas" in spec.conditions
+            and "pressure_mbar" in spec.conditions
+            and "mole_fraction" in spec.conditions
+        )
     if equilibrium is None:
         # Read the Spectrum conditions. By default, use False.
         equilibrium = spec.conditions.get(
@@ -161,6 +173,7 @@ def _build_update_graph(
         "radiance",
         "radiance_noslit",
         "transmittance_noslit",
+        "xsection",
     ]
     assert all_in(all_keys, CONVOLUTED_QUANTITIES + NON_CONVOLUTED_QUANTITIES)
 
@@ -221,6 +234,10 @@ def _build_update_graph(
             derives_from("radiance_noslit", ["emisscoeff", "abscoeff"])
             derives_from("emisscoeff", ["radiance_noslit", "abscoeff"])
 
+    if p_T_x:
+        derives_from("abscoeff", ["xsection"])
+        derives_from("xsection", ["abscoeff"])
+
     if slit:
         if __debug__:
             printdbg("... build_graph: slit given > convoluted keys can be recomputed")
@@ -232,7 +249,8 @@ def _build_update_graph(
             printdbg("... build_graph: equilibrium > all keys derive from one")
         # Anything can be recomputed from anything
         for key in all_keys:
-            if key in NON_CONVOLUTED_QUANTITIES:
+            if key in NON_CONVOLUTED_QUANTITIES and key != "xsection":
+                # except from xsection, where we still need P & T
                 all_but_k = [[k] for k in all_keys if k != key]
                 derives_from(key, *all_but_k)
 
@@ -349,28 +367,23 @@ def get_recompute(spec, wanted, no_change=False, true_path_length=None):
 
     Parameters
     ----------
-
     spec: Spectrum
         a :class:`~radis.spectrum.spectrum.Spectrum` object
-
     wanted: list
         list of quantities to recompute
 
 
     Other Parameters
     ----------------
-
     no_change: boolean
         if True, signals that we are somehow rescaling without changing path length
         nor mole fractions, i.e, all quantities can be recomputed from themselves...
-
     true_path_length: boolean
         know whether the path length is given to build the equivalence graph tree.
         If None, ``path_length`` is looked up in the Spectrum condition. Default ``None``
 
     Returns
     -------
-
     recompute: list
         list of quantities needed
 
@@ -594,7 +607,7 @@ def rescale_abscoeff(
     extra,
     true_path_length,
 ):
-    """
+    r"""
 
     Parameters
     ----------
@@ -603,6 +616,38 @@ def rescale_abscoeff(
 
     old_path_length: float
         path length in cm
+
+    References
+    ----------
+
+    Scale absorption coefficient :
+
+    .. math::
+
+        k_2=k_1 \frac{x_2}{x_1}
+
+    Or recompute from the absorbance:
+
+    .. math::
+
+        k_2=\frac{A_1}{L_1} \cdot \frac{x_2}{x_1}
+
+    .. note::
+
+        scaling mole fractions is not strictly valid because the lineshape changes slightly if resonant
+        and non-resonant broadening coefficients are different
+
+    Or from the transmittance :
+
+    .. math::
+
+        k_2=\frac{-\ln(T_1)}{L_1} \cdot \frac{x_2}{x_1}
+
+    Or from the cross-sections :
+
+    .. math::
+
+        \k_2 =\sigma_1 * \frac{x p}{k_b T}  \cdot \frac{x_2}{x_1}
 
     """
 
@@ -621,13 +666,13 @@ def rescale_abscoeff(
         _, abscoeff_init = spec.get("abscoeff", wunit=wunit)
     elif "absorbance" in initial and true_path_length:  # aka: true path_lengths given
         if __debug__:
-            printdbg("... rescale: abscoeff k1 = A/L1")
+            printdbg("... rescale: abscoeff k_1 = A_1/L_1")
         _, A = spec.get("absorbance", wunit=wunit)
         abscoeff_init = A / old_path_length  # recalculate initial
         unit = "cm-1"
     elif "transmittance_noslit" in initial and true_path_length:
         if __debug__:
-            printdbg("... rescale: abscoeff k1 = -ln(T1)/L1")
+            printdbg("... rescale: abscoeff k_1 = -ln(T_1)/L_1")
         # Get abscoeff from transmittance
         _, T1 = spec.get("transmittance_noslit", wunit=wunit)
 
@@ -645,6 +690,25 @@ def rescale_abscoeff(
         # Else, let's calculate it
         abscoeff_init = -ln(T1) / old_path_length  # recalculate initial
         unit = "cm-1"
+    elif (
+        "xsection" in initial
+        and "Tgas" in spec.conditions
+        and "pressure_mbar" in spec.conditions
+        and "mole_fraction" in spec.conditions
+    ):
+        if __debug__:  # cm-1
+            printdbg("... rescale: abscoeff k_2 = XS_2 * (x * p) / (k_b * T)")
+        xsection = rescaled["xsection"]  # x already scaled
+        pressure_Pa = spec.conditions["pressure_mbar"] * 1e2
+        x = spec.conditions["mole_fraction"]
+        Tgas = spec.conditions["Tgas"]  # K
+        from radis.phys.constants import k_b
+
+        abscoeff_init = xsection * (x * pressure_Pa / k_b / Tgas) * 1e-6  # cm2
+        if "xsection" in spec.units:
+            assert spec.units["xsection"] == "cm2"
+        unit = "cm-1"
+
     elif "abscoeff" in extra:  # cant calculate this one but let it go
         abscoeff_init = None
     else:
@@ -660,7 +724,7 @@ def rescale_abscoeff(
     # --------------------
     if abscoeff_init is not None:
         if __debug__:
-            printdbg("... rescale: abscoeff k2 = k1 * N2/N1")
+            printdbg("... rescale: abscoeff k_2 = k_1 * (x_2/x_1)")
         abscoeff = abscoeff_init * new_mole_fraction / old_mole_fraction  # rescale
         rescaled["abscoeff"] = abscoeff
     if unit is not None:
@@ -747,12 +811,43 @@ def rescale_emisscoeff(
     extra,
     true_path_length,
 ):
-    """
+    r"""
 
     Parameters
     ----------
 
     spec: Spectrum
+
+
+    References
+    ----------
+
+    If optically thin, compute from the radiance :
+
+    .. math::
+
+        j_2=\frac{I_1}{L_1} \cdot \frac{x_2}{x_1}
+
+
+    In the general case, compute from the radiance and the absorption coefficient :
+
+    .. math::
+
+        j_2=\frac{k_1 I_1}{1-\operatorname{exp}\left(-k_1 L_1\right)} \cdot \frac{x_2}{x_1}
+
+    .. note::
+
+        scaling path length is always valid ; scaling mole fractions is not
+        strictly valid because the lineshape changes slightly if resonant
+        and non-resonant broadening coefficients are different
+
+    or from the radiance and the transmittance:
+
+    .. math::
+
+        j_2=\frac{k_1 I_1}{1-T_1} \frac{x_2}{x_1}
+
+
     """
 
     unit = None
@@ -782,14 +877,14 @@ def rescale_emisscoeff(
 
     elif "radiance_noslit" in initial and true_path_length and optically_thin:
         if __debug__:
-            printdbg("... rescale: emisscoeff j1 = I1/L1")
+            printdbg("... rescale: emisscoeff j_1 = I_1/L_1")
         _, I = spec.get("radiance_noslit", wunit=wunit, Iunit=units["radiance_noslit"])
         emisscoeff_init = I / old_path_length  # recalculate initial
         unit = get_unit(units["radiance_noslit"])
 
     elif "radiance_noslit" in initial and true_path_length and "abscoeff" in initial:
         if __debug__:
-            printdbg("... rescale: emisscoeff j1 = k1*I1/(1-exp(-k1*L1))")
+            printdbg("... rescale: emisscoeff j_1 = k_1*I_1/(1-exp(-k_1*L_1))")
         # get emisscoeff from (initial) abscoeff and (initial) radiance
         _, I = spec.get("radiance_noslit", wunit=wunit, Iunit=units["radiance_noslit"])
         _, k = spec.get("abscoeff", wunit=wunit, Iunit=units["abscoeff"])
@@ -815,7 +910,7 @@ def rescale_emisscoeff(
         and "transmittance_noslit" in initial
     ):
         if __debug__:
-            printdbg("... rescale: emisscoeff j1 = k1*I1/(1-T1)")
+            printdbg("... rescale: emisscoeff j_1 = k_1*I_1/(1-T_1)")
         # get emisscoeff from (initial) transmittance and (initial) radiance
         _, I = spec.get("radiance_noslit", wunit=wunit, Iunit=units["radiance_noslit"])
         _, T = spec.get(
@@ -872,7 +967,7 @@ def rescale_emisscoeff(
     # -----------------------
     if emisscoeff_init is not None:
         if __debug__:
-            printdbg("... rescale: emisscoeff j2 = j1 * N2/N1")
+            printdbg("... rescale: emisscoeff j_2 = j_1 * (x_2/x_1)")
         # Now rescale for mole fractions
         emisscoeff = (
             emisscoeff_init * new_mole_fraction / old_mole_fraction
@@ -906,6 +1001,39 @@ def rescale_absorbance(
     ----------
 
     spec: Spectrum
+
+    References
+    ----------
+
+    Rescale the absorbance:
+
+    .. math::
+
+        A_2=A_1 \frac{x_2}{x_1} \frac{L_2}{L_1}
+
+    .. note::
+
+        scaling path length is always valid ; scaling mole fractions is not
+        strictly valid because the lineshape changes slightly if resonant
+        and non-resonant broadening coefficients are different
+
+    Or compute from the absorption coefficient :
+
+    .. math::
+
+        A_2=k_2 L_2
+
+    Or from the transmittance :
+
+    .. math::
+
+        A_2=-\ln(T1) \frac{x_2}{x_1} \frac{L_2}{L_1}
+
+    See Also
+    --------
+    :py:attr:`~radis.spectrum.rescale.rescale_abscoeff`,
+    :py:attr:`~radis.spectrum.rescale.rescale_transmittance_noslit`,
+
     """
 
     unit = None
@@ -922,22 +1050,24 @@ def rescale_absorbance(
 
     if "absorbance" in initial:
         if __debug__:
-            printdbg("... rescale: absorbance A2 = A1*N2/N1*L2/L1")
+            printdbg("... rescale: absorbance A_2 = A_1*(x_2/x_1)*(L_2/L_1)")
         _, absorbance = spec.get(
             "absorbance", wunit=waveunit, Iunit=units["absorbance"]
         )
         absorbance *= new_mole_fraction / old_mole_fraction  # rescale x
         absorbance *= new_path_length / old_path_length  # rescale L
         unit = ""
-    elif "abscoeff" in rescaled and true_path_length:
+    elif "abscoeff" in rescaled and true_path_length:  # in cm
         if __debug__:
-            printdbg("... rescale: absorbance A2 = j2*L2")
+            printdbg("... rescale: absorbance A_2 = k_2*L_2")
         abscoeff = rescaled["abscoeff"]  # x already scaled
         absorbance = abscoeff * new_path_length  # calculate L
+        if "abscoeff" in spec.units:
+            assert spec.units["abscoeff"] == "cm-1"
         unit = ""
     elif "transmittance_noslit" in initial and true_path_length:
         if __debug__:
-            printdbg("... rescale: absorbance A2 = -ln(T1)*N2/N1*L2/L1")
+            printdbg("... rescale: absorbance A_2 = -ln(T1)*(x_2/x_1)*(L_2/L_1)")
         # Get absorbance from transmittance
         _, T1 = spec.get("transmittance_noslit", wunit=waveunit)
 
@@ -997,12 +1127,46 @@ def rescale_transmittance_noslit(
     extra,
     true_path_length,
 ):
-    """
+    r"""
 
     Parameters
     ----------
 
     spec: Spectrum
+
+
+    References
+    ----------
+
+    Compute from the absorbance :
+
+    .. math::
+
+        \tau_2=\operatorname{exp}\left(-A_2\right)
+
+    Or from the absorption coefficient and the new path length :
+
+    .. math::
+
+        \tau_2=\operatorname{exp}\left(-k_2 L_2\right)
+
+    Or from the previous transmittance :
+
+    .. math::
+
+        \tau_2=\operatorname{exp}\left(\ln(T_1) \frac{x_2}{x_1} \frac{L_2}{L_1}\right)
+
+    .. note::
+
+        scaling path length is always valid ; scaling mole fractions is not
+        strictly valid because the lineshape changes slightly if resonant
+        and non-resonant broadening coefficients are different
+
+    See Also
+    --------
+    :py:attr:`~radis.spectrum.rescale.rescale_abscoeff`,
+    :py:attr:`~radis.spectrum.rescale.rescale_absorbance`,
+    :py:attr:`~radis.spectrum.rescale.rescale_transmittance_noslit`,
     """
 
     unit = None
@@ -1023,13 +1187,13 @@ def rescale_transmittance_noslit(
     # Rescale
     if "absorbance" in rescaled:
         if __debug__:
-            printdbg("... rescale: transmittance_noslit T2 = exp(-A2)")
+            printdbg("... rescale: transmittance_noslit T_2 = exp(-A_2)")
         absorbance = rescaled["absorbance"]  # x and L already scaled
         transmittance_noslit = exp(-absorbance)  # recalculate
         unit = get_unit()
     elif "abscoeff" in rescaled and true_path_length:
         if __debug__:
-            printdbg("... rescale: transmittance_noslit T2 = exp(-j2*L2)")
+            printdbg("... rescale: transmittance_noslit T_2 = exp(-k_2*L_2)")
         abscoeff = rescaled["abscoeff"]  # x already scaled
         absorbance = abscoeff * new_path_length  # calculate
         transmittance_noslit = exp(-absorbance)  # recalculate
@@ -1037,8 +1201,8 @@ def rescale_transmittance_noslit(
     elif "transmittance_noslit" in initial:
         if __debug__:
             printdbg(
-                "... rescale: transmittance_noslit T2 = "
-                + "exp( ln(T1) * N2/N1 * L2/L1)"
+                "... rescale: transmittance_noslit T_2 = "
+                + "exp( ln(T_1) * (x_2/x_1) * (L_2/L_1))"
             )
         # get transmittance from initial transmittance
         _, T1 = spec.get(
@@ -1143,12 +1307,55 @@ def rescale_radiance_noslit(
     extra,
     true_path_length,
 ):
-    """
+    r"""
 
     Parameters
     ----------
 
     spec: Spectrum
+
+
+    References
+    ----------
+
+    If optically thin, calculate from the emission coefficient :
+
+    .. math::
+
+        I_2=j_2 L_2
+
+    or scale the existing radiance :
+
+    .. math::
+
+        I_2=\frac{\frac{I_1 x_2}{x_1} L_2}{L_1}
+
+    .. note::
+
+        scaling path length is always valid ; scaling mole fractions is not
+        strictly valid because the lineshape changes slightly if resonant
+        and non-resonant broadening coefficients are different
+
+    If not optically thin, recompute from the transmittance and absorption coefficient
+    (analytical output of the 1D-homogenous column emission without scattering) :
+
+    .. math::
+
+        I_2=\frac{j_2 \left(1-T_2\right)}{k_2}
+
+    or from the emission coefficient and absorption coefficient:
+
+    .. math::
+
+        I_2=\frac{j_2 \left(1-\operatorname{exp}\left(-k_2 L_2\right)\right)}{k_2}
+
+
+    See Also
+    --------
+    :py:attr:`~radis.spectrum.rescale.rescale_emisscoeff`,
+    :py:attr:`~radis.spectrum.rescale.rescale_abscoeff`,
+    :py:attr:`~radis.spectrum.rescale.rescale_radiance_noslit`,
+
     """
 
     unit = None
@@ -1170,7 +1377,9 @@ def rescale_radiance_noslit(
     # Rescale!
     if "emisscoeff" in rescaled and true_path_length and optically_thin:
         if __debug__:
-            printdbg("... rescale: radiance_noslit I2 = j2 * L2 " + "(optically thin)")
+            printdbg(
+                "... rescale: radiance_noslit I_2 = j_2 * L_2 " + "(optically thin)"
+            )
         emisscoeff = rescaled["emisscoeff"]  # x already scaled
         radiance_noslit = emisscoeff * new_path_length  # recalculate L
         unit = get_radiance_unit(units["emisscoeff"])
@@ -1183,7 +1392,7 @@ def rescale_radiance_noslit(
         and not optically_thin
     ):  # not optically thin
         if __debug__:
-            printdbg("... rescale: radiance_noslit I2 = j2*(1-T2)/k2")
+            printdbg("... rescale: radiance_noslit I_2 = j_2*(1-T_2)/k_2")
         emisscoeff = rescaled["emisscoeff"]  # x already scaled
         abscoeff = rescaled["abscoeff"]  # x already scaled
         # mole_fraction, path_length already scaled
@@ -1203,7 +1412,7 @@ def rescale_radiance_noslit(
         and not optically_thin
     ):  # not optically thin
         if __debug__:
-            printdbg("... rescale: radiance_noslit I2 = j2*(1-exp(-k2*L2))/k2")
+            printdbg("... rescale: radiance_noslit I_2 = j_2*(1-exp(-k_2*L_2))/k_2")
         emisscoeff = rescaled["emisscoeff"]  # x already scaled
         abscoeff = rescaled["abscoeff"]  # x already scaled
         b = abscoeff == 0  # optically thin mask
@@ -1217,7 +1426,8 @@ def rescale_radiance_noslit(
     elif "radiance_noslit" in initial and optically_thin:
         if __debug__:
             printdbg(
-                "... rescale: radiance_noslit I2 = I1*N2/N1*L2/L1 " + "(optically thin)"
+                "... rescale: radiance_noslit I_2 = I_1*x_2/x_1*L_2/L_1 "
+                + "(optically thin)"
             )
         _, radiance_noslit = spec.get(
             "radiance_noslit", wunit=waveunit, Iunit=units["radiance_noslit"]
@@ -1320,12 +1530,25 @@ def rescale_radiance(
 
 
 def rescale_emissivity_noslit(spec, rescaled, units, extra, true_path_length):
-    """
+    r"""
 
     Parameters
     ----------
 
     spec: Spectrum
+
+    References
+    ----------
+
+    Compute from the transmittance :
+
+    .. math::
+
+        \epsilon_2 = 1 - \tau_2
+
+    See Also
+    --------
+    :py:attr:`~radis.spectrum.rescale.rescale_transmittance_noslit`,
     """
 
     # case where we recomputed it already (somehow... ex: no_change signaled)
@@ -1338,7 +1561,7 @@ def rescale_emissivity_noslit(spec, rescaled, units, extra, true_path_length):
     # Rescale!
     if "transmittance_noslit" in rescaled:
         if __debug__:
-            printdbg("... rescale: emissivity_noslit e2 = 1 - T2")
+            printdbg("... rescale: emissivity_noslit e_2 = 1 - T_2")
         # transmittivity already scaled
         T2 = rescaled["transmittance_noslit"]
         emissivity_noslit = 1 - T2  # recalculate
@@ -1355,6 +1578,118 @@ def rescale_emissivity_noslit(spec, rescaled, units, extra, true_path_length):
     if emissivity_noslit is not None:
         rescaled["emissivity_noslit"] = emissivity_noslit
         units["emissivity_noslit"] = ""
+
+    return rescaled, units
+
+
+# ... cross sections
+
+
+def rescale_xsection(
+    spec,
+    rescaled,
+    initial,
+    old_mole_fraction,
+    new_mole_fraction,
+    old_path_length,
+    new_path_length,
+    waveunit,
+    units,
+    extra,
+    true_path_length,
+):
+    r"""Rescale cross-sections
+
+    Parameters
+    ----------
+    spec: Spectrum
+    old_path_length: float
+        path length in cm
+
+    References
+    ----------
+    Either scale the cross-section directly :
+
+    .. math::
+
+        \sigma_2=\sigma_1
+
+    (by definition, cross-sections are unchanged)
+
+    or recompute from scaled absorption coefficient:
+
+    .. math::
+
+        \sigma_2=k_2 \frac{k_b T}{x p}
+
+    With ``p`` the total pressure and ``x`` the species mole fraction.
+
+
+    See Also
+    --------
+    :py:attr:`~radis.spectrum.rescale.rescale_abscoeff`,
+    """
+
+    unit = None
+
+    # case where we recomputed it already (somehow... ex: no_change signaled)
+    if "xsection" in rescaled:
+        if __debug__:
+            printdbg("... rescale: xsection was scaled already")
+        assert "xsection" in units
+        return rescaled, units
+
+    # Get scaled xsection directly from XS1
+    # -------------------------------------
+
+    if "xsection" in initial:
+        # cross-sections are unchanged
+        if __debug__:
+            printdbg("... rescale: xsection XS_2 = XS_1")
+        _, xsection = spec.get("xsection", wunit=waveunit, Iunit=units["xsection"])
+        unit = units["xsection"]  # units unchanged
+    elif (
+        "abscoeff" in rescaled
+        and "Tgas" in spec.conditions
+        and "pressure_mbar" in spec.conditions
+        and "mole_fraction" in spec.conditions
+    ):
+        if __debug__:  # cm-1
+            printdbg("... rescale: xsection XS_2 = k_2 * (k_b * T / x / p)")
+        abscoeff = rescaled["abscoeff"]  # x already scaled
+        pressure_Pa = spec.conditions["pressure_mbar"] * 1e2
+        x = spec.conditions["mole_fraction"]
+        Tgas = spec.conditions["Tgas"]  # K
+        from radis.phys.constants import k_b
+
+        xsection = abscoeff * (k_b * Tgas / x / pressure_Pa) * 1e6  # cm2
+        if "abscoeff" in spec.units:
+            assert spec.units["abscoeff"] == "cm-1"
+        unit = "cm2"
+    else:
+        msg = (
+            "Cant recalculate xsection if not all these quantities are given : "
+            + "scaled abscoeff ({0}), Tgas ({1}), pressure_mbar ({2})".format(
+                "abscoeff" in rescaled,
+                "Tgas" in spec.conditions,
+                "pressure_mbar" in spec.conditions,
+            )
+        )
+        if "xsection" in extra:  # cant calculate this one but let it go
+            xsection = None
+            if __debug__:
+                printdbg(msg)
+        else:
+            raise ValueError(msg)
+
+    # Then rescale and export
+    # -----------------------
+
+    # Export rescaled value
+    if xsection is not None:
+        rescaled["xsection"] = xsection
+    if unit is not None:
+        units["xsection"] = unit
 
     return rescaled, units
 
@@ -1654,6 +1989,21 @@ def _recalculate(
                 extra,
             )
             apply_slit = apply_slit or slit_needed
+
+    if "xsection" in recompute:
+        rescaled, units = rescale_xsection(
+            spec,
+            rescaled,
+            initial,
+            old_mole_fraction,
+            new_mole_fraction,
+            old_path_length,
+            optically_thin,
+            waveunit,
+            units,
+            extra,
+            true_path_length,
+        )
 
     # delete former convoluted value if apply_slit will be used (just to be sure
     # we arent keeping a non rescaled value if something goes wrong)

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -925,7 +925,7 @@ class Spectrum(object):
 
         Parameters
         ----------
-        var: variable ('absorbance', 'transmittance', etc.)
+        var: variable (``'absorbance'``, ``'transmittance'``, ``'xsection'`` etc.)
             Should be a defined quantity among :data:`~radis.spectrum.utils.CONVOLUTED_QUANTITIES`
             or :data:`~radis.spectrum.utils.NON_CONVOLUTED_QUANTITIES`.
             To get the full list of quantities defined in this Spectrum object use
@@ -1818,7 +1818,7 @@ class Spectrum(object):
 
         Parameters
         ----------
-        var: variable (`absorbance`, `transmittance`, `transmittance_noslit`, etc.)
+        var: variable (`absorbance`, `transmittance`, `transmittance_noslit`, `xsection`, etc.)
             For full list see :py:meth:`~radis.spectrum.spectrum.Spectrum.get_vars()`.
             If ``None``, plot the first thing in the Spectrum. Default ``None``.
         wunit: ``'default'``, ``'nm'``, ``'cm-1'``, ``'nm_vac'``,
@@ -4182,7 +4182,7 @@ class Spectrum(object):
         Parameters
         ----------
         var : str
-            spectral quantity
+            spectral quantity (``'absorbance'``, ``'transmittance'``, ``'xsection'`` etc.)
 
         Returns
         -------
@@ -4191,8 +4191,7 @@ class Spectrum(object):
 
         Examples
         --------
-
-        Use it to chain other commands ::
+        Use ``take`` to chain other commands ::
 
             s.take('radiance').normalize().plot()
 

--- a/radis/spectrum/utils.py
+++ b/radis/spectrum/utils.py
@@ -122,6 +122,17 @@ Notes
 units for these parameters are stored in Spectrum.cond_units and are defined
 by the generating class (ex: SpectrumFactory)"""
 
+CONFIG_PARAMS = [
+    "GRIDPOINTS_PER_LINEWIDTH_WARN_THRESHOLD",
+    "GRIDPOINTS_PER_LINEWIDTH_ERROR_THRESHOLD",
+    "SPARSE_WAVERANGE",
+    "DEFAULT_DOWNLOAD_PATH",
+]
+""" list: these parameters are read from radis.config and stored in the Spectrum
+objects. Should be added here only the parameters that may have an impact on the computation,
+for instance the one defining the 'auto' thresholds
+"""
+
 # %% Util functions
 
 
@@ -256,6 +267,7 @@ def print_conditions(
     units,
     phys_param_list=PHYSICAL_PARAMS,
     info_param_list=INFORMATIVE_PARAMS,
+    config_param_list=CONFIG_PARAMS,
 ):
     """Print all Spectrum calculation parameters.
 
@@ -270,6 +282,11 @@ def print_conditions(
     info_param_list: list
         These parameters are shown below "Information" rather than "Computation
         Parameters. See :data:`~radis.spectrum.utils.INFORMATIVE_PARAMS` for more
+        information.
+
+    config_param_list: list
+        These parameters are read from radis.config file. See
+        :data:`~radis.spectrum.utils.CONFIG_PARAMS` for more
         information.
 
     See Also
@@ -323,9 +340,6 @@ def print_conditions(
         lambda x: x in info_param_list, non_phys_param
     )
 
-    import radis
-
-    config_param_list = list(radis.config.keys())
     config_param, non_phys_param = partition(
         lambda x: x in config_param_list, non_phys_param
     )

--- a/radis/spectrum/utils.py
+++ b/radis/spectrum/utils.py
@@ -319,6 +319,13 @@ def print_conditions(
         lambda x: x in info_param_list, non_phys_param
     )
 
+    import radis
+
+    config_param_list = list(radis.config.keys())
+    config_param, non_phys_param = partition(
+        lambda x: x in config_param_list, non_phys_param
+    )
+
     print("Physical Conditions")
     print("-" * 40)
     for k in sorted(phys_param):
@@ -327,6 +334,11 @@ def print_conditions(
     print("Computation Parameters")
     print("-" * 40)
     for k in sorted(non_phys_param):
+        print_param(k)
+
+    print("Config parameters")
+    print("-" * 40)
+    for k in sorted(config_param):
         print_param(k)
 
     if len(info_param) > 0:

--- a/radis/spectrum/utils.py
+++ b/radis/spectrum/utils.py
@@ -38,6 +38,7 @@ NON_CONVOLUTED_QUANTITIES = [
     "abscoeff",  # opacity
     "abscoeff_continuum",
     "emissivity_noslit",
+    "xsection",  # cross-sections
 ]
 """list: name of spectral quantities not convolved with slit function
 
@@ -174,6 +175,9 @@ def make_up(label):
         label = label.replace(
             "transmittance", "Transmittance"
         )  # make a small difference between no_slit and slit while plotting
+
+    label = label.replace("xsection", "cross-section")
+
     # ... Remove _noslit
     label = label.replace("_noslit", "")
 

--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -1536,10 +1536,17 @@ class SpecList(object):
         out: dict
             {condition:Spectrum}
 
+        Examples
+        --------
+        ::
+
+            db.get_items("Tgas")
+
         See Also
         --------
         :meth:`~radis.tools.database.SpecList.to_dict`,
-        :meth:`~radis.tools.database.SpecList.get`
+        :meth:`~radis.tools.database.SpecList.get`,
+        :py:meth:`~radis.tools.database.SpecList.create_fname_grid`
         """
 
         if not self.df[condition].is_unique:
@@ -1713,10 +1720,13 @@ class SpecList(object):
 
         import matplotlib.pyplot as plt
 
+        from radis.misc.plot import fix_style, set_style
+
         x = self.df[cond_x]
         y = self.df[cond_y]
 
         # Default
+        set_style()
         fig = plt.figure(num=nfig)
         ax = fig.gca()
         ax.plot(x, y, "ok")
@@ -1760,10 +1770,9 @@ class SpecList(object):
             )
             # lbls = plt.clabel(cs0, inline=1, fontsize=16,fmt='%.0fK',colors='k',manual=False)     # show labels
 
-            # %%
-
         plt.title(title)
         plt.tight_layout()
+        fix_style()
 
     def __len__(self):
         return len(self.df)

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatfo
 
 
 def show_message(*lines):
-    """ Note : will only happen if user installs with `pip install -v` """
+    """Note : will only happen if user installs with `pip install -v`"""
     print("=" * 74, file=sys.stderr)
     for line in lines:
         print(line, file=sys.stderr)
@@ -146,8 +146,8 @@ def show_message(*lines):
 
 def get_ext_modules(with_binaries):
     """
-    Parameter
-    ---------
+    Parameters
+    ----------
     with_binaries: bool
         if False, do not try to build Cython extensions
     """


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

- [x] Cross-sections are computed automatically from other spectral arrays (absorptino coefficient, etc.) ; or can be used to compute other spectral arrays. 

```
>>> s = radis.test_spectrum()
>>> s.plot("xsection")

COspectrum2502421670720 new quantities added: ['xsection']
```

![image](https://user-images.githubusercontent.com/16088743/146680303-9ae5f8d6-ef0f-4697-ae15-f95335e40c0d.png)



- [x]  Updates to SpecDatabase
- [x]  groundwork for the bridge to [Exo-K](http://perso.astrophy.u-bordeaux.fr/~jleconte/exo_k-doc/index.html)