### PR TITLE
number of trans files in H3O_p/Exomol error manually fixed

### DIFF
--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -129,6 +129,8 @@ def read_def(deff):
     # SOME DEF FILES CONTAINS ERRORS. THESE ARE THE EXCEPTIONS
     if deff.stem == "12C-16O2__UCL-4000":
         ntransf = 20
+    if deff.stem == "1H3-16O_p__eXeL":
+        ntransf = 100
     if deff.stem == "14N-1H3__CoYuTe":
         maxnu = 20000.0
     if deff.stem == "12C2-1H2__aCeTY":

--- a/radis/db/classes.py
+++ b/radis/db/classes.py
@@ -300,6 +300,7 @@ assert EXOMOL_ONLY_ISOTOPES_NAMES[("FeH", 1)] == "56Fe-1H"
 assert EXOMOL_ONLY_ISOTOPES_NAMES[("SiO", 1)] == "28Si-16O"
 assert EXOMOL_ONLY_ISOTOPES_NAMES[("CN", 1)] == "12C-14N"
 
+
 EXOMOL_MOLECULES = [
     "AlCl",
     "AlF",


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address a wrong value in [def file of H3O_p in Exomol](https://www.exomol.com/db/H3O_p/1H3-16O_p/eXeL/1H3-16O_p__eXeL.def). 

```
101                                                                             # No. of transition files
```

The actual number is 100. So, this mistake occurs a loading error of transition files. I fixed it to add a manual exception in `exomolapi.py`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


