### PR TITLE
Features/exomol loading optional fields, such as quantum states, when kip_optional_data=False in api.read_states

### DIFF
--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -128,7 +128,7 @@ def read_def(deff):
             quantum_labels.append(dat["VAL"][i].strip(" "))
         elif "Uncertainty availability" in com:
             unc = int(dat["VAL"][i]) == 1
-
+    
     # SOME DEF FILES CONTAINS ERRORS. THESE ARE THE EXCEPTIONS
     if deff.stem == "12C-16O2__UCL-4000":
         ntransf = 20
@@ -137,6 +137,9 @@ def read_def(deff):
         ntransf = 100
     if deff.stem == "14N-1H3__CoYuTe":
         maxnu = 20000.0
+    if deff.stem == "40Ca-16O-1H__OYT6":
+        ntransf = 18
+        maxnu = 36000.0
     if deff.stem == "12C2-1H2__aCeTY":
         if molmass == 12.0:
             molmass = 26.0

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -508,7 +508,7 @@ def pickup_gE(states, trans, dic_def, skip_optional_data=True):
     if not skip_optional_data:
         for q in dic_def["quantum_labels"]:
             map_add(q, f"{q}_l", "i_lower")
-            # map_add(q, f"{q}_u", "i_upper")
+            map_add(q, f"{q}_u", "i_upper")
 
     return trans
 

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -376,13 +376,7 @@ def read_states(statesf, dic_def, engine="vaex", skip_optional_data=True):
             warnings.warn(
                 "There appear to be further additional columns in .state file,"
                 + "which are not defined in .def file. We skip them.")
-        #   raise InconsistentDatabaseError(
-        #        "The EXOMOL definitions and states files are inconsistent.\n" +
-        #        "Some data are specified as available by the *.def file, but are absent in the *.bz2 file.\n"
-        #        +
-        #        "Set `skip_optional_data=False` in `fetch_exomol()` to load only the required data for a LTE computation.\n"
-        #        + "The problematic optional data/columns will be ignored.")
-
+    
     if engine == "vaex":
         import vaex
 
@@ -433,7 +427,7 @@ def pickup_gE(states, trans, dic_def, skip_optional_data=True):
     states: states DataFrame  - the i, E, g, J are in the 4 first columns
     trans: transition numpy array
     dic_def: Informations about additional quantum labels
-    add_quantum_labels: bool . If True fetch all quantum labels in dic_def['quantum_labels'] from states into transitions
+    skip_optional_data: bool . If True fetch all quantum labels in dic_def['quantum_labels'] from states into transitions (_l for lower, _u for upper states)
 
     Returns
     -------
@@ -487,11 +481,6 @@ def pickup_gE(states, trans, dic_def, skip_optional_data=True):
     map_add("J", "jlower", "i_lower")
     map_add("J", "jupper", "i_upper")
     map_add("E", "elower", "i_lower")
-
-    #print("TEST")
-    #print(states)
-    #map_add("v", "nulower", "i_lower")
-    #map_add("v", "nuupper", "i_upper")
 
     def has_nan(column):
         try:  # Vaex

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -140,6 +140,8 @@ def read_def(deff):
     if deff.stem == "40Ca-16O-1H__OYT6":
         ntransf = 18
         maxnu = 36000.0
+    if deff.stem == "1H-35Cl__HITRAN-HCl":
+        quantum_labels={"v"} # See https://github.com/HajimeKawahara/exojax/issues/330
     if deff.stem == "12C2-1H2__aCeTY":
         if molmass == 12.0:
             molmass = 26.0
@@ -290,7 +292,7 @@ def read_trans(transf, engine="vaex"):
     return dat
 
 
