### PR TITLE
Add some small docs/examples

### DIFF
--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -1476,6 +1476,7 @@ class SpectrumFactory(BandFactory):
             wavenum_max=3000,
             molecule="CO",
             isotope="1,2,3",
+            wstep="auto"
             )
             sf.fetch_databank("hitemp", load_columns='noneq')
 

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -1000,6 +1000,9 @@ class DatabankLoader(object):
             .. warning::
                 if using ``'equilibrium'``, not all parameters will be available
                 for a Spectrum :py:func:`~radis.spectrum.spectrum.Spectrum.line_survey`.
+                If you are calculating equilibrium (LTE) spectra, it is recommended to
+                use ``'equilibrium'``. If you are calculating non-LTE spectra, it is
+                recommended to use ``'noneq'``.
 
         Notes
         -----


### PR DESCRIPTION
This pull request is to address #496 . My apologies, Mr. @erwanp, for missing this issue, and also missing the chance to include it in 0.13.1 release last night. Several things in th PR:

- Add several lines within the doc of `fetch_databank()` about using `load_columns = "noneq"` when doing non-LTE calculations with `non_eq_spectrum`.
- I also intended to fix the example, but someone did it already. When I tried to run the updated, an accuracy error popped up, about "some lines are too small for the default wstep" or something like that, so I added `wstep = "auto"` into the code to make it run.
- You also suggested [here](https://github.com/radis/radis/issues/496#issuecomment-1191083134) to catch the error and return a suggestion, but the code already did that, as shown in the issue's description:
```
KeyError: "`branch` not defined in database (['wav', 'int', 'A', 'airbrd', 'selbrd', 'Tdpair', 'Pshft', 'El', 'gp']). Make sure you properly load parameters required for non-LTE calculations by adding `load_columns=['branch', ...]` or simply `load_columns='noneq'` in fetch_databank / load_databank()"
```
So, do you think we need to add another suggestion?