### PR TITLE
Removing completed TODO in radis/lbl/calc.py

### DIFF
--- a/radis/lbl/calc.py
+++ b/radis/lbl/calc.py
@@ -470,7 +470,7 @@ def calc_spectrum(
                             molecule,
                             argument_name,
                             molecule_reference_set,
-                            argument_dict.keys())
+                            set(argument_dict.keys()))
                     )
             else:  # argument_name is not a dictionary.
                 # Let's distribute the same value to every molecule:

--- a/radis/lbl/calc.py
+++ b/radis/lbl/calc.py
@@ -461,17 +461,7 @@ def calc_spectrum(
         for argument_name, argument_dict in DICT_INPUT_ARGUMENTS.items():
             if isinstance(argument_dict, dict):
                 # Choose the correspond value
-                try:
-                    molecule_dict[molecule][argument_name] = argument_dict[molecule]
-                except KeyError:
-                    # KeyError is raised if a molecule is missing from the dictionary
-                    raise KeyError(
-                        "'{0}'' missing in '{1}=' argument. For reference, here are the molecules provided in the following arguments: 'molecule=' {2} and '{1}=' {3}".format(
-                            molecule,
-                            argument_name,
-                            molecule_reference_set,
-                            set(argument_dict.keys()))
-                    )
+                molecule_dict[molecule][argument_name] = argument_dict[molecule]
             else:  # argument_name is not a dictionary.
                 # Let's distribute the same value to every molecule:
                 molecule_dict[molecule][argument_name] = argument_dict

--- a/radis/lbl/calc.py
+++ b/radis/lbl/calc.py
@@ -461,9 +461,17 @@ def calc_spectrum(
         for argument_name, argument_dict in DICT_INPUT_ARGUMENTS.items():
             if isinstance(argument_dict, dict):
                 # Choose the correspond value
-                molecule_dict[molecule][argument_name] = argument_dict[molecule]
-                # Will raise a KeyError if not defined. That's fine!
-                # TODO: maybe need to catch KeyError and raise a better error message?
+                try:
+                    molecule_dict[molecule][argument_name] = argument_dict[molecule]
+                except KeyError:
+                    # KeyError is raised if a molecule is missing from the dictionary
+                    raise KeyError(
+                        "'{0}'' missing in '{1}=' argument. For reference, here are the molecules provided in the following arguments: 'molecule=' {2} and '{1}=' {3}".format(
+                            molecule,
+                            argument_name,
+                            molecule_reference_set,
+                            argument_dict.keys())
+                    )
             else:  # argument_name is not a dictionary.
                 # Let's distribute the same value to every molecule:
                 molecule_dict[molecule][argument_name] = argument_dict


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address a TODO found in radis/lbl/calc.py. The change catches and raises a KeyError when a molecule is missing from a dictionary (isotope, mole_fraction, databank, or overpopulation) for calc_spectrum. The raised error message informs the user of which molecule and dictionary caused the KeyError and also tries to provide some additional context.

Here are the comments of the TODO for reference (found on lines 465 and 466 main branch's calc.py):
\# Will raise a KeyError if not defined. That's fine!
\# TODO: maybe need to catch KeyError and raise a better error message?

This is my first OSS contribution. Any help or input is appreciated.
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
