### PR TITLE
major error in sparse algorithm if lines were not sorted

### DIFF
--- a/radis/io/hdf5.py
+++ b/radis/io/hdf5.py
@@ -171,7 +171,7 @@ class HDF5Manager(object):
             raise NotImplementedError(self.engine)
             # h5py is not designed to write Pandas DataFrames
 
-    def combine_temp_batch_files(self, file, key="default"):
+    def combine_temp_batch_files(self, file, key="default", sort_values=None):
         """Combine all batch files in ``self._temp_batch_files`` into one.
         Removes all batch files.
         """
@@ -184,7 +184,10 @@ class HDF5Manager(object):
             import vaex
 
             df = vaex.open(self._temp_batch_files, group=key)
-            df.export_hdf5(file, group=key, mode="w")
+            if sort_values:
+                df.sort(by=sort_values).export_hdf5(file, group=key, mode="w")
+            else:
+                df.export_hdf5(file, group=key, mode="w")
             df.close()
         self._close_temp_batch_files()
 

--- a/radis/io/hitran.py
+++ b/radis/io/hitran.py
@@ -1188,7 +1188,11 @@ class HITRANDatabaseManager(DatabaseManager):
             )  # create temporary files if required
 
         # Open all HDF5 cache files and export in a single file with Vaex
-        writer.combine_temp_batch_files(local_file)  # used for vaex mode only
+        writer.combine_temp_batch_files(
+            local_file, sort_values="wav"
+        )  # used for vaex mode only
+        # Note: by construction, in Pytables mode the database is not sorted
+        # by 'wav' but by isotope
 
         self.wmin = wmin_final
         self.wmax = wmax_final

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -1955,6 +1955,9 @@ class BaseFactory(DatabankLoader):
             )
             df["shiftwav"] = df.wav
 
+        # Sorted lines is needed for sparse wavenumber range algorithm.
+        df.sort_values("shiftwav", inplace=True)
+
         self.profiler.stop("calc_lineshift", "Calculated lineshift")
 
         return

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -1372,6 +1372,9 @@ class DatabankLoader(object):
                 + "{0:.2f}-{1:.2f} cm-1".format(wavenum_min, wavenum_max)
             )
 
+        # Always sort line database by wavenumber (required to SPARSE_WAVERANGE mode)
+        df.sort_values("wav", ignore_index=True, inplace=True)
+
         # Post-processing of the line database
         # (note : this is now done in 'fetch_hitemp' before saving to the disk)
         # spectroscopic quantum numbers will be needed for nonequilibrium calculations, and line survey.

--- a/radis/misc/arrays.py
+++ b/radis/misc/arrays.py
@@ -691,8 +691,13 @@ def boolean_array_from_ranges(ranges, n):
 )
 def sparse_add_at(ki0, Iv0, Iv1, weight, max_range, truncation_pts):
     """Returns (start, stop) of non-zero ranges, and intensity ``I`` (length
-    ``truncation_pts``) for all lines ``Iv0`` and ``Iv1`` summed at ``ki0``
-    and ``ki0+1`` with weights ``weight``"""
+    ``truncation_pts``) for all line intensities ``Iv0`` and ``Iv1`` at position ``ki0``
+    and ``ki0+1`` with weights ``weight``
+
+    .. warning::
+        ``ki0`` must be sorted.
+    """
+    assert is_sorted(ki0)
     I = np.zeros(max_range)
     L = [
         (0, 0) for k in range(0)
@@ -712,15 +717,15 @@ def sparse_add_at(ki0, Iv0, Iv1, weight, max_range, truncation_pts):
         if pos > end:
             # close the previous range:
             L.append((start, end))
-            # reopen new range :
+            # reopen new range as `[pos-n, pos+n]`:
             start = max(pos - n, 0)
             end = min(
-                pos + 1 + n, max_range
-            )  # TODO: check if not +2 because line is added on ki0 and ki1 ()
+                pos + 2 + n, max_range
+            )  # TODO:  +2 because line is added on ki0 and ki0+1
         else:
             # we're in the middle of a range:
             # keep the start, move the end
-            end = min(pos + 1 + n, max_range)
+            end = min(pos + 2 + n, max_range)
 
         # Sum intensity  (equivalent of "add-at")
         I[pos] += Iv0[i] * weight[i]


### PR DESCRIPTION
Sparse algorithm introduced in #386 , #388  [Radis 0.11](https://github.com/radis/radis/pull/400)  introduced an error in cases where the line database was not sorted in wavenumber. 

This happened in real-life scenario when : 
- downloading from HITRAN , where each isotope is downloaded one after another 
- and large spectral ranges where the sparse-mode is activated 
Typically, CO spectra. 

- or computing from ExoMol with multiple isotopes. 

No problems for HITEMP  calculations (all isotopes are stored together and already sorted). 

Fix : 

- [x] assert database is always sorted at runtime
- [x] sort lines after fetch_databank
- [x] sort lines when downloading HITRAN with vaex


Lines missing in 0.11, fixed in 0.12 : 

![image](https://user-images.githubusercontent.com/16088743/146694521-70354c37-6a67-4a42-8e13-ad8eb4887044.png)