-def read_states(statesf, dic_def, engine="vaex", skip_optional_data=True):
+def read_states(statesf, dic_def, engine="vaex", skip_optional_data=True, print_states=False):
     """Exomol IO for a state file
 
     Notes
@@ -329,6 +331,9 @@ def read_states(statesf, dic_def, engine="vaex", skip_optional_data=True):
               structure described in [1]_, unlike the states file of
               https://exomol.com/data/molecules/NO/14N-16O/XABC/ which follows the
               structure described in [2]_.
+    print_states: bool
+        print some info. When .def file looks inconsistent with .states file, turn ON and report them in Issue.
+
 
     Returns
     -------
@@ -415,6 +420,8 @@ def read_states(statesf, dic_def, engine="vaex", skip_optional_data=True):
             dat = pd.read_csv(statesf, sep=r"\s+", usecols=usecol, names=names)
     else:
         raise NotImplementedError(engine)
+    if print_states:
+        print(dat)
     return dat
 
 

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -140,9 +140,10 @@ def read_def(deff):
         ntransf = 18
         maxnu = 36000.0
     if deff.stem == "1H-35Cl__HITRAN-HCl":
-        quantum_labels = {
-            "v"
-        }  # See https://github.com/HajimeKawahara/exojax/issues/330
+        quantum_labels = ["v"]
+        # See https://github.com/HajimeKawahara/exojax/issues/330
+    if deff.stem == "16O-1H__MoLLIST":
+        quantum_labels = ["e/f", "v", "F1/F2", "Es"]
     if deff.stem == "12C2-1H2__aCeTY":
         if molmass == 12.0:
             molmass = 26.0

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -106,7 +106,7 @@ def read_def(deff):
     ntransf = 1
     maxnu = 0.0
     quantum_labels = []
-    unc=False
+    unc = False
     for i, com in enumerate(dat["COMMENT"]):
         if "Default value of Lorentzian half-width" in com:
             alpha_ref = float(dat["VAL"][i])
@@ -128,7 +128,7 @@ def read_def(deff):
             quantum_labels.append(dat["VAL"][i].strip(" "))
         elif "Uncertainty availability" in com:
             unc = int(dat["VAL"][i]) == 1
-    
+
     # SOME DEF FILES CONTAINS ERRORS. THESE ARE THE EXCEPTIONS
     if deff.stem == "12C-16O2__UCL-4000":
         ntransf = 20
@@ -196,7 +196,7 @@ def read_def(deff):
         "quantum_labels": quantum_labels,  # array
         "Landé": lande,  # bool
         "lifetime": lifetime,  # bool
-        "unc": unc, #bool uncertainty of line center availability
+        "unc": unc,  #bool uncertainty of line center availability
     }
     return output
 
@@ -353,20 +353,16 @@ def read_states(statesf, dic_def, engine="vaex", skip_optional_data=True):
     mandatory_fields = ("i", "E", "g", "J")
     N_mandatory_fields = len(mandatory_fields)
     mandatory_usecol = np.arange(N_mandatory_fields)
-    print(dic_def,"dic_def")
     if skip_optional_data:
         usecol = mandatory_usecol
         names = mandatory_fields
     else:
-        label = np.array(["unc","lifetime","Lande"])
-        mask = np.array([dic_def["unc"], dic_def["Landé"], dic_def["lifetime"]])
+        label = np.array(["unc", "lifetime", "Lande"])
+        mask = np.array(
+            [dic_def["unc"], dic_def["Landé"], dic_def["lifetime"]])
         N_except = np.sum(mask)
-        print(mask)
-        print(N_except)
-        print(label[mask])
         usecol = np.arange(0, N_mandatory_fields + N_except + N_otherfields)
         names = mandatory_fields + tuple(label[mask]) + tuple(quantum_labels)
-
         # The definitions file (*.def) specifies which fields are available
         # in the states fiel (*.states). Check the number of available fields
         # (see *.def) match the numbers of columns in the states file (*.states).
@@ -376,7 +372,10 @@ def read_states(statesf, dic_def, engine="vaex", skip_optional_data=True):
             splitline = [x for x in re.split(r"\s+", firstline) if x != ""]
             # splitline = re.split(r"\s+", firstline)
             f.close()
-        #if len(splitline) != len(names):
+        if len(splitline) != len(names):
+            warnings.warn(
+                "There appear to be further additional columns in .state file,"
+                + "which are not defined in .def file. We skip them.")
         #   raise InconsistentDatabaseError(
         #        "The EXOMOL definitions and states files are inconsistent.\n" +
         #        "Some data are specified as available by the *.def file, but are absent in the *.bz2 file.\n"
@@ -422,9 +421,6 @@ def read_states(statesf, dic_def, engine="vaex", skip_optional_data=True):
             dat = pd.read_csv(statesf, sep=r"\s+", usecols=usecol, names=names)
     else:
         raise NotImplementedError(engine)
-    print("*_*_*")
-    print(dat)
-    print("*_*_*")
     return dat
 
 

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -125,6 +125,8 @@ def read_def(deff):
             lande = int(dat["VAL"][i]) == 1
         elif "Quantum label" in com:
             quantum_labels.append(dat["VAL"][i].strip(" "))
+        elif "Uncertainty availability" in com:
+            unc = int(dat["VAL"][i]) == 1
 
     # SOME DEF FILES CONTAINS ERRORS. THESE ARE THE EXCEPTIONS
     if deff.stem == "12C-16O2__UCL-4000":
@@ -141,17 +143,17 @@ def read_def(deff):
                 f"Known error in ExoMol def file, molmass corrected from 12.0 to {molmass}"
             )
         if quantum_labels == [
-            "totalSym",
-            "v1",
-            "v2",
-            "v3",
-            "v4",
-            "v5",
-            "v5",
-            "v7",
-            "vibSym",
-            "K",
-            "rotSym",
+                "totalSym",
+                "v1",
+                "v2",
+                "v3",
+                "v4",
+                "v5",
+                "v5",
+                "v7",
+                "vibSym",
+                "K",
+                "rotSym",
         ]:
             quantum_labels = [
                 "totalSym",
@@ -191,6 +193,7 @@ def read_def(deff):
         "quantum_labels": quantum_labels,  # array
         "Landé": lande,  # bool
         "lifetime": lifetime,  # bool
+        "unc": unc, #bool uncertainty of line center availability
     }
     return output
 
@@ -270,9 +273,10 @@ def read_trans(transf, engine="vaex"):
             )
         except:
             try:
-                dat = pd.read_csv(
-                    transf, sep=r"\s+", names=("i_upper", "i_lower", "A", "nu_lines")
-                )
+                dat = pd.read_csv(transf,
+                                  sep=r"\s+",
+                                  names=("i_upper", "i_lower", "A",
+                                         "nu_lines"))
             except Exception as err:
                 raise Exception(
                     f"Error reading {transf}. Maybe the file was corrupted during download ? You can try to delete it."
@@ -340,27 +344,23 @@ def read_states(statesf, dic_def, engine="vaex", skip_optional_data=True):
     # we read first 4 columns for ("i", "E", "g", "J"),
     # skip lifetime, skip Landé g-factor,
     # read quantum numbers
-    N = np.size(dic_def["quantum_labels"])
+    N_otherfields = np.size(dic_def["quantum_labels"])
     quantum_labels = dic_def["quantum_labels"]
 
-    mandatory_usecol = np.arange(4)
     mandatory_fields = ("i", "E", "g", "J")
+    N_mandatory_fields = len(mandatory_fields)
+    mandatory_usecol = np.arange(N_mandatory_fields)
+    print(dic_def,"dic_def")
     if skip_optional_data:
         usecol = mandatory_usecol
         names = mandatory_fields
     else:
-        if dic_def["Landé"] and dic_def["lifetime"]:
-            usecol = np.concatenate((mandatory_usecol, 5 + 2 + np.arange(N)))
-            names = mandatory_fields + ("Lande", "lifetime") + tuple(quantum_labels)
-        elif dic_def["Landé"]:
-            usecol = np.concatenate((mandatory_usecol, 5 + 1 + np.arange(N)))
-            names = mandatory_fields + ("Lande",) + tuple(quantum_labels)
-        elif dic_def["lifetime"]:
-            usecol = np.concatenate((mandatory_usecol, 5 + 1 + np.arange(N)))
-            names = mandatory_fields + ("lifetime",) + tuple(quantum_labels)
-        else:  # no lifetime, nor landé according to the def file
-            usecol = np.concatenate((mandatory_usecol, 5 + np.arange(N)))
-            names = mandatory_fields + tuple(quantum_labels)
+        label = np.array(["unc","lifetime","Lande"])
+        mask = np.array([dic_def["unc"], dic_def["Landé"], dic_def["lifetime"]])
+        N_except = np.sum(mask)
+        usecol = np.arange(0, N_mandatory_fields + N_except + N_otherfields)
+        names = mandatory_fields + tuple(label[mask]) + tuple(quantum_labels)
+
         # The definitions file (*.def) specifies which fields are available
         # in the states fiel (*.states). Check the number of available fields
         # (see *.def) match the numbers of columns in the states file (*.states).
@@ -370,13 +370,13 @@ def read_states(statesf, dic_def, engine="vaex", skip_optional_data=True):
             splitline = [x for x in re.split(r"\s+", firstline) if x != ""]
             # splitline = re.split(r"\s+", firstline)
             f.close()
-        if len(splitline) != len(names):
-            raise InconsistentDatabaseError(
-                "The EXOMOL definitions and states files are inconsistent.\n"
-                + "Some data are specified as available by the *.def file, but are absent in the *.bz2 file.\n"
-                + "Set `skip_optional_data=False` in `fetch_exomol()` to load only the required data for a LTE computation.\n"
-                + "The problematic optional data/columns will be ignored."
-            )
+        #if len(splitline) != len(names):
+        #   raise InconsistentDatabaseError(
+        #        "The EXOMOL definitions and states files are inconsistent.\n" +
+        #        "Some data are specified as available by the *.def file, but are absent in the *.bz2 file.\n"
+        #        +
+        #        "Set `skip_optional_data=False` in `fetch_exomol()` to load only the required data for a LTE computation.\n"
+        #        + "The problematic optional data/columns will be ignored.")
 
     if engine == "vaex":
         import vaex
@@ -407,20 +407,19 @@ def read_states(statesf, dic_def, engine="vaex", skip_optional_data=True):
                 ) from err
     elif engine == "csv":
         try:
-            dat = pd.read_csv(
-                statesf, compression="bz2", sep=r"\s+", usecols=usecol, names=names
-            )
+            dat = pd.read_csv(statesf,
+                              compression="bz2",
+                              sep=r"\s+",
+                              usecols=usecol,
+                              names=names)
         except:  #!!!TODO What was the expected error?
             dat = pd.read_csv(statesf, sep=r"\s+", usecols=usecol, names=names)
     else:
         raise NotImplementedError(engine)
-
     return dat
 
 
-def pickup_gE(
-    states, trans, trans_file, dic_def, trans_lines=False, skip_optional_data=True
-):
+def pickup_gE(states, trans, dic_def, skip_optional_data=True):
     """extract g_upper (gup), E_lower (elower), and J_lower and J_upper from states
     DataFrame and insert them into the transition DataFrame.
 
