### PR TITLE
Implement astropy unit conversion to rescale_path_length()

### DIFF
--- a/radis/spectrum/rescale.py
+++ b/radis/spectrum/rescale.py
@@ -15,11 +15,13 @@ Equations derived from the code using `pytexit <https://pytexit.readthedocs.io/e
 from warnings import warn
 
 import numpy as np
+from astropy import units as unit
 from numpy import exp
 from numpy import log as ln
 
 from radis.misc.basics import all_in, any_in, compare_lists
 from radis.misc.debug import printdbg
+from radis.phys.units_astropy import convert_and_strip_units
 from radis.spectrum.equations import calc_radiance
 from radis.spectrum.utils import CONVOLUTED_QUANTITIES, NON_CONVOLUTED_QUANTITIES
 
@@ -2175,6 +2177,10 @@ def rescale_path_length(
         raise ValueError(
             "Rescaling to 0 will loose information. Choose force " "= True"
         )
+    # Convert units
+    new_path_length = convert_and_strip_units(new_path_length, unit.cm)
+    old_path_length = convert_and_strip_units(old_path_length, unit.cm)
+
     for q in ["transmittance", "radiance"]:
         qns = q + "_noslit"
         qties = spec.get_vars()

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -1405,6 +1405,17 @@ class Spectrum(object):
             for path in [0.1, 10, 100]:
                 s.rescale_path_length(10, inplace=False).plot(nfig='same')
 
+        Additionally, you can also use astropy units in the input arguments, for example:
+        ::
+
+            # preparing a test spectrum :
+            import radis
+            s = radis.test_spectrum()
+
+            # rescaling :
+            import astropy.units as u
+            s.rescale_path_length(1 * u.km).plot()
+
         .. minigallery:: radis.Spectrum.rescale_path_length
 
         Notes

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -1416,7 +1416,7 @@ class Spectrum(object):
             import astropy.units as u
             s.rescale_path_length(1 * u.km).plot()
 
-        .. minigallery:: radis.Spectrum.rescale_path_length
+        .. minigallery:: radis.spectrum.Spectrum.rescale_path_length
 
         Notes
         -----

--- a/radis/test/spectrum/test_rescale.py
+++ b/radis/test/spectrum/test_rescale.py
@@ -296,19 +296,15 @@ def test_astropy_units(verbose=True, warnings=True, *args, **kwargs):
     s_km = s0.copy().rescale_path_length(1 * u.km)  # Rescale directly to 1 astropy km
 
     # Get absorbance of original spectrum
-    w0, k0 = s0.get("abscoeff", wunit="cm-1")
-    L0 = s0.get_conditions()["path_length"]
-    A0 = k0 * L0
+    A0 = s0.get("absorbance", wunit="cm-1")
 
-    # Get absorbance of 100000cm-rescaled spectrum
-    w_cm, k_cm = s_cm.get("abscoeff", wunit="cm-1")
+    # Get absorbance and path length of 100000cm-rescaled spectrum
     L_cm = s_cm.get_conditions()["path_length"]
-    A_cm = k_cm * L_cm
+    A_cm = s_cm.get("absorbance", wunit="cm-1")
 
-    # Get absorbance of 1km-rescale spectrum
-    w_km, k_km = s_km.get("abscoeff", wunit="cm-1")
+    # Get absorbance and path length of 1km-rescale spectrum
     L_km = s_km.get_conditions()["path_length"]
-    A_km = k_km * L_km
+    A_km = s_km.get("absorbance", wunit="cm-1")
 
     # ---------- ASSERTION ----------
 
@@ -317,6 +313,9 @@ def test_astropy_units(verbose=True, warnings=True, *args, **kwargs):
 
     # Compare absorbances of 100000cm and 1km. They should be THE SAME.
     assert np.array_equal(A_cm, A_km)
+
+    # Compare path lengths in 1km and 100000cm. They should be THE SAME.
+    assert L_cm == L_km
 
     if verbose:
         print(

--- a/radis/test/spectrum/test_rescale.py
+++ b/radis/test/spectrum/test_rescale.py
@@ -12,6 +12,7 @@ Test Spectrum rescaling methods
 
 """
 
+import astropy.units as u
 import numpy as np
 import pytest
 
@@ -282,14 +283,59 @@ def test_xsections(*args, **kwargs):
     )
 
 
+def test_astropy_units(verbose=True, warnings=True, *args, **kwargs):
+    """This test is to assert the use of astropy units in rescale function,
+    by comparing the absorbance of a spectrum rescaled with astropy units
+    (in this test we use u.km) with the absorbance of original spectrum"""
+
+    # Get precomputed spectrum
+    s0 = load_spec(getTestFile("CO_Tgas1500K_mole_fraction0.01.spec"), binary=True)
+
+    # Generate new spectrums by rescaling original one
+    s_cm = s0.copy().rescale_path_length(100000)  # Rescale to 100000 cm = 1 km
+    s_km = s0.copy().rescale_path_length(1 * u.km)  # Rescale directly to 1 astropy km
+
+    # Get absorbance of original spectrum
+    w0, k0 = s0.get("abscoeff", wunit="cm-1")
+    L0 = s0.get_conditions()["path_length"]
+    A0 = k0 * L0
+
+    # Get absorbance of 100000cm-rescaled spectrum
+    w_cm, k_cm = s_cm.get("abscoeff", wunit="cm-1")
+    L_cm = s_cm.get_conditions()["path_length"]
+    A_cm = k_cm * L_cm
+
+    # Get absorbance of 1km-rescale spectrum
+    w_km, k_km = s_km.get("abscoeff", wunit="cm-1")
+    L_km = s_km.get_conditions()["path_length"]
+    A_km = k_km * L_km
+
+    # ---------- ASSERTION ----------
+
+    # Compare absorbances of original and 1km. They should be DIFFERENT.
+    assert not np.array_equal(A0, A_km)
+
+    # Compare absorbances of 100000cm and 1km. They should be THE SAME.
+    assert np.array_equal(A_cm, A_km)
+
+    if verbose:
+        print(
+            (
+                "Astropy units work normally in the provided test case. "
+                "The absorbances observed in original and rescaled spectrums "
+                "follow the basis of absorption spectroscopy."
+            )
+        )
+
+
 def _run_all_tests(verbose=True, warnings=True, *args, **kwargs):
     test_compression(verbose=verbose, warnings=warnings, *args, **kwargs)
     test_update_transmittance(verbose=verbose, warnings=warnings, *args, **kwargs)
     test_get_recompute(verbose=verbose, warnings=warnings, *args, **kwargs)
     test_recompute_equilibrium(verbose=verbose, warnings=warnings, *args, **kwargs)
     test_rescale_all_quantities(verbose=verbose, *args, **kwargs)
-    test_xsections()
-
+    test_xsections(*args, **kwargs)
+    test_astropy_units(verbose=True, warnings=True, *args, **kwargs)
     return True
 
 


### PR DESCRIPTION
### Description

This pull request is to address #444. Now we can use astropy units for the input arguments of `rescale_path_length()`.

Beside, currently on the RADIS documentation, `rescale_path_length()` has 2 references:

1. [radis.Spectrum.rescale_path_length](https://radis.readthedocs.io/en/latest/source/radis.html#radis.Spectrum.rescale_path_length)
2. [radis.Spectrum.rescale.rescale_path_length](https://radis.readthedocs.io/en/latest/source/radis.spectrum.rescale.html#radis.spectrum.rescale.rescale_path_length)

For [1]:

- @erwanp 's [syntax](https://github.com/radis/radis/issues/444#issue-1193462213) is added in the Examples section.
- I also notice that the gallery example for [1] does not show up on documentation. Currently the referring syntax is `.. minigallery:: radis.Spectrum.rescale_path_length`.
- Link for the source is currently not working. You can see it [here](https://radis.readthedocs.io/en/latest/source/radis.html#radis.Spectrum.rescale_path_length).

For [2], it's just kinda empty here.