### PR TITLE
Exomol api update

### DIFF
--- a/docs/references/_bibliography.rst
+++ b/docs/references/_bibliography.rst
@@ -73,6 +73,9 @@ The latest HITEMP database version is automatically downloaded if using ``databa
                 exoplanet and other hot atmospheres, Journal of Quantitative Spectroscopy and Radiative Transfer 255,
                 (2020), 107228,  `doi:10.1016/j.jqsrt.2020.107228 <https://www.sciencedirect.com/science/article/abs/pii/S002240732030491X>`__
 
+.. [ExoMol-2016] Tennyson et al.,  The ExoMol database: molecular line lists for exoplanet and other hot atmospheres,
+                J. Molec. Spectrosc., 327, 73-94 (2016), `doi:10.1016/j.jms.2016.05.002 <https://arxiv.org/abs/1603.05890>`__
+
 For download and configuration of line databases, see the :ref:`Line Databases section <label_line_databases>`
 
 

--- a/examples/plot_exomol_spectrum.py
+++ b/examples/plot_exomol_spectrum.py
@@ -6,9 +6,6 @@ Calculate a spectrum from ExoMol
 
 Auto-download and compute a SiO spectrum from the ExoMol database ([ExoMol-2020]_)
 
-ExoMol lines can be downloaded and accessed separately using
-:py:func:`~radis.io.exomol.fetch_exomol`
-
 """
 
 from radis import calc_spectrum
@@ -29,14 +26,21 @@ s.apply_slit(1, "cm-1")  # simulate an experimental slit
 s.plot("radiance")
 
 
-#%% See line data:
+#%%
+
+"""ExoMol lines can be downloaded and accessed separately using
+:py:func:`~radis.io.exomol.fetch_exomol`
+"""
+
+# See line data:
 from radis.io.exomol import fetch_exomol
 
 df = fetch_exomol("SiO", database="EBJT", isotope="1", load_wavenum_max=5000)
 print(df)
 
 
-#%% See the list of recommended databases for the 1st isotope of SiO :
+#%%
+# See the list of recommended databases for the 1st isotope of SiO :
 from radis.io.exomol import get_exomol_database_list, get_exomol_full_isotope_name
 
 databases, recommended = get_exomol_database_list(

--- a/radis/io/dbmanager.py
+++ b/radis/io/dbmanager.py
@@ -134,7 +134,7 @@ class DatabaseManager(object):
                     .startswith(abspath(expanduser(local_databases).lower()))
                 ):  # TODO: replace with pathlib
                     raise ValueError(
-                        f"Databank `{self.name}` is already registered in radis.json but the declared path ({registered_path}) is not in the expected local databases folder ({local_databases}). Please fix/delete the radis.json entry, or change the default local databases path entry 'DEFAULT_DOWNLOAD_PATH' in `radis.config` or ~/radis.json"
+                        f"Databank `{self.name}` is already registered in radis.json but the declared path ({registered_path}) is not in the expected local databases folder ({local_databases}). Please fix/delete the radis.json entry, change the `databank_name`, or change the default local databases path entry 'DEFAULT_DOWNLOAD_PATH' in `radis.config` or ~/radis.json"
                     )
 
         self.downloadable = False  # by default
@@ -427,12 +427,16 @@ class DatabaseManager(object):
         columns,
         load_wavenum_min,
         load_wavenum_max,
+        output="pandas",
     ):
         """
         Other Parameters
         ----------------
         columns: list of str
             list of columns to load. If ``None``, returns all columns in the file.
+        output: 'pandas', 'vaex', 'jax'
+            format of the output DataFrame. If ``'jax'``, returns a dictionary of
+            jax arrays.
         """
         engine = self.engine
         if engine == "pytables":
@@ -447,6 +451,7 @@ class DatabaseManager(object):
                         load_wavenum_max=load_wavenum_max,
                         verbose=self.verbose,
                         engine=engine,
+                        output=output,
                     )
                 )
             return pd.concat(df_all)
@@ -461,6 +466,7 @@ class DatabaseManager(object):
                 load_wavenum_max=load_wavenum_max,
                 verbose=self.verbose,
                 engine=engine,
+                output=output,
             )
         else:
             raise NotImplementedError(engine)

--- a/radis/io/hdf5.py
+++ b/radis/io/hdf5.py
@@ -515,6 +515,7 @@ def hdf2df(
     verbose=True,
     store_kwargs={},
     engine="guess",
+    output="pandas",
 ):
     """Load a HDF5 line databank into a Pandas DataFrame.
 