@@ -428,8 +427,6 @@ def pickup_gE(
     ----------
     states: states DataFrame  - the i, E, g, J are in the 4 first columns
     trans: transition numpy array
-    trans_file: name of the transition file
-    trans_lines: By default (False) we use nu_lines computed using the state file, i.e. E_upper - E_lower. If trans_nuline=True, we use the nu_lines in the transition file. Note that some trans files do not this info.
     dic_def: Informations about additional quantum labels
     add_quantum_labels: bool . If True fetch all quantum labels in dic_def['quantum_labels'] from states into transitions
 
@@ -484,8 +481,12 @@ def pickup_gE(
     map_add("g", "gup", "i_upper")
     map_add("J", "jlower", "i_lower")
     map_add("J", "jupper", "i_upper")
-
     map_add("E", "elower", "i_lower")
+
+    #print("TEST")
+    #print(states)
+    #map_add("v", "nulower", "i_lower")
+    #map_add("v", "nuupper", "i_upper")
 
     def has_nan(column):
         try:  # Vaex
@@ -591,7 +592,6 @@ def check_bdat(bdat):
     Returns:
        code level: None, a0, a1, other codes unavailable currently,
     """
-
     def checkcode(code):
         cmask = bdat["code"] == code
         if len(bdat["code"][cmask]) > 0:
@@ -607,7 +607,10 @@ def check_bdat(bdat):
     return codelv
 
 
-def make_j2b(bdat, alpha_ref_default=0.07, n_Texp_default=0.5, jlower_max=None):
+def make_j2b(bdat,
+             alpha_ref_default=0.07,
+             n_Texp_default=0.5,
+             jlower_max=None):
     """compute j2b (code a0, map from jlower to alpha_ref)
 
     Args:
@@ -788,26 +791,23 @@ def get_exomol_database_list(molecule, isotope_full_name=None):
             extra = ""
         raise ValueError(f"HTTPError opening url={url}" + extra) from err
 
-    soup = BeautifulSoup(
-        response, features="lxml"
-    )  # make soup that is parse-able by bs
+    soup = BeautifulSoup(response,
+                         features="lxml")  # make soup that is parse-able by bs
 
     # Recommended database
     rows = soup.find_all(
-        "a", {"class": "list-group-item link-list-group-item recommended"}
-    )
+        "a", {"class": "list-group-item link-list-group-item recommended"})
     databases_recommended = [r.get_attribute_list("title")[0] for r in rows]
 
     # All others
-    rows = soup.find_all("a", {"class": "list-group-item link-list-group-item"})
+    rows = soup.find_all("a",
+                         {"class": "list-group-item link-list-group-item"})
     databases = [r.get_attribute_list("title")[0] for r in rows]
 
     if len(databases_recommended) > 1:
         # Known exceptions :
-        if (
-            isotope_full_name == "28Si-16O"
-            and databases_recommended[0] == "xsec-SiOUVenIR"
-        ):
+        if (isotope_full_name == "28Si-16O"
+                and databases_recommended[0] == "xsec-SiOUVenIR"):
             # this is a cross-section dataset, shouldn't be used. Reverse and use the other one:
             databases_recommended = databases_recommended[::-1]
         else:
@@ -999,7 +999,6 @@ class MdbExomol(DatabaseManager):
     .. [2] Tennyson, J., Yurchenko, S. N., Al-Refaie, A. F., Clark, V. H. J., Chubb, K. L., Conway, E. K., … Yurchenko, O. P. (2020). The 2020 release of the ExoMol database: Molecular line lists for exoplanet and other hot atmospheres. Journal of Quantitative Spectroscopy and Radiative Transfer, 255, 107228. https://doi.org/10.1016/j.jqsrt.2020.107228
 
     """
-
     """molecular database of ExoMol
 
     MdbExomol is a class for ExoMol.
@@ -1187,28 +1186,23 @@ class MdbExomol(DatabaseManager):
         if self.n_Texp_def is None:
             self.n_Texp_def = 0.5
             warnings.warn(
-                Warning(
-                    f"""
+                Warning(f"""
                     No default broadening exponent in def file. Assigned n = {self.n_Texp_def}
-                    """
-                )
-            )
+                    """))
         #  default alpha_ref value if not given
         if self.alpha_ref_def is None:
             self.alpha_ref_def = 0.07
             warnings.warn(
-                Warning(
-                    f"""
+                Warning(f"""
                     No default broadening in def file. Assigned alpha_ref = {self.alpha_ref_def}
-                    """
-                )
-            )
+                    """))
 
         # load states
         mgr = self.get_datafile_manager()
         if cache == "regen" and mgr.cache_file(self.states_file).exists():
             if verbose:
-                print("Removing existing file ", mgr.cache_file(self.states_file))
+                print("Removing existing file ",
+                      mgr.cache_file(self.states_file))
             os.remove(mgr.cache_file(self.states_file))
         if mgr.cache_file(self.states_file).exists():
             states = mgr.read(mgr.cache_file(self.states_file))
@@ -1256,26 +1250,22 @@ class MdbExomol(DatabaseManager):
             # imin :
             # index i of the "w(i)-w(i+1)" element in dic_def["numtag"] such
             # that nurange[0]<=w(i)
-            imin = (
-                np.searchsorted(dic_def["numinf"], nurange[0] - margin, side="right")
-                - 1
-            )
+            imin = (np.searchsorted(
+                dic_def["numinf"], nurange[0] - margin, side="right") - 1)
             # imax :
             # index i of the "w(i)-w(i+1)" element in dic_def["numtag"] such
             # that w(i+1)<=nurange[1]
-            imax = (
-                np.searchsorted(dic_def["numinf"], nurange[1] + margin, side="right")
-                - 1
-            )
+            imax = (np.searchsorted(
+                dic_def["numinf"], nurange[1] + margin, side="right") - 1)
             # not to exceed index out of the range
             imax = np.min([imax, len(dic_def["numinf"]) - 2])
             self.trans_file = []
             self.num_tag = []
 
             for k, i in enumerate(range(imin, imax + 1)):
-                trans_file = self.path / pathlib.Path(
-                    molec + "__" + dic_def["numtag"][i] + ".trans.bz2"
-                )
+                trans_file = self.path / pathlib.Path(molec + "__" +
+                                                      dic_def["numtag"][i] +
+                                                      ".trans.bz2")
                 self.trans_file.append(trans_file)
                 self.num_tag.append(dic_def["numtag"][i])
 
@@ -1286,7 +1276,8 @@ class MdbExomol(DatabaseManager):
             print("Reading", trans_file)
             if cache == "regen" and mgr.cache_file(trans_file).exists():
                 if verbose:
-                    print("Removing existing file ", mgr.cache_file(trans_file))
+                    print("Removing existing file ",
+                          mgr.cache_file(trans_file))
                 os.remove(mgr.cache_file(trans_file))
 
             if not mgr.cache_file(trans_file).exists():
@@ -1296,15 +1287,16 @@ class MdbExomol(DatabaseManager):
                     )
 
                 if not trans_file.exists():
