### PR TITLE
fix HCN import 

### DIFF
--- a/radis/io/hitran.py
+++ b/radis/io/hitran.py
@@ -94,7 +94,7 @@ def cast_to_int64_with_missing_values(dg, keys):
     """replace missing values of int64 columns with -1"""
     for c in keys:
         if dg.dtypes[c] != int64:
-            dg.loc[dg[c] == "  "] = -1  # replace empty cells by -1, e.g. HCN
+            dg.loc[dg[c] == "  ", c] = -1  # replace empty cells by -1, e.g. HCN
             dg[c] = dg[c].fillna(-1).astype(int64)
 
 

--- a/radis/io/hitran.py
+++ b/radis/io/hitran.py
@@ -94,6 +94,7 @@ def cast_to_int64_with_missing_values(dg, keys):
     """replace missing values of int64 columns with -1"""
     for c in keys:
         if dg.dtypes[c] != int64:
+            dg.loc[dg[c] == "  "] = -1  # replace empty cells by -1, e.g. HCN
             dg[c] = dg[c].fillna(-1).astype(int64)
 
 


### PR DESCRIPTION
Hello,
The following was not working  before:


```python
from radis import calc_spectrum
s = calc_spectrum(500, 2300,         # cm-1
                  molecule='HCN',
                  isotope='1',
                  pressure=1.01325,   # bar
                  Tgas=300,
                  mole_fraction=0.1,
                  databank='hitran',  # or 'hitemp'
                  )
s.plot('absorbance')
```

I just extended the cases where the vibrational numbers are replaced by "-1". Let me know if that's ok.

Related to the kind of error seen in https://github.com/radis/radis/issues/211

Happy valentine's day <3

