### PR TITLE
fix emisscoeff units conversion

### DIFF
--- a/radis/phys/units.py
+++ b/radis/phys/units.py
@@ -213,7 +213,14 @@ def convert_emi2nm(j_cm, wavenum, Iunit0, Iunit):
 # %% Radiance conversion functions (with changes from ~1/nm in ~1/cm-1)
 
 
-def convert_rad2cm(l_nm, wavenum, Iunit0, Iunit):
+def convert_rad2cm(
+    l_nm,
+    wavenum,
+    Iunit0,
+    Iunit,
+    per_nm_is_like="mW/sr/cm2/nm",
+    per_cm_is_like="mW/sr/cm2/cm-1",
+):
     """Convert spectral radiance in wavelength base (~1/nm) to spectral
     radiance in wavenumber base (~1/cm-1)
 
@@ -253,7 +260,7 @@ def convert_rad2cm(l_nm, wavenum, Iunit0, Iunit):
     Both integrals are to be the same
     """
 
-    l_nm = conv2(l_nm, Iunit0, "mW/cm2/sr/nm")
+    l_nm = conv2(l_nm, Iunit0, per_nm_is_like)
 
     # Convert ''mW/cm2/sr/nm' to 'mW/cm2/sr/cm-1'
     l_cm = l_nm * 1e7 / wavenum**2
@@ -263,12 +270,19 @@ def convert_rad2cm(l_nm, wavenum, Iunit0, Iunit):
     # But both plots look alright
 
     # Convert to whatever was wanted
-    l_cm = conv2(l_cm, "mW/cm2/sr/cm-1", Iunit)
+    l_cm = conv2(l_cm, per_cm_is_like, Iunit)
 
     return l_cm
 
 
-def convert_rad2nm(l_cm, wavenum, Iunit0, Iunit):
+def convert_rad2nm(
+    l_cm,
+    wavenum,
+    Iunit0,
+    Iunit,
+    per_nm_is_like="mW/sr/cm2/nm",
+    per_cm_is_like="mW/sr/cm2/cm-1",
+):
     """Convert spectral radiance in wavenumber base (~1/cm-1) to spectral
     radiance in wavelength base (~1/nm)
 
@@ -296,7 +310,7 @@ def convert_rad2nm(l_cm, wavenum, Iunit0, Iunit):
     so        Lλ  = - Lν * 1e-7 * ν^2
     """
 
-    l_cm = conv2(l_cm, Iunit0, "mW/cm2/sr/cm-1")
+    l_cm = conv2(l_cm, Iunit0, per_cm_is_like)
 
     # Convert 'mW/cm2/sr/cm-1' to 'mW/cm2/sr/nm'
     l_nm = l_cm * 1e-7 * wavenum**2
@@ -306,7 +320,7 @@ def convert_rad2nm(l_cm, wavenum, Iunit0, Iunit):
     # But both plots look alright
 
     # Convert to whatever was wanted
-    l_nm = conv2(l_nm, "mW/cm2/sr/nm", Iunit)
+    l_nm = conv2(l_nm, per_nm_is_like, Iunit)
 
     return l_nm
 
@@ -350,14 +364,28 @@ def convert_universal(
             Iunit, per_cm_is_like
         ):
             w_cm = spec.get_wavenumber()
-            I = convert_rad2cm(I, w_cm, Iunit0, Iunit)
+            I = convert_rad2cm(
+                I,
+                w_cm,
+                Iunit0,
+                Iunit,
+                per_nm_is_like=per_nm_is_like,
+                per_cm_is_like=per_cm_is_like,
+            )
             # note that there may still be a new DimensionalityError
             # raise here if the input was non-sense.
         elif is_homogeneous(Iunit0, per_cm_is_like) and is_homogeneous(
             Iunit, per_nm_is_like
         ):
             w_cm = spec.get_wavenumber()
-            I = convert_rad2nm(I, w_cm, Iunit0, Iunit)
+            I = convert_rad2nm(
+                I,
+                w_cm,
+                Iunit0,
+                Iunit,
+                per_nm_is_like=per_nm_is_like,
+                per_cm_is_like=per_cm_is_like,
+            )
             # note that there may still be a new DimensionalityError
             # raise here if the input was non-sense.
         else:  # general case: just convert

--- a/radis/test/spectrum/test_spectrum.py
+++ b/radis/test/spectrum/test_spectrum.py
@@ -309,27 +309,32 @@ def test_intensity_conversion(verbose=True, *args, **kwargs):
     assert allclose(I_cm, I, rtol=1e-3)
 
 
-# def test_emissivity_conversion(verbose=True, *args, **kwargs):
-#    ''' Test conversion of intensity cm-1 works:
-#
-#    - conversion of mW/sr/cm2/nm -> mW/sr/cm2/cm-1
-#
-#    '''
-#
-#    from radis.phys.units import convert_emi2nm
-#    from radis.test.utils import getTestFile
-#    from radis.tools.database import load_spec
-#
-#    s = load_spec(getTestFile('CO_Tgas1500K_mole_fraction0.01.spec'), binary=True)
-#    s.update()
-#
-#    # mW/sr/cm3/nm -> mW/sr/cm3/cm-1
-#
-#    w, I = s.get('emissivity_noslit', Iunit='mW/sr/cm3/cm-1')
-#    I_cm = convert_emi2nm(I, 'mW/sr/cm3/cm-1', 'mW/sr/m3/µm')
-#
+def test_emisscoeff_conversion(verbose=True, *args, **kwargs):
+    """Test conversion of intensity cm-1 works:
 
-# TODO: finish implementing emissivity_conversino above
+    - conversion of mW/sr/cm3/nm -> mW/sr/cm3/cm-1
+
+    """
+
+    # from radis.phys.units import convert_emi2nm
+    from radis.test.utils import getTestFile
+    from radis.tools.database import load_spec
+
+    s = load_spec(getTestFile("CO_Tgas1500K_mole_fraction0.01.spec"), binary=True)
+    s.update()
+
+    # mW/sr/cm3/nm -> mW/sr/cm3/cm-1
+
+    w_nm, I_nm = s.get("emisscoeff", Iunit="mW/sr/cm3/nm", wunit="nm")
+
+    w_cm, I_cm = s.get("emisscoeff", Iunit="mW/sr/cm3/cm-1", wunit="cm-1")
+    # I_cm = convert_emi2nm(I, 'mW/sr/cm3/cm-1', 'mW/sr/m3/µm')
+
+    import numpy as np
+
+    # compare. Integral should be the same
+    assert (I_nm != I_cm).all()
+    assert abs(np.trapz(I_nm, w_nm) / np.trapz(I_cm, -w_cm) - 1) < 0.001
 
 
 def test_rescaling_function(verbose=True, *args, **kwargs):
@@ -592,6 +597,7 @@ def _run_testcases(
     # Test conversion of intensity cm-1 works
     # -------------
     test_intensity_conversion(debug=debug, verbose=verbose, *args, **kwargs)
+    test_emisscoeff_conversion(debug=debug, verbose=verbose, *args, **kwargs)
 
     # Test updating / rescaling functions (no self absorption)
     # ---------


### PR DESCRIPTION
- fix emisscoeff units conversion  in Spectrum.get()   [ conversion from ~mW/cm3/sr/nm to ~mW/cm2/sr/cm-1 was not implemented)
- add test

fixes #454