-                    self.download(molec, extension=[".trans.bz2"], numtag=num_tag)
+                    self.download(molec,
+                                  extension=[".trans.bz2"],
+                                  numtag=num_tag)
                     # TODO: add option to delete file at the end
 
                 print(
                     f"Note: Caching line transition data to the {engine} format. After the second time, it will become much faster."
                 )
                 trans = read_trans(
-                    trans_file, engine="vaex" if engine == "vaex" else "csv"
-                )
+                    trans_file, engine="vaex" if engine == "vaex" else "csv")
 
                 # Complete transition data with lookup on upper & lower state :
                 # In particular, compute gup and elower
@@ -1312,21 +1304,20 @@ class MdbExomol(DatabaseManager):
                 pickup_gE(
                     states,
                     trans,
-                    trans_file,
                     dic_def,
                     skip_optional_data=skip_optional_data,
                 )
 
                 ##Recompute Line strength:
                 from radis.lbl.base import (  # TODO: move elsewhere
-                    linestrength_from_Einstein,
-                )
+                    linestrength_from_Einstein, )
 
                 self.Sij0 = linestrength_from_Einstein(
                     A=trans["A"],
                     gu=trans["gup"],
                     El=trans["elower"],
-                    Ia=1,  #  Sij0 is a linestrength calculated without taking into account isotopic abundance (unlike line intensity parameter of HITRAN. In RADIS this is corrected for in fetch_exomol()  )
+                    Ia=
+                    1,  #  Sij0 is a linestrength calculated without taking into account isotopic abundance (unlike line intensity parameter of HITRAN. In RADIS this is corrected for in fetch_exomol()  )
                     nu=trans["nu_lines"],
                     Q=self.QTref,
                     T=self.Tref,
@@ -1341,7 +1332,11 @@ class MdbExomol(DatabaseManager):
         # self.set_broadening()
         #
 
-    def set_broadening(self, df, alpha_ref_def=None, n_Texp_def=None, output=None):
+    def set_broadening(self,
+                       df,
+                       alpha_ref_def=None,
+                       n_Texp_def=None,
+                       output=None):
         """setting broadening parameters
 
         Parameters
@@ -1366,9 +1361,12 @@ class MdbExomol(DatabaseManager):
         self.add_column(df, "alpha_ref", self.alpha_ref)
         self.add_column(df, "n_Texp", self.n_Texp)
 
-    def compute_broadening(
-        self, jlower, jupper, alpha_ref_def=None, n_Texp_def=None, output=None
-    ):
+    def compute_broadening(self,
+                           jlower,
+                           jupper,
+                           alpha_ref_def=None,
+                           n_Texp_def=None,
+                           output=None):
         """computing broadening parameters
 
         Parameters
@@ -1423,12 +1421,14 @@ class MdbExomol(DatabaseManager):
                 print(
                     "Warning: Cannot load .broad. The default broadening parameters are used."
                 )
-                self.alpha_ref = np.array(self.alpha_ref_def * np.ones_like(jlower))
+                self.alpha_ref = np.array(self.alpha_ref_def *
+                                          np.ones_like(jlower))
                 self.n_Texp = np.array(self.n_Texp_def * np.ones_like(jlower))
 
         else:
             print("The default broadening parameters are used.")
-            self.alpha_ref = np.array(self.alpha_ref_def * np.ones_like(jlower))
+            self.alpha_ref = np.array(self.alpha_ref_def *
+                                      np.ones_like(jlower))
             self.n_Texp = np.array(self.n_Texp_def * np.ones_like(jlower))
 
     def QT_interp(self, T):
@@ -1492,21 +1492,20 @@ class MdbExomol(DatabaseManager):
                 url = EXOMOL_URL + molname_simple + "/" + tag[0] + "/"
             else:
                 pfname_arr = [molec + ext]
-                url = EXOMOL_URL + molname_simple + "/" + tag[0] + "/" + tag[1] + "/"
+                url = EXOMOL_URL + molname_simple + "/" + tag[0] + "/" + tag[
+                    1] + "/"
 
             for pfname in pfname_arr:
                 pfpath = url + pfname
                 os.makedirs(str(self.path), exist_ok=True)
-                print(
-                    "Downloading "
-                    + pfpath
-                    + " and saving as "
-                    + str(self.path / pfname)
-                )
+                print("Downloading " + pfpath + " and saving as " +
+                      str(self.path / pfname))
                 try:
                     urllib.request.urlretrieve(pfpath, str(self.path / pfname))
                 except HTTPError:
-                    print(f"Error: Couldn't download {ext} file at {pfpath} and save.")
+                    print(
+                        f"Error: Couldn't download {ext} file at {pfpath} and save."
+                    )
 
     def to_partition_function_tabulator(self):
         """Generate a :py:class:`~radis.levels.partfunc.PartFuncExoMol` object"""
@@ -1580,6 +1579,7 @@ if __name__ == "__main__":
     s.plot("xsection")
 
     # %% Exojax like Example
+
 
     class mdbExoMol:
 
@@ -1663,9 +1663,11 @@ if __name__ == "__main__":
             jdict = mdb.load(
                 local_files,
                 columns=[k for k in self.__slots__ if k not in ["logsij0"]],
-                lower_bound=([("nu_lines", wavenum_min)] if wavenum_min else [])
-                + ([("Sij0", mdb.crit)] if not np.isneginf(mdb.crit) else []),
-                upper_bound=([("nu_lines", wavenum_max)] if wavenum_max else []),
+                lower_bound=([("nu_lines",
+                               wavenum_min)] if wavenum_min else []) +
+                ([("Sij0", mdb.crit)] if not np.isneginf(mdb.crit) else []),
+                upper_bound=([("nu_lines",
+                               wavenum_max)] if wavenum_max else []),
                 output="jax",
             )
 
@@ -1695,7 +1697,8 @@ if __name__ == "__main__":
         "CH4/12C-1H4/YT10to10/",
         nus,
         crit=1.0e-30,
-        local_databases=pathlib.Path(radis.config["DEFAULT_DOWNLOAD_PATH"]) / "exomol",
+        local_databases=pathlib.Path(radis.config["DEFAULT_DOWNLOAD_PATH"]) /
+        "exomol",
     )
     # ... ready to run Jax calculations
 

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -25,7 +25,6 @@ import pandas as pd
 from bs4 import BeautifulSoup
 
 from radis.api.hdf5 import vaexsafe_colname
