### PR TITLE
prevent imax index from exceeding the range

### DIFF
--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -1267,6 +1267,8 @@ class MdbExomol(DatabaseManager):
                 np.searchsorted(dic_def["numinf"], nurange[1] + margin, side="right")
                 - 1
             )
+            # not to exceed index out of the range
+            imax = np.min([imax, len(dic_def["numinf"])-2])
             self.trans_file = []
             self.num_tag = []
 


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

I am Yui Kawashima, and involved in the development of exojax. I have just realized that when the highest value of the wavenumber grid exceeds the range of the molecular line list, imax is set outside the range [here](https://github.com/radis/radis/blob/0ea4672952a459393ef3384effe5abdc1de862fa/radis/api/exomolapi.py#L1266). So I would like to send a pull request to avoid this. An example script you can check is as follows. Thank you in advance.
```
from exojax.spec import api
from exojax.spec import defmol
from exojax.utils.grids import wavenumber_grid

db_dir = defmol.search_molfile("ExoMol", "H2CO")
nus, wav, res = wavenumber_grid(990,1010,10000,unit="nm")
mdb = api.MdbExomol(db_dir, nus, gpu_transfer=True)
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

