### PR TITLE
add explicit warning/error message if line with 0-cm-1 broadening

### DIFF
--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -1434,6 +1434,15 @@ class BroadenFactory(BaseFactory):
 
         def _init_w_axis(w_dat, log_p):
             w_min = w_dat.min()
+            if w_min == 0:
+                self.warn(
+                    f"{(w_dat==0).sum()}"
+                    + " line(s) had a calculated broadening of 0 cm-1. Check the database. At least this line is faulty: \n\n"
+                    + "{}".format(self.df1.iloc[(w_min == 0).argmax()])
+                    + "\n\nIf you want to ignore, use `warnings['ZeroBroadeningWarning'] = 'ignore'`",
+                    category="ZeroBroadeningWarning",
+                )
+                w_min = w_dat[w_dat > 0].min()
             w_max = (
                 w_dat.max() + 1e-4
             )  # Add small number to prevent w_max falling outside of the grid

--- a/radis/misc/warning.py
+++ b/radis/misc/warning.py
@@ -143,6 +143,15 @@ class MissingSelfBroadeningWarning(UserWarning):
     pass
 
 
+class ZeroBroadeningWarning(UserWarning):
+    """At least one line has a calculated broadening of 0
+
+    See :py:meth:`~radis.lbl.broadening.BroadenFactory._calc_lineshape_LDM`
+    """
+
+    pass
+
+
 class MissingPressureShiftWarning(UserWarning):
     """Pressure-shift coefficient is missing in Line Database."""
 
@@ -214,6 +223,7 @@ WarningClasses = {
     "NegativeEnergiesWarning": NegativeEnergiesWarning,
     "MissingSelfBroadeningTdepWarning": MissingSelfBroadeningTdepWarning,
     "MissingSelfBroadeningWarning": MissingSelfBroadeningWarning,
+    "ZeroBroadeningWarning": ZeroBroadeningWarning,
     "MissingPressureShiftWarning": MissingPressureShiftWarning,
     "LinestrengthCutoffWarning": LinestrengthCutoffWarning,
     "InputConditionsWarning": InputConditionsWarning,
@@ -261,6 +271,7 @@ default_warning_status = {
     # warning if self-broadening abs coefficnet missing (Air is used instead)
     "MissingSelfBroadeningTdepWarning": "warn",
     "MissingSelfBroadeningWarning": "warn",
+    "ZeroBroadeningWarning": "warn",
     "MissingPressureShiftWarning": "warn",
     "InputConditionsWarning": "warn",
     "DeprecatedFileWarning": "warn",


### PR DESCRIPTION
Fixes #521



Returns explicit error message + ignore the lines : 

```
d:\github\radis\radis\misc\warning.py:365: ZeroBroadeningWarning: 1line(s) had a calculated broadening of 0 cm-1. Check the database. At least this line is faulty: 

iso             1.000000e+00
wav             9.998551e+02
int             4.005000e-30
A               2.017000e-03
airbrd          4.100000e-02
selbrd          5.500000e-02
Tdpair          5.700000e-01
Pshft          -2.000000e-03
El              3.906668e+03
gp              1.590000e+02
S               1.560973e-25
shiftwav        9.998531e+02
hwhm_voigt      2.259427e-02
hwhm_lorentz    2.203425e-02
hwhm_gauss      3.432419e-03
Name: 1, dtype: float64
```