### PR TITLE
Fixing the case when the chunksize is too small

### DIFF
--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -2255,10 +2255,14 @@ class BroadenFactory(BaseFactory):
                     assert N < len(df)
                 except AssertionError:
                     self.warn(
-                        "Chunksize is currently too small according"
-                        + " to the dataframe size. Please set a larger"
-                        + " value of chunksize.",
-                        "PerformanceWarning",
+                        "There are currently more chunks ({0:.3e}) than lines ({1:.3e}),".format(
+                            N, len(df)
+                        )
+                        + " calculation times will be extremely slow. Try to have at least 10,000 - 100,000"
+                        + " lines per chunk. We suggest increasing chunksize to"
+                        + " {0:.1e} - {1:.1e}".format(
+                            10000 * len(wavenumber), 100000 * len(wavenumber)
+                        ),
                     )
 
                 abscoeff = zeros_like(self.wavenumber)

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -2248,6 +2248,19 @@ class BroadenFactory(BaseFactory):
                 N = int(len(df) * len(wavenumber) / chunksize) + 1
                 # Too big may be faster but overload memory.
                 # See Performance for more information
+
+                # Raise performance warning if the chunks are bigger
+                # than the number of lines.
+                try:
+                    assert N < len(df)
+                except AssertionError:
+                    self.warn(
+                        "Chunksize is currently too small according"
+                        + " to the dataframe size. Please set a larger"
+                        + " value of chunksize.",
+                        "PerformanceWarning",
+                    )
+
                 abscoeff = zeros_like(self.wavenumber)
                 pb = ProgressBar(N, active=self.verbose)
 

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -2251,9 +2251,7 @@ class BroadenFactory(BaseFactory):
 
                 # Raise performance warning if the chunks are bigger
                 # than the number of lines.
-                try:
-                    assert N < len(df)
-                except AssertionError:
+                if N >= len(df):
                     self.warn(
                         "There are currently more chunks ({0:.3e}) than lines ({1:.3e}),".format(
                             N, len(df)
@@ -2263,6 +2261,7 @@ class BroadenFactory(BaseFactory):
                         + " {0:.1e} - {1:.1e}".format(
                             10000 * len(wavenumber), 100000 * len(wavenumber)
                         ),
+                        "PerformanceWarning",
                     )
 
                 abscoeff = zeros_like(self.wavenumber)

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -2253,14 +2253,15 @@ class BroadenFactory(BaseFactory):
                 # than the number of lines.
                 if N >= len(df):
                     self.warn(
-                        "There are currently more chunks ({0:.3e}) than lines ({1:.3e}),".format(
-                            N, len(df)
-                        )
-                        + " calculation times will be extremely slow. Try to have at least 10,000 - 100,000"
-                        + " lines per chunk. We suggest increasing chunksize to"
+                        "We suggest increasing chunksize to"
                         + " {0:.1e} - {1:.1e}".format(
                             10000 * len(wavenumber), 100000 * len(wavenumber)
-                        ),
+                        )
+                        + " to speed up calculations. Currently, there are more chunks"
+                        + " ({0:.3e}) than lines ({1:.3e}).".format(N, len(df))
+                        + " Hence, calculation times will be extremely slow, since broadening will be"
+                        + " calculated using only one line per iteration. Ideally, 10,000 - 100,000"
+                        + " lines per chunk are recommended.",
                         "PerformanceWarning",
                     )
 


### PR DESCRIPTION
### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address the case of small chunksize as mentioned by @erwanp. 
When the input chunksize is too small, the intermediate chunks(dg) can be of length equal to 1, resulting in a huge number of iterations.
Here, we assert that the number of groups should be less than the size of the dataframe(df), and raise a PerformanceWarning otherwise.

Related to #489