-from radis.misc.warning import InconsistentDatabaseError
 
 
 def e2s(molname_exact):
@@ -141,7 +140,9 @@ def read_def(deff):
         ntransf = 18
         maxnu = 36000.0
     if deff.stem == "1H-35Cl__HITRAN-HCl":
-        quantum_labels={"v"} # See https://github.com/HajimeKawahara/exojax/issues/330
+        quantum_labels = {
+            "v"
+        }  # See https://github.com/HajimeKawahara/exojax/issues/330
     if deff.stem == "12C2-1H2__aCeTY":
         if molmass == 12.0:
             molmass = 26.0
@@ -292,7 +293,11 @@ def read_trans(transf, engine="vaex"):
     return dat
 
 
-def read_states(statesf, dic_def, engine="vaex", skip_optional_data=True, print_states=False):
+def read_states(statesf,
+                dic_def,
+                engine="vaex",
+                skip_optional_data=True,
+                print_states=False):
     """Exomol IO for a state file
 
     Notes
@@ -381,7 +386,7 @@ def read_states(statesf, dic_def, engine="vaex", skip_optional_data=True, print_
             warnings.warn(
                 "There appear to be further additional columns in .state file,"
                 + "which are not defined in .def file. We skip them.")
-    
+
     if engine == "vaex":
         import vaex
 

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -151,17 +151,17 @@ def read_def(deff):
                 f"Known error in ExoMol def file, molmass corrected from 12.0 to {molmass}"
             )
         if quantum_labels == [
-                "totalSym",
-                "v1",
-                "v2",
-                "v3",
-                "v4",
-                "v5",
-                "v5",
-                "v7",
-                "vibSym",
-                "K",
-                "rotSym",
+            "totalSym",
+            "v1",
+            "v2",
+            "v3",
+            "v4",
+            "v5",
+            "v5",
+            "v7",
+            "vibSym",
+            "K",
+            "rotSym",
         ]:
             quantum_labels = [
                 "totalSym",
@@ -200,7 +200,7 @@ def read_def(deff):
         "quantum_labels": quantum_labels,  # array
         "Landé": lande,  # bool
         "lifetime": lifetime,  # bool
-        "unc": unc,  #bool uncertainty of line center availability
+        "unc": unc,  # bool uncertainty of line center availability
     }
     return output
 
@@ -280,10 +280,9 @@ def read_trans(transf, engine="vaex"):
             )
         except:
             try:
-                dat = pd.read_csv(transf,
-                                  sep=r"\s+",
-                                  names=("i_upper", "i_lower", "A",
-                                         "nu_lines"))
+                dat = pd.read_csv(
+                    transf, sep=r"\s+", names=("i_upper", "i_lower", "A", "nu_lines")
+                )
             except Exception as err:
                 raise Exception(
                     f"Error reading {transf}. Maybe the file was corrupted during download ? You can try to delete it."
@@ -294,11 +293,9 @@ def read_trans(transf, engine="vaex"):
     return dat
 
 
-def read_states(statesf,
-                dic_def,
-                engine="vaex",
-                skip_optional_data=True,
-                print_states=False):
+def read_states(
+    statesf, dic_def, engine="vaex", skip_optional_data=True, print_states=False
+):
     """Exomol IO for a state file
 
     Notes
