### PR TITLE
Chunk size implementation for DIT Algorithm loops for Broadening

### DIFF
--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -2194,16 +2194,17 @@ class BroadenFactory(BaseFactory):
         try:
             if chunksize is None:
                 # Deal with all lines directly (usually faster)
-                # printing estimated time
-                if self.verbose >= 2:
-                    estimated_time = self.predict_time()
-                    print(
-                        "Estimated time for calculating broadening: {0:.2f}s on 1 CPU".format(
-                            estimated_time
-                        )
-                    )
-
                 if optimization is None:
+
+                    # printing estimated time
+                    if self.verbose >= 2:
+                        estimated_time = self.predict_time()
+                        print(
+                            "Estimated time for calculating broadening: {0:.2f}s on 1 CPU".format(
+                                estimated_time
+                            )
+                        )
+
                     line_profile = self._calc_lineshape(df)  # usually the bottleneck
                     (wavenumber, abscoeff) = self._apply_lineshape(
                         df.S.values, line_profile, df.shiftwav.values
@@ -2217,6 +2218,16 @@ class BroadenFactory(BaseFactory):
                         wL_dat,
                         wG_dat,
                     ) = self._calc_lineshape_LDM(df)
+
+                    # printing estimated time
+                    if self.verbose >= 2:
+                        estimated_time = self.predict_time()
+                        print(
+                            "Estimated time for calculating broadening: {0:.2f}s on 1 CPU".format(
+                                estimated_time
+                            )
+                        )
+
                     (wavenumber, abscoeff) = self._apply_lineshape_LDM(
                         df.S.values,
                         line_profile_LDM,
@@ -2240,16 +2251,17 @@ class BroadenFactory(BaseFactory):
                 abscoeff = zeros_like(self.wavenumber)
                 pb = ProgressBar(N, active=self.verbose)
 
-                # printing estimated time
-                if self.verbose >= 2:
-                    estimated_time = self.predict_time()
-                    print(
-                        "Estimated time for calculating broadening: {0:.2f}s on 1 CPU".format(
-                            estimated_time
-                        )
-                    )
-
                 if optimization is None:
+
+                    # printing estimated time
+                    if self.verbose >= 2:
+                        estimated_time = self.predict_time()
+                        print(
+                            "Estimated time for calculating broadening: {0:.2f}s on 1 CPU".format(
+                                estimated_time
+                            )
+                        )
+
                     for i, (_, dg) in enumerate(df.groupby(arange(len(df)) % N)):
                         line_profile = self._calc_lineshape(dg)
                         (wavenumber, absorption) = self._apply_lineshape(

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -2166,7 +2166,7 @@ class BroadenFactory(BaseFactory):
                     line_profile_LDM, wL, wG, wL_dat, wG_dat = self._calc_lineshape_LDM(
                         df
                     )
-                    (wavenumber, absorption) = self._apply_lineshape_LDM(
+                    (wavenumber, abscoeff) = self._apply_lineshape_LDM(
                         df.S.values,
                         line_profile_LDM,
                         df.shiftwav.values,

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -2126,6 +2126,53 @@ class BroadenFactory(BaseFactory):
             line dataframe
 
         See _calc_lineshape for more information
+
+        Examples
+        ----------
+        s = calc_spectrum(
+            2135,
+            2170,
+            molecule="CO",
+            isotope="1",
+            pressure=3,
+            Tgas=2000,
+            mole_fraction=0.1,
+            path_length=1,
+            databank="hitemp",
+            name="Chunksize=1e7",
+            chunksize=1e7,
+            optimization = "min-RMS",
+        )
+
+        Alternatively, you can also initialize a SpectrumFactory object and
+        include chunksize, as follows:
+
+        sf = SpectrumFactory(
+            wavelength_min=4000,
+            wavelength_max=4500,
+            cutoff=1e-27,
+            pressure=1,
+            isotope="1,2",
+            truncation=5,
+            neighbour_lines=5,
+            path_length=0.1,
+            mole_fraction=1e-3,
+            medium="vacuum",
+            optimization=None,
+            chunksize=1e7,
+            wstep=0.001,
+            verbose=False,
+        )
+        sf.load_databank("HITEMP-CO")
+
+        To plot:
+
+        s.plot("abscoeff")
+        plt.show()
+
+        To iterate over the entire dataframe at once (not recommended for large molecules
+        unless you have large RAM), just pass chunksize = None
+
         """
         # --------------------------
 

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -2163,17 +2163,21 @@ class BroadenFactory(BaseFactory):
                     )
                 elif optimization in ("simple", "min-RMS"):
                     self.reftracker.add(doi["DIT-2020"], "algorithm")
-                    line_profile_LDM, wL, wG, wL_dat, wG_dat = self._calc_lineshape_LDM(
-                        df
-                    )
+                    (
+                        line_profile_LDM,
+                        wL_i,
+                        wG_i,
+                        wL_dat_i,
+                        wG_dat_i,
+                    ) = self._calc_lineshape_LDM(df)
                     (wavenumber, abscoeff) = self._apply_lineshape_LDM(
                         df.S.values,
                         line_profile_LDM,
                         df.shiftwav.values,
-                        wL,
-                        wG,
-                        wL_dat,
-                        wG_dat,
+                        wL_i,
+                        wG_i,
+                        wL_dat_i,
+                        wG_dat_i,
                         self.params.optimization,
                     )
                 else:
@@ -2216,19 +2220,19 @@ class BroadenFactory(BaseFactory):
                     for i, (_, dg) in enumerate(df.groupby(arange(len(df)) % N)):
                         (
                             line_profile_LDM,
-                            wL,
-                            wG,
-                            wL_dat,
-                            wG_dat,
+                            wL_i,
+                            wG_i,
+                            wL_dat_i,
+                            wG_dat_i,
                         ) = self._calc_lineshape_LDM(dg)
                         (wavenumber, absorption) = self._apply_lineshape_LDM(
                             dg.S.values,
                             line_profile_LDM,
                             dg.shiftwav.values,
-                            wL,
-                            wG,
-                            wL_dat,
-                            wG_dat,
+                            wL_i,
+                            wG_i,
+                            wL_dat_i,
+                            wG_dat_i,
                             self.params.optimization,
                         )
                         abscoeff += absorption

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -2165,19 +2165,19 @@ class BroadenFactory(BaseFactory):
                     self.reftracker.add(doi["DIT-2020"], "algorithm")
                     (
                         line_profile_LDM,
-                        wL_i,
-                        wG_i,
-                        wL_dat_i,
-                        wG_dat_i,
+                        wL,
+                        wG,
+                        wL_dat,
+                        wG_dat,
                     ) = self._calc_lineshape_LDM(df)
                     (wavenumber, abscoeff) = self._apply_lineshape_LDM(
                         df.S.values,
                         line_profile_LDM,
                         df.shiftwav.values,
-                        wL_i,
-                        wG_i,
-                        wL_dat_i,
-                        wG_dat_i,
+                        wL,
+                        wG,
+                        wL_dat,
+                        wG_dat,
                         self.params.optimization,
                     )
                 else:

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -2207,36 +2207,24 @@ class BroadenFactory(BaseFactory):
                         abscoeff += absorption
                         pb.update(i)
                     pb.done()
+
                 elif optimization in ("simple", "min-RMS"):
+
                     self.reftracker.add(doi["DIT-2020"], "algorithm")
-                    # Running a separate loop for appending to the arrays.
+                    # Iterating over the chunks of the line database
+                    # Using DIT Algorithm calculations for optimized loops
                     for i, (_, dg) in enumerate(df.groupby(arange(len(df)) % N)):
-                        if i == 0:
-                            (
-                                line_profile_LDM,
-                                wL,
-                                wG,
-                                wL_dat,
-                                wG_dat,
-                            ) = self._calc_lineshape_LDM(dg)
-                        else:
-                            (
-                                _,
-                                _,
-                                _,
-                                wL_dat_temp,
-                                wG_dat_temp,
-                            ) = self._calc_lineshape_LDM(dg)
-                            wL_dat, wG_dat = np.append(wL_dat, wL_dat_temp), np.append(
-                                wG_dat, wG_dat_temp
-                            )
-                        pb.update(i)
-                    # Feeding the updated arrays to _apply_lineshape_LDM
-                    for i, (_, dg) in enumerate(df.groupby(arange(len(df)) % N)):
+                        (
+                            line_profile_LDM,
+                            wL,
+                            wG,
+                            wL_dat,
+                            wG_dat,
+                        ) = self._calc_lineshape_LDM(dg)
                         (wavenumber, absorption) = self._apply_lineshape_LDM(
                             dg.S.values,
                             line_profile_LDM,
-                            df.shiftwav.values,
+                            dg.shiftwav.values,
                             wL,
                             wG,
                             wL_dat,
@@ -2244,7 +2232,7 @@ class BroadenFactory(BaseFactory):
                             self.params.optimization,
                         )
                         abscoeff += absorption
-
+                        pb.update(i)
                     pb.done()
                 else:
                     raise ValueError(

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -2284,26 +2284,16 @@ class BroadenFactory(BaseFactory):
         optimization = self.params.optimization
 
         try:
-            # Note @dev: typical results is:
-            # >>> abscoeff:
-            # ... Precomputed LDM lineshapes in 0.0s
-            # ... Initialized vectors in 0.0s
-            # ... Get closest matching line & fraction in 0.3s
-            # ... Distribute lines over LDM 2.1s
-            # ... Convolve and sum on spectral range 0.4s
-            # >>> emisscoeff
-            # ... Initialized vectors in 0.0s
-            # ... Get closest matching line & fraction in 0.2s
-            # ... Distribute lines over LDM 2.1s
-            # ... Convolve and sum on spectral range 0.3s
-            # @EP: #performance.
-            # unlike in the non LDM case, the nonequilibruum case here is ~2x
-            # the equilibrium case: only the closest matching line is common to the
-            # absorption & emission steps. The bottleneck is the distribution
-            # of the line over the LDM, which has to be done for both abscoeff & emisscoeff.
+            if optimization in ("simple", "min-RMS"):
+                self.reftracker.add(doi["DIT-2020"], "algorithm")
+                # Use LDM
 
-            if chunksize is None:
-                # Deal with all lines directly (usually faster)
+                if self.misc.zero_padding < 0 or self.misc.zero_padding > len(
+                    self.wavenumber_calc
+                ):
+                    self.misc.zero_padding = len(self.wavenumber_calc)
+
+                line_profile_LDM, wL, wG, wL_dat, wG_dat = self._calc_lineshape_LDM(df)
                 # printing estimated time
                 if self.verbose >= 2:
                     estimated_time = self.predict_time()
@@ -2312,8 +2302,55 @@ class BroadenFactory(BaseFactory):
                             estimated_time
                         )
                     )
+                (wavenumber, abscoeff) = self._apply_lineshape_LDM(
+                    df.S.values,
+                    line_profile_LDM,
+                    df.shiftwav.values,
+                    wL,
+                    wG,
+                    wL_dat,
+                    wG_dat,
+                    optimization,
+                )
+                (_, emisscoeff) = self._apply_lineshape_LDM(
+                    df.Ei.values,
+                    line_profile_LDM,
+                    df.shiftwav.values,
+                    wL,
+                    wG,
+                    wL_dat,
+                    wG_dat,
+                    optimization,
+                )
+                # Note @dev: typical results is:
+                # >>> abscoeff:
+                # ... Precomputed LDM lineshapes in 0.0s
+                # ... Initialized vectors in 0.0s
+                # ... Get closest matching line & fraction in 0.3s
+                # ... Distribute lines over LDM 2.1s
+                # ... Convolve and sum on spectral range 0.4s
+                # >>> emisscoeff
+                # ... Initialized vectors in 0.0s
+                # ... Get closest matching line & fraction in 0.2s
+                # ... Distribute lines over LDM 2.1s
+                # ... Convolve and sum on spectral range 0.3s
+                # @EP: #performance.
+                # unlike in the non LDM case, the nonequilibruum case here is ~2x
+                # the equilibrium case: only the closest matching line is common to the
+                # absorption & emission steps. The bottleneck is the distribution
+                # of the line over the LDM, which has to be done for both abscoeff & emisscoeff.
 
-                if optimization is None:
+            elif optimization is None:
+                # printing estimated time
+                if self.verbose >= 2:
+                    estimated_time = self.predict_time()
+                    print(
+                        "Estimated time for calculating broadening: {0:.2f}s on 1 CPU".format(
+                            estimated_time
+                        )
+                    )
+                if chunksize is None:
+                    # Deal with all lines directly (usually faster)
                     line_profile = self._calc_lineshape(df)  # usually the bottleneck
                     (wavenumber, abscoeff) = self._apply_lineshape(
                         df.S.values, line_profile, df.shiftwav.values
@@ -2321,118 +2358,28 @@ class BroadenFactory(BaseFactory):
                     (_, emisscoeff) = self._apply_lineshape(
                         df.Ei.values, line_profile, df.shiftwav.values
                     )
-                elif optimization in ("simple", "min-RMS"):
 
-                    self.reftracker.add(doi["DIT-2020"], "algorithm")  # Use LDM
-                    if self.misc.zero_padding < 0 or self.misc.zero_padding > len(
-                        self.wavenumber_calc
-                    ):
-                        self.misc.zero_padding = len(self.wavenumber_calc)
+                elif is_float(chunksize):
+                    # Cut lines in smaller bits for better memory handling
 
-                    (
-                        line_profile_LDM,
-                        wL,
-                        wG,
-                        wL_dat,
-                        wG_dat,
-                    ) = self._calc_lineshape_LDM(df)
+                    # Get size of numpy array for vectorialization
+                    N = int(len(df) * len(wavenumber) / chunksize) + 1
+                    # Too big may be faster but overload memory.
+                    # See Performance for more information
 
-                    (wavenumber, abscoeff) = self._apply_lineshape_LDM(
-                        df.S.values,
-                        line_profile_LDM,
-                        df.shiftwav.values,
-                        wL,
-                        wG,
-                        wL_dat,
-                        wG_dat,
-                        optimization,
-                    )
-                    (_, emisscoeff) = self._apply_lineshape_LDM(
-                        df.Ei.values,
-                        line_profile_LDM,
-                        df.shiftwav.values,
-                        wL,
-                        wG,
-                        wL_dat,
-                        wG_dat,
-                        optimization,
-                    )
-                else:
-                    raise ValueError(
-                        "Unexpected value for optimization: {0}".format(optimization)
-                    )
+                    abscoeff = zeros_like(self.wavenumber)
+                    emisscoeff = zeros_like(self.wavenumber)
 
-            elif is_float(chunksize):
-                # Cut lines in smaller bits for better memory handling
-                N = int(len(df) * len(wavenumber) / chunksize) + 1
-                # Too big may be faster but overload memory.
-                # See Performance for more information
-                abscoeff = zeros_like(self.wavenumber)
-                emisscoeff = zeros_like(self.wavenumber)
-
-                pb = ProgressBar(N, active=self.verbose)
-
-                # printing estimated time
-                if self.verbose >= 2:
-                    estimated_time = self.predict_time()
-                    print(
-                        "Estimated time for calculating broadening: {0:.2f}s on 1 CPU".format(
-                            estimated_time
-                        )
-                    )
-                if optimization is None:
+                    pb = ProgressBar(N, active=self.verbose)
                     for i, (_, dg) in enumerate(df.groupby(arange(len(df)) % N)):
                         line_profile = self._calc_lineshape(dg)
                         (wavenumber, absorption) = self._apply_lineshape(
                             dg.S.values, line_profile, dg.shiftwav.values
                         )
                         (_, emission) = self._apply_lineshape(
-                            df.Ei.values, line_profile, df.shiftwav.values
+                            dg.Ei.values, line_profile, dg.shiftwav.values
                         )
-                        abscoeff += absorption
-                        emisscoeff += emission
-                        pb.update(i)
-                    pb.done()
-
-                elif optimization in ("simple", "min-RMS"):
-
-                    self.reftracker.add(doi["DIT-2020"], "algorithm")
-
-                    if self.misc.zero_padding < 0 or self.misc.zero_padding > len(
-                        self.wavenumber_calc
-                    ):
-                        self.misc.zero_padding = len(self.wavenumber_calc)
-                    # Iterating over the chunks of the line database
-                    # Using DIT Algorithm calculations for optimized loops
-                    for i, (_, dg) in enumerate(df.groupby(arange(len(df)) % N)):
-                        (
-                            line_profile_LDM,
-                            wL_i,
-                            wG_i,
-                            wL_dat_i,
-                            wG_dat_i,
-                        ) = self._calc_lineshape_LDM(dg)
-                        (wavenumber, absorption) = self._apply_lineshape_LDM(
-                            dg.S.values,
-                            line_profile_LDM,
-                            dg.shiftwav.values,
-                            wL_i,
-                            wG_i,
-                            wL_dat_i,
-                            wG_dat_i,
-                            self.params.optimization,
-                        )
-                        (_, emission) = self._apply_lineshape_LDM(
-                            dg.Ei.values,
-                            line_profile_LDM,
-                            dg.shiftwav.values,
-                            wL_i,
-                            wG_i,
-                            wL_dat_i,
-                            wG_dat_i,
-                            optimization,
-                        )
-                        abscoeff += absorption
+                        abscoeff += absorption  #
                         emisscoeff += emission
                         pb.update(i)
                     pb.done()

--- a/radis/lbl/calc.py
+++ b/radis/lbl/calc.py
@@ -55,6 +55,7 @@ def calc_spectrum(
     cutoff=1e-27,
     parsum_mode="full summation",
     optimization="simple",
+    chunksize=None,
     broadening_method="voigt",
     overpopulation=None,
     name=None,
@@ -532,6 +533,7 @@ def calc_spectrum(
             cutoff=cutoff,
             parsum_mode=parsum_mode,
             optimization=optimization,
+            chunksize=chunksize,
             broadening_method=broadening_method,
             name=name,
             use_cached=use_cached,
@@ -586,6 +588,7 @@ def _calc_spectrum_one_molecule(
     cutoff,
     parsum_mode,
     optimization,
+    chunksize,
     broadening_method,
     name,
     use_cached,
@@ -628,8 +631,8 @@ def _calc_spectrum_one_molecule(
         # factory is used once only
         kwargs["save_memory"] = True
 
-    if "chunksize" in kwargs:
-        raise DeprecationWarning("use optimization= instead of chunksize=")
+    # if "chunksize" in kwargs:
+    #     raise DeprecationWarning("use optimization= instead of chunksize=")
 
     def _is_at_equilibrium():
         try:
@@ -665,6 +668,7 @@ def _calc_spectrum_one_molecule(
         parsum_mode=parsum_mode,
         verbose=verbose,
         optimization=optimization,
+        chunksize=chunksize,
         broadening_method=broadening_method,
         export_lines=export_lines,
         **kwargs,

--- a/radis/spectrum/operations.py
+++ b/radis/spectrum/operations.py
@@ -1089,11 +1089,11 @@ def get_baseline(
     w1, I1 = s.get(var=var, wunit=wunit, Iunit=Iunit)
 
     if algorithm == "polynomial":
-        import peakutils
+        from radis.misc.signal import baseline
 
         polyargs = {"deg": 1, "max_it": 500}
         polyargs.update(kwargs)
-        baseline = peakutils.baseline(I1, **polyargs)
+        baseline = baseline(I1, **polyargs)
     elif algorithm == "als":
         from radis.misc.signal import als_baseline
 

--- a/radis/test/lbl/test_broadening.py
+++ b/radis/test/lbl/test_broadening.py
@@ -974,12 +974,14 @@ def test_broadening_chunksize_eq(verbose=True, plot=False, *args, **kwargs):
         sf.params["optimization"] = optimization  # Setting optimization
         sf.misc["chunksize"] = None
         s_no_chunk = sf.eq_spectrum(Tgas=Tgas)
-        s_no_chunk.name  = "no chunksize"
-        assert s_no_chunk.c["chunksize"] is None  #make sure it was taken into account in Spectrum conditions
-        
+        s_no_chunk.name = "no chunksize"
+        assert (
+            s_no_chunk.c["chunksize"] is None
+        )  # make sure it was taken into account in Spectrum conditions
+
         sf.misc["chunksize"] = 1e5  # Setting chunksize
         s_chunk = sf.eq_spectrum(Tgas=Tgas)
-        s_chunk.name  = f"chunksize {chunksize:.1e}"
+        s_chunk.name = f"chunksize {sf.misc.chunksize:.1e}"
         assert s_chunk.c["chunksize"] == 1e5
 
         # Residual calculation

--- a/radis/test/lbl/test_broadening.py
+++ b/radis/test/lbl/test_broadening.py
@@ -973,11 +973,14 @@ def test_broadening_chunksize_eq(verbose=True, plot=False, *args, **kwargs):
     for optimization in [None, "simple", "min-RMS"]:
         sf.params["optimization"] = optimization  # Setting optimization
         sf.misc["chunksize"] = None
-
-        s_chunk = sf.eq_spectrum(Tgas=Tgas)
-
-        sf.misc["chunksize"] = 1e5  # Setting chunksize
         s_no_chunk = sf.eq_spectrum(Tgas=Tgas)
+        s_no_chunk.name  = "no chunksize"
+        assert s_no_chunk.c["chunksize"] is None  #make sure it was taken into account in Spectrum conditions
+        
+        sf.misc["chunksize"] = 1e5  # Setting chunksize
+        s_chunk = sf.eq_spectrum(Tgas=Tgas)
+        s_chunk.name  = f"chunksize {chunksize:.1e}"
+        assert s_chunk.c["chunksize"] == 1e5
 
         # Residual calculation
         res = get_residual(s_no_chunk, s_chunk, "abscoeff")


### PR DESCRIPTION
### Objectives
This pull request is to address the chunksize implementation in DIT Algorithm(optimized) loops in the [_broaden_lines](https://github.com/radis/radis/blob/develop/radis/lbl/broadening.py#:~:text=def%20_broaden_lines(self%2C%20df)%3A) method. 
With this PR, RADIS users shall be able to fully utilize the Chunksize feature in the code. Instead of looping the entire DataFrame, we use chunks of it at a time, hence allowing for much better memory management!

### Changes Made
- I restructured the code such that the outer loops check for the chunksize variable, since I think that it'll improve code readability. I've only added the time prediction block of code twice at the start of each loop.
- Arrays are being updated according to the Chunksize.
- Chunksize is now a parameter in [calc_spectrum()](https://github.com/radis/radis/blob/b853a26b34a0b9b53670062a2214da4d134ec391/radis/lbl/calc.py#L38) and [calc_spectrum_one_molecule()](https://github.com/radis/radis/blob/b853a26b34a0b9b53670062a2214da4d134ec391/radis/lbl/calc.py#L568)

### Future Objectives
- [ ] Support for non-equilibrium loops as well (see [_broaden_lines_noneq](https://github.com/radis/radis/blob/b853a26b34a0b9b53670062a2214da4d134ec391/radis/lbl/broadening.py#L2231))
- [ ] Add an "auto" parameter for chunksize, which will calculate the best chunksize based on user-RAM.


Fixes #488 