### PR TITLE
Normalize() return norm factor and units option

### DIFF
--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -4311,6 +4311,7 @@ class Spectrum(object):
         inplace=False,
         force=False,
         verbose=False,
+        return_norm=False,
     ):
         """Normalise the Spectrum, if only one spectral quantity is available.
 
@@ -4404,6 +4405,8 @@ class Spectrum(object):
             out = multiply(s, 1 / (norm * Unit(norm_unit)), inplace=inplace)
         if verbose:
             print("Normalization factor : {0}".format(norm))
+        if return_norm:
+            return out, norm * Unit(norm_unit)
         return out
 
     def get_baseline(self, algorithm="als", **kwargs):


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->
Add the `return_norm` option in `spectrum.normalize()` to return the norm factor and its unit.
Usefull when rescaling mole fraction to match an experimental spectrum.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