@@ -369,8 +366,7 @@ def read_states(statesf,
         names = mandatory_fields
     else:
         label = np.array(["unc", "lifetime", "Lande"])
-        mask = np.array(
-            [dic_def["unc"], dic_def["Landé"], dic_def["lifetime"]])
+        mask = np.array([dic_def["unc"], dic_def["Landé"], dic_def["lifetime"]])
         N_except = np.sum(mask)
         usecol = np.arange(0, N_mandatory_fields + N_except + N_otherfields)
         names = mandatory_fields + tuple(label[mask]) + tuple(quantum_labels)
@@ -386,7 +382,8 @@ def read_states(statesf,
         if len(splitline) != len(names):
             warnings.warn(
                 "There appear to be further additional columns in .state file,"
-                + "which are not defined in .def file. We skip them.")
+                + "which are not defined in .def file. We skip them."
+            )
 
     if engine == "vaex":
         import vaex
@@ -417,11 +414,9 @@ def read_states(statesf,
                 ) from err
     elif engine == "csv":
         try:
-            dat = pd.read_csv(statesf,
-                              compression="bz2",
-                              sep=r"\s+",
-                              usecols=usecol,
-                              names=names)
+            dat = pd.read_csv(
+                statesf, compression="bz2", sep=r"\s+", usecols=usecol, names=names
+            )
         except:  #!!!TODO What was the expected error?
             dat = pd.read_csv(statesf, sep=r"\s+", usecols=usecol, names=names)
     else:
@@ -599,6 +594,7 @@ def check_bdat(bdat):
     Returns:
        code level: None, a0, a1, other codes unavailable currently,
     """
+
     def checkcode(code):
         cmask = bdat["code"] == code
         if len(bdat["code"][cmask]) > 0:
@@ -614,10 +610,7 @@ def check_bdat(bdat):
     return codelv
 
 
-def make_j2b(bdat,
-             alpha_ref_default=0.07,
-             n_Texp_default=0.5,
-             jlower_max=None):
+def make_j2b(bdat, alpha_ref_default=0.07, n_Texp_default=0.5, jlower_max=None):
     """compute j2b (code a0, map from jlower to alpha_ref)
 
     Args:
@@ -798,23 +791,26 @@ def get_exomol_database_list(molecule, isotope_full_name=None):
             extra = ""
         raise ValueError(f"HTTPError opening url={url}" + extra) from err
 
-    soup = BeautifulSoup(response,
-                         features="lxml")  # make soup that is parse-able by bs
+    soup = BeautifulSoup(
+        response, features="lxml"
+    )  # make soup that is parse-able by bs
 
     # Recommended database
     rows = soup.find_all(
-        "a", {"class": "list-group-item link-list-group-item recommended"})
+        "a", {"class": "list-group-item link-list-group-item recommended"}
+    )
     databases_recommended = [r.get_attribute_list("title")[0] for r in rows]
 
     # All others
-    rows = soup.find_all("a",
-                         {"class": "list-group-item link-list-group-item"})
+    rows = soup.find_all("a", {"class": "list-group-item link-list-group-item"})
     databases = [r.get_attribute_list("title")[0] for r in rows]
 
     if len(databases_recommended) > 1:
         # Known exceptions :
-        if (isotope_full_name == "28Si-16O"
-                and databases_recommended[0] == "xsec-SiOUVenIR"):
+        if (
+            isotope_full_name == "28Si-16O"
+            and databases_recommended[0] == "xsec-SiOUVenIR"
+        ):
             # this is a cross-section dataset, shouldn't be used. Reverse and use the other one:
             databases_recommended = databases_recommended[::-1]
         else:
@@ -1006,6 +1002,7 @@ class MdbExomol(DatabaseManager):
     .. [2] Tennyson, J., Yurchenko, S. N., Al-Refaie, A. F., Clark, V. H. J., Chubb, K. L., Conway, E. K., … Yurchenko, O. P. (2020). The 2020 release of the ExoMol database: Molecular line lists for exoplanet and other hot atmospheres. Journal of Quantitative Spectroscopy and Radiative Transfer, 255, 107228. https://doi.org/10.1016/j.jqsrt.2020.107228
 
     """
+
     """molecular database of ExoMol
 
     MdbExomol is a class for ExoMol.
