### PR TITLE
 added double axis and updated exomol molecules list and get_molecule method of DataFileManager class

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: isort
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.7.9
     hooks:
       - id: flake8

--- a/radis/api/hdf5.py
+++ b/radis/api/hdf5.py
@@ -205,7 +205,7 @@ class DataFileManager(object):
 
             # by default vaex does not load everything
             df = vaex.open(local_file)
-            columns = df.columns
+            columns = df.column_names
             df.close()
 
         elif engine == "pytables":

--- a/radis/db/classes.py
+++ b/radis/db/classes.py
@@ -391,6 +391,9 @@ EXOMOL_MOLECULES = [
     "YO",
     "cis-P2H2",
     "trans-P2H2",
+    "ZrO",
+    "K",
+    "Na",
 ]
 EXOMOL_ONLY_MOLECULES = sorted(
     list(set([M for M, iso in EXOMOL_ONLY_ISOTOPES_NAMES.keys()]))

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -2163,21 +2163,17 @@ class Spectrum(object):
         if "label" in kwargs:
             ax.legend()
         fix_style()
-
-        def waveLength2waveNumber(x):
-            return 1e4/x
-
-        def waveNumber2waveLength(x):
-            return 1e4/x
-
-        print(xlabel)
-        print(ylabel)
-
+        
+        from radis.phys.convert import cm2nm , nm2cm
         if "cm⁻¹" in ylabel:
-            secx=ax.secondary_xaxis('top',functions=(waveNumber2waveLength, waveLength2waveNumber))
-            secx.set_xlabel('Wavelength (μm)')
-        elif "μm" in ylabel:
-            secx=ax.secondary_xaxis('top',functions=(waveLength2waveNumber, waveNumber2waveLength))
+            secx=ax.secondary_xaxis('top',functions=(cm2nm, nm2cm))
+            secx.set_xlabel('Wavelength (nm)')
+        elif "nm" in ylabel:
+            if wunit=="nm" or wunit=="nm_air":
+                secx=ax.secondary_xaxis('top',functions=(nm2cm, cm2nm))
+            else:
+                from radis.phys.convert import cm2nm_air,nm_air2cm
+                secx=ax.secondary_xaxis('top',functions=(nm_air2cm, cm2nm_air))
             secx.set_xlabel('wavenumber (cm⁻¹)')
 
         # Add plotting tools

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -2096,10 +2096,16 @@ class Spectrum(object):
             Iunit = "norm"
 
         set_style()
-        if nfig == "same":
-            nfig = plt.gcf().number
-        fig = plt.figure(nfig)
-
+        
+        
+        fig, ax = plt.subplots(constrained_layout=True)
+            
+        # if nfig== "same":
+        #     ax=fig.subplot(nfig)
+        #     print(ax)
+        # else:
+        #     ax=fig.add_subplot()
+        
         # If figure exist, ensures xlabel and ylabel are the same (prevents some
         # users errors if plotting difference units!)... Note that since
         # 'radiance' and 'radiance_noslit' are now plotted under the same name,
@@ -2140,22 +2146,39 @@ class Spectrum(object):
         # Actual plot :
         # ... note: '-k' by default with style origin for first plot
         if not plot_by_parts:
-            (line,) = plt.plot(x, y, label=label, **kwargs)
+            (line,) = ax.plot(x, y, label=label, **kwargs)
         else:
             (line,) = split_and_plot_by_parts(x, y, ax=fig.gca(), label=label, **kwargs)
             # note: split_and_plot_by_parts pops 'cutwing' & 'split_threshold' from kwargs
 
         if show_points:
-            plt.plot(x, y, "o", color="lightgrey", **kwargs)
+            ax.plot(x, y, "o", color="lightgrey", **kwargs)
 
+    
         # Labels
-        plt.ticklabel_format(useOffset=False, axis="x")
-        plt.xlabel(xlabel)
-        plt.ylabel(ylabel)
-        plt.yscale(yscale)
+        ax.ticklabel_format(useOffset=False, axis="x")
+        ax.set_xlabel(xlabel)
+        ax.set_ylabel(ylabel)
+        ax.set_yscale(yscale)
         if "label" in kwargs:
-            plt.legend()
+            ax.legend()
         fix_style()
+
+        def waveLength2waveNumber(x):
+            return 1e4/x
+
+        def waveNumber2waveLength(x):
+            return 1e4/x
+
+        print(xlabel)
+        print(ylabel)
+
+        if "cm⁻¹" in ylabel:
+            secx=ax.secondary_xaxis('top',functions=(waveNumber2waveLength, waveLength2waveNumber))
+            secx.set_xlabel('Wavelength (μm)')
+        elif "μm" in ylabel:
+            secx=ax.secondary_xaxis('top',functions=(waveLength2waveNumber, waveNumber2waveLength))
+            secx.set_xlabel('wavenumber (cm⁻¹)')
 
         # Add plotting tools
         # ... Add cursor

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -2098,14 +2098,11 @@ class Spectrum(object):
         set_style()
         
         
-        fig, ax = plt.subplots(constrained_layout=True)
             
-        # if nfig== "same":
-        #     ax=fig.subplot(nfig)
-        #     print(ax)
-        # else:
-        #     ax=fig.add_subplot()
-        
+        if nfig == "same":
+            nfig = plt.gcf().number
+        fig = plt.figure(nfig)
+
         # If figure exist, ensures xlabel and ylabel are the same (prevents some
         # users errors if plotting difference units!)... Note that since
         # 'radiance' and 'radiance_noslit' are now plotted under the same name,
@@ -2142,6 +2139,9 @@ class Spectrum(object):
         # Add a label. Not shown by default but User can set it if using plt.legend()
         # (useful when plotting multiple plots on same figure)
         label = kwargs.pop("label", self.get_name())
+
+
+        ax=fig.gca()
 
         # Actual plot :
         # ... note: '-k' by default with style origin for first plot


### PR DESCRIPTION
This is to solve issuse https://github.com/radis/radis/issues/446 on Radis repository
Also, I have updated Exomol Molecules list and added ZrO, Na and K in it the list.
Plot with double axis (nm, cm-1) https://github.com/radis/radis/issues/446

It provides the secondary or double x axis at the top of plot
-When the plot is between wavenumber(cm-1 )vs radiance , it adds a secondary axis for wavelength(nm)
-When the plot is between radiance vs wavelenght , it also adds a secondary axis for wavenumber(cm-1)

Fixes https://github.com/radis/radis/issues/446

 
![Screenshot from 2023-01-16 01-09-20](https://user-images.githubusercontent.com/78527441/212563352-f359d2db-cec6-457c-a941-9b08be81e72b.png)


Edit : Updated code to use functions defined in .pysics.convert and now wavelength is obtained depending upon whether medium is air or vaccum