### PR TITLE
Plots show up even if interactive mode is off

### DIFF
--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -1951,7 +1951,7 @@ class Spectrum(object):
         normalize=False,
         force=False,
         plot_by_parts=False,
-        show=False,
+        show=True,
         show_ruler=False,
         **kwargs,
     ):


### PR DESCRIPTION
This is address issue #507 
I have changed default value of show parameter to True.
Apparently , changing default value of show parameter( of Spectrum.plot() ) to True resolves this issue . So, even if user is unaware of show parameter spectrum is shown up.

If there is some other things that i need to take care of please let me know , i'll happy to add that .

Fixes #507 