@@ -1193,23 +1190,28 @@ class MdbExomol(DatabaseManager):
         if self.n_Texp_def is None:
             self.n_Texp_def = 0.5
             warnings.warn(
-                Warning(f"""
+                Warning(
+                    f"""
                     No default broadening exponent in def file. Assigned n = {self.n_Texp_def}
-                    """))
+                    """
+                )
+            )
         #  default alpha_ref value if not given
         if self.alpha_ref_def is None:
             self.alpha_ref_def = 0.07
             warnings.warn(
-                Warning(f"""
+                Warning(
+                    f"""
                     No default broadening in def file. Assigned alpha_ref = {self.alpha_ref_def}
-                    """))
+                    """
+                )
+            )
 
         # load states
         mgr = self.get_datafile_manager()
         if cache == "regen" and mgr.cache_file(self.states_file).exists():
             if verbose:
-                print("Removing existing file ",
-                      mgr.cache_file(self.states_file))
+                print("Removing existing file ", mgr.cache_file(self.states_file))
             os.remove(mgr.cache_file(self.states_file))
         if mgr.cache_file(self.states_file).exists():
             states = mgr.read(mgr.cache_file(self.states_file))
@@ -1257,22 +1259,26 @@ class MdbExomol(DatabaseManager):
             # imin :
             # index i of the "w(i)-w(i+1)" element in dic_def["numtag"] such
             # that nurange[0]<=w(i)
-            imin = (np.searchsorted(
-                dic_def["numinf"], nurange[0] - margin, side="right") - 1)
+            imin = (
+                np.searchsorted(dic_def["numinf"], nurange[0] - margin, side="right")
+                - 1
+            )
             # imax :
             # index i of the "w(i)-w(i+1)" element in dic_def["numtag"] such
             # that w(i+1)<=nurange[1]
-            imax = (np.searchsorted(
-                dic_def["numinf"], nurange[1] + margin, side="right") - 1)
+            imax = (
+                np.searchsorted(dic_def["numinf"], nurange[1] + margin, side="right")
+                - 1
+            )
             # not to exceed index out of the range
             imax = np.min([imax, len(dic_def["numinf"]) - 2])
             self.trans_file = []
             self.num_tag = []
 
             for k, i in enumerate(range(imin, imax + 1)):
-                trans_file = self.path / pathlib.Path(molec + "__" +
-                                                      dic_def["numtag"][i] +
-                                                      ".trans.bz2")
+                trans_file = self.path / pathlib.Path(
+                    molec + "__" + dic_def["numtag"][i] + ".trans.bz2"
+                )
                 self.trans_file.append(trans_file)
                 self.num_tag.append(dic_def["numtag"][i])
 
@@ -1283,8 +1289,7 @@ class MdbExomol(DatabaseManager):
             print("Reading", trans_file)
             if cache == "regen" and mgr.cache_file(trans_file).exists():
                 if verbose:
-                    print("Removing existing file ",
-                          mgr.cache_file(trans_file))
+                    print("Removing existing file ", mgr.cache_file(trans_file))
                 os.remove(mgr.cache_file(trans_file))
 
             if not mgr.cache_file(trans_file).exists():
@@ -1294,16 +1299,15 @@ class MdbExomol(DatabaseManager):
                     )
 
                 if not trans_file.exists():
-                    self.download(molec,
-                                  extension=[".trans.bz2"],
-                                  numtag=num_tag)
+                    self.download(molec, extension=[".trans.bz2"], numtag=num_tag)
                     # TODO: add option to delete file at the end
 
                 print(
                     f"Note: Caching line transition data to the {engine} format. After the second time, it will become much faster."
                 )
                 trans = read_trans(
-                    trans_file, engine="vaex" if engine == "vaex" else "csv")
+                    trans_file, engine="vaex" if engine == "vaex" else "csv"
+                )
 
                 # Complete transition data with lookup on upper & lower state :
                 # In particular, compute gup and elower