@@ -539,6 +540,9 @@ def hdf2df(
     engine: ``'h5py'``, ``'pytables'``, ``'vaex'``, ``'auto'``
         which HDF5 library to use. If ``'guess'``, try to guess. Note: ``'vaex'``
         uses ``'h5py'`` compatible HDF5.
+    output: 'pandas', 'vaex', 'jax'
+        format of the output DataFrame. If ``'jax'``, returns a dictionary of
+        jax arrays.
 
     Returns
     -------
@@ -627,7 +631,27 @@ def hdf2df(
         # Load
         if columns:  # load only these columns (if they exist)
             columns = [c for c in columns if c in df.columns]
+
+    # Convert to output format
+    if output == "pandas" and engine == "vaex":
         df = df.to_pandas_df(column_names=columns)
+    elif output == "vaex" and engine == "pandas":
+        raise NotImplementedError
+    elif output == "jax":
+        if columns == None:
+            columns = ["wav", "int", "A", "El", "gpp"]
+        out = {}
+        try:
+            import jax as jnp
+        except ImportError:
+            import numpy as jnp
+        for c in columns:
+            out[c] = jnp.array(df[c].values)
+        df = out
+    elif output == engine:  # pandas > pandas; vaex -> vaex
+        df = df
+    else:
+        raise NotImplementedError(output)
 
     # Read and add metadata in the DataFrame
     metadata = manager.read_metadata(fname)
@@ -641,12 +665,18 @@ def hdf2df(
         if "wavenumber_max" in metadata:
             assert df["wav"].max() == metadata["wavenumber_max"]
 
-    if isinstance(metadata, list):
-        metadata_dict = {}
-        for k, v in metadata[0].items():
-            metadata_dict[k] = [v] + [M[k] for M in metadata[1:]]
-        metadata = metadata_dict
-    df.attrs.update(metadata)
+    # Update metadata
+    if output != "jax":
+        if isinstance(metadata, list):
+            metadata_dict = {}
+            for k, v in metadata[0].items():
+                metadata_dict[k] = [v] + [M[k] for M in metadata[1:]]
+            metadata = metadata_dict
+        if (
+            output in "vaex"
+        ):  # by default vaex.dataframe.DataFrameLocal doesn't have a .attrs attribute
+            df.attrs = {}
+        df.attrs.update(metadata)
 
     if verbose >= 3:
         from radis.misc.printer import printg

--- a/radis/io/hdf5.py
+++ b/radis/io/hdf5.py
@@ -635,7 +635,7 @@ def hdf2df(
     # Convert to output format
     if output == "pandas" and engine == "vaex":
         df = df.to_pandas_df(column_names=columns)
-    elif output == "vaex" and engine == "pandas":
+    elif output == "vaex" and engine == "pytables":
         raise NotImplementedError
     elif output == "jax":
         if columns == None:
@@ -648,7 +648,9 @@ def hdf2df(
         for c in columns:
             out[c] = jnp.array(df[c].values)
         df = out
-    elif output == engine:  # pandas > pandas; vaex -> vaex
+    elif output == engine or (
+        engine == "pytables" and output == "pandas"
+    ):  # pandas > pandas; vaex -> vaex
         df = df
     else:
         raise NotImplementedError(output)

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -436,6 +436,7 @@ def fetch_hitemp(
     clean_cache_files=True,
     return_local_path=False,
     engine="default",
+    output="pandas",
     parallel=True,
 ):
     """Stream HITEMP file from HITRAN website. Unzip and build a HDF5 file directly.
@@ -475,7 +476,10 @@ def fetch_hitemp(
     return_local_path: bool
         if ``True``, also returns the path of the local database file.
     engine: 'pytables', 'vaex', 'default'
-        which HDF5 library to use. If 'default' use the value from ~/radis.json
+        which HDF5 library to use to parse local files. If 'default' use the value from ~/radis.json
+    output: 'pandas', 'vaex', 'jax'
+        format of the output DataFrame. If ``'jax'``, returns a dictionary of
+        jax arrays.
     parallel: bool
         if ``True``, uses joblib.parallel to load database with multiple processes
 
@@ -617,6 +621,7 @@ def fetch_hitemp(
         isotope=isotope,
         load_wavenum_min=load_wavenum_min,  # for relevant files, get only the right range
         load_wavenum_max=load_wavenum_max,
+        output=output,
     )
 
     return (df, files_loaded) if return_local_path else df

--- a/radis/io/hitran.py
+++ b/radis/io/hitran.py
@@ -1283,6 +1283,7 @@ def fetch_hitran(
     clean_cache_files=True,
     return_local_path=False,
     engine="default",
+    output="pandas",
     parallel=True,
     parse_quanta=True,
 ):
@@ -1323,6 +1324,9 @@ def fetch_hitran(
         if ``True``, also returns the path of the local database file.
     engine: 'pytables', 'vaex', 'default'
         which HDF5 library to use. If 'default' use the value from ~/radis.json
+    output: 'pandas', 'vaex', 'jax'
+        format of the output DataFrame. If ``'jax'``, returns a dictionary of
+        jax arrays.
     parallel: bool
         if ``True``, uses joblib.parallel to load database with multiple processes
     parse_quanta: bool
@@ -1416,6 +1420,7 @@ def fetch_hitran(
         isotope=isotope,
         load_wavenum_min=load_wavenum_min,  # for relevant files, get only the right range
         load_wavenum_max=load_wavenum_max,
+        output=output,
     )
 
     return (df, local_file) if return_local_path else df


### PR DESCRIPTION
- avoid duplicate creation of *trans.bz2.hdf5 (without Sij0), *trans.hdf5 (with Sij0) files in ExoMol
- fail with more explicit error if missing nu_lines  (see #434)
- prepare refactor of ExoMolDb
- improve ExoMol molarmass parsing 
- fix reported errors in ExoMol definition file for C2H2. Fixes #434

Also : 
- add vaex/jax options to output a DataFrame loaded from HITRAN/HITEMP   (prepare Exojax/RADIS common API)