### PR TITLE
Add some improvements in fetch_*() documentations

### DIFF
--- a/radis/io/__init__.py
+++ b/radis/io/__init__.py
@@ -7,8 +7,16 @@
 
 
 from .cdsd import cdsd2df
+from .exomol import fetch_exomol
 from .hitemp import fetch_hitemp
-from .hitran import hit2df
+from .hitran import fetch_hitran, hit2df
 from .query import fetch_astroquery
 
-__all__ = ["cdsd2df", "hit2df", "fetch_hitemp", "fetch_astroquery"]
+__all__ = [
+    "cdsd2df",
+    "hit2df",
+    "fetch_hitemp",
+    "fetch_hitran",
+    "fetch_exomol",
+    "fetch_astroquery",
+]

--- a/radis/io/exomol.py
+++ b/radis/io/exomol.py
@@ -307,6 +307,7 @@ def fetch_exomol(
 
     See Also
     --------
+    :py:func:`~radis.io.hitran.fetch_hitran`, :py:func:`~radis.io.hitemp.fetch_hitemp`
     :py:func:`~radis.io.hdf5.hdf2df`
 
     """

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -501,7 +501,7 @@ def fetch_hitemp(
             'syml', 'Fl', 'vu', 'vl'],
             dtype='object')
 
-    .. minigallery:: radis.io.hitemp.fetch_hitemp
+    .. minigallery:: radis.fetch_hitemp
 
     Notes
     -----
@@ -513,6 +513,7 @@ def fetch_hitemp(
 
     See Also
     --------
+    :py:func:`~radis.io.hitran.fetch_hitran`, :py:func:`~radis.io.exomol.fetch_exomol`
     :py:func:`~radis.io.hdf5.hdf2df`, :py:meth:`~radis.lbl.loader.DatabankLoader.fetch_databank`
 
     """

--- a/radis/io/hitran.py
+++ b/radis/io/hitran.py
@@ -1288,8 +1288,10 @@ def fetch_hitran(
 
     Parameters
     ----------
-    molecule: `"H2O", "CO2", "N2O", "CO", "CH4", "NO", "NO2", "OH"`
-        HITEMP molecule. See https://hitran.org/hitemp/
+    molecule: str
+        one specific molecule name, listed in HITRAN molecule metadata.
+        See https://hitran.org/docs/molec-meta/
+        Example: "H2O", "CO2", etc.
     local_databases: str
         where to create the RADIS HDF5 files. Default ``"~/.radisdb/hitran"``.
         Can be changed in ``radis.config["DEFAULT_DOWNLOAD_PATH"]`` or in ~/radis.json config file
@@ -1338,15 +1340,14 @@ def fetch_hitran(
     --------
     ::
 
-        from radis import fetch_hitemp
-        df = fetch_hitemp("CO")
+        from radis.io.hitran import fetch_hitran
+        df = fetch_hitran("CO")
         print(df.columns)
         >>> Index(['id', 'iso', 'wav', 'int', 'A', 'airbrd', 'selbrd', 'El', 'Tdpair',
-            'Pshft', 'ierr', 'iref', 'lmix', 'gp', 'gpp', 'Fu', 'branch', 'jl',
-            'syml', 'Fl', 'vu', 'vl'],
+            'Pshft', 'gp', 'gpp', 'branch', 'jl', 'vu', 'vl'],
             dtype='object')
 
-    .. minigallery:: radis.io.hitemp.fetch_hitemp
+    .. minigallery:: radis.fetch_hitemp
 
     Notes
     -----
@@ -1358,6 +1359,7 @@ def fetch_hitran(
 
     See Also
     --------
+    :py:func:`~radis.io.hitemp.fetch_hitemp`, :py:func:`~radis.io.exomol.fetch_exomol`
     :py:func:`~radis.io.hdf5.hdf2df`, :py:meth:`~radis.lbl.loader.DatabankLoader.fetch_databank`
 
     """

--- a/radis/io/hitran.py
+++ b/radis/io/hitran.py
@@ -1347,7 +1347,7 @@ def fetch_hitran(
             'Pshft', 'gp', 'gpp', 'branch', 'jl', 'vu', 'vl'],
             dtype='object')
 
-    .. minigallery:: radis.fetch_hitemp
+    .. minigallery:: radis.fetch_hitran
 
     Notes
     -----


### PR DESCRIPTION
### Description

This pull request is to solve issues suggested by @erwanp 's comment [here](https://github.com/radis/radis/issues/77#issuecomment-1087403583)

As [this gallery example](https://radis.readthedocs.io/en/latest/auto_examples/plot_hitemp_OH_database.html#sphx-glr-auto-examples-plot-hitemp-oh-database-py) features both HITRAN and HITEMP fetching, I add it into gallery example sessions of both `fetch_hitran()` and `fetch_hitemp()`. When a gallery example specifically for HITRAN is available, we can use it for HITRAN one.