@@ -1317,14 +1321,14 @@ class MdbExomol(DatabaseManager):
 
                 ##Recompute Line strength:
                 from radis.lbl.base import (  # TODO: move elsewhere
-                    linestrength_from_Einstein, )
+                    linestrength_from_Einstein,
+                )
 
                 self.Sij0 = linestrength_from_Einstein(
                     A=trans["A"],
                     gu=trans["gup"],
                     El=trans["elower"],
-                    Ia=
-                    1,  #  Sij0 is a linestrength calculated without taking into account isotopic abundance (unlike line intensity parameter of HITRAN. In RADIS this is corrected for in fetch_exomol()  )
+                    Ia=1,  #  Sij0 is a linestrength calculated without taking into account isotopic abundance (unlike line intensity parameter of HITRAN. In RADIS this is corrected for in fetch_exomol()  )
                     nu=trans["nu_lines"],
                     Q=self.QTref,
                     T=self.Tref,
@@ -1339,11 +1343,7 @@ class MdbExomol(DatabaseManager):
         # self.set_broadening()
         #
 
-    def set_broadening(self,
-                       df,
-                       alpha_ref_def=None,
-                       n_Texp_def=None,
-                       output=None):
+    def set_broadening(self, df, alpha_ref_def=None, n_Texp_def=None, output=None):
         """setting broadening parameters
 
         Parameters
@@ -1368,12 +1368,9 @@ class MdbExomol(DatabaseManager):
         self.add_column(df, "alpha_ref", self.alpha_ref)
         self.add_column(df, "n_Texp", self.n_Texp)
 
-    def compute_broadening(self,
-                           jlower,
-                           jupper,
-                           alpha_ref_def=None,
-                           n_Texp_def=None,
-                           output=None):
+    def compute_broadening(
+        self, jlower, jupper, alpha_ref_def=None, n_Texp_def=None, output=None
+    ):
         """computing broadening parameters
 
         Parameters
@@ -1428,14 +1425,12 @@ class MdbExomol(DatabaseManager):
                 print(
                     "Warning: Cannot load .broad. The default broadening parameters are used."
                 )
-                self.alpha_ref = np.array(self.alpha_ref_def *
-                                          np.ones_like(jlower))
+                self.alpha_ref = np.array(self.alpha_ref_def * np.ones_like(jlower))
                 self.n_Texp = np.array(self.n_Texp_def * np.ones_like(jlower))
 
         else:
             print("The default broadening parameters are used.")
-            self.alpha_ref = np.array(self.alpha_ref_def *
-                                      np.ones_like(jlower))
+            self.alpha_ref = np.array(self.alpha_ref_def * np.ones_like(jlower))
             self.n_Texp = np.array(self.n_Texp_def * np.ones_like(jlower))
 
     def QT_interp(self, T):
@@ -1499,20 +1494,21 @@ class MdbExomol(DatabaseManager):
                 url = EXOMOL_URL + molname_simple + "/" + tag[0] + "/"
             else:
                 pfname_arr = [molec + ext]
-                url = EXOMOL_URL + molname_simple + "/" + tag[0] + "/" + tag[
-                    1] + "/"
+                url = EXOMOL_URL + molname_simple + "/" + tag[0] + "/" + tag[1] + "/"
 
             for pfname in pfname_arr:
                 pfpath = url + pfname
                 os.makedirs(str(self.path), exist_ok=True)
-                print("Downloading " + pfpath + " and saving as " +
-                      str(self.path / pfname))
+                print(
+                    "Downloading "
+                    + pfpath
+                    + " and saving as "
+                    + str(self.path / pfname)
+                )
                 try:
                     urllib.request.urlretrieve(pfpath, str(self.path / pfname))
                 except HTTPError:
-                    print(
-                        f"Error: Couldn't download {ext} file at {pfpath} and save."
-                    )
+                    print(f"Error: Couldn't download {ext} file at {pfpath} and save.")
 
     def to_partition_function_tabulator(self):
         """Generate a :py:class:`~radis.levels.partfunc.PartFuncExoMol` object"""
@@ -1586,7 +1582,6 @@ if __name__ == "__main__":
     s.plot("xsection")
 
     # %% Exojax like Example
-
 
     class mdbExoMol:
 
@@ -1670,11 +1665,9 @@ if __name__ == "__main__":
             jdict = mdb.load(
                 local_files,
                 columns=[k for k in self.__slots__ if k not in ["logsij0"]],
-                lower_bound=([("nu_lines",
-                               wavenum_min)] if wavenum_min else []) +
-                ([("Sij0", mdb.crit)] if not np.isneginf(mdb.crit) else []),
-                upper_bound=([("nu_lines",
-                               wavenum_max)] if wavenum_max else []),
+                lower_bound=([("nu_lines", wavenum_min)] if wavenum_min else [])
+                + ([("Sij0", mdb.crit)] if not np.isneginf(mdb.crit) else []),
+                upper_bound=([("nu_lines", wavenum_max)] if wavenum_max else []),
                 output="jax",
             )
 
@@ -1704,8 +1697,7 @@ if __name__ == "__main__":
         "CH4/12C-1H4/YT10to10/",
         nus,
         crit=1.0e-30,
-        local_databases=pathlib.Path(radis.config["DEFAULT_DOWNLOAD_PATH"]) /
-        "exomol",
+        local_databases=pathlib.Path(radis.config["DEFAULT_DOWNLOAD_PATH"]) / "exomol",
     )
     # ... ready to run Jax calculations
 

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -106,6 +106,7 @@ def read_def(deff):
     ntransf = 1
     maxnu = 0.0
     quantum_labels = []
+    unc=False
     for i, com in enumerate(dat["COMMENT"]):
         if "Default value of Lorentzian half-width" in com:
             alpha_ref = float(dat["VAL"][i])
@@ -183,7 +184,6 @@ def read_def(deff):
     else:
         numinf = None
         numtag = ""
-
     output = {
         "n_Texp": n_Texp,
         "alpha_ref": alpha_ref,
@@ -358,6 +358,9 @@ def read_states(statesf, dic_def, engine="vaex", skip_optional_data=True):
         label = np.array(["unc","lifetime","Lande"])
         mask = np.array([dic_def["unc"], dic_def["Landé"], dic_def["lifetime"]])
         N_except = np.sum(mask)
+        print(mask)
+        print(N_except)
+        print(label[mask])
         usecol = np.arange(0, N_mandatory_fields + N_except + N_otherfields)
         names = mandatory_fields + tuple(label[mask]) + tuple(quantum_labels)
 
@@ -416,6 +419,9 @@ def read_states(statesf, dic_def, engine="vaex", skip_optional_data=True):
             dat = pd.read_csv(statesf, sep=r"\s+", usecols=usecol, names=names)
     else:
         raise NotImplementedError(engine)
+    print("*_*_*")
+    print(dat)
+    print("*_*_*")
     return dat
 
 


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address the loading optional fileds in ExoMol when `skip_optional_data=False` in `api.read_states`.

The loading a .states file based on the def file is a bit tricky, but the following rules work well for most species:

- if `unc `(uncertainty of line center),`lifetime`, `Lande` exists, additional column(s) should be placed before `quantum_labels` in this order
- some additional columns (maybe not described in def) can exist after  `quantum_labels` (I found e.f. Marvelized/Calculated, Calculated energy)

Note that sometime the def file looks inconsistent with states in terms of the description of  `quantum_labels`. It should be handled as an exception in `read_def`. For instance, HITRAN-HCl, see [here](https://github.com/HajimeKawahara/exojax/issues/330#issuecomment-1401174128) 




<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #540
See also https://github.com/HajimeKawahara/exojax/issues/330
