### PR TITLE
Warn when branch data type is not int64

### DIFF
--- a/radis/api/tools.py
+++ b/radis/api/tools.py
@@ -162,7 +162,7 @@ def _format_dtype(dtype):
         try:
             print("Data type")
             print("-" * 30)
-            for (k, c) in dtype:
+            for k, c in dtype:
                 print(str(k), "\t\t", c)
             print("-" * 30)
         finally:
@@ -269,4 +269,3 @@ def replace_PQR_with_m101(df):
             ),
             category=PerformanceWarning,
         )
-

--- a/radis/api/tools.py
+++ b/radis/api/tools.py
@@ -5,8 +5,12 @@
 """
 # TODO refactor : rename this file as hitran_utils.py
 
+from warnings import warn
+
 import numpy as np
 import pandas as pd
+
+from ..misc.warning import PerformanceWarning
 
 
 def parse_hitran_file(fname, columns, count=-1):
@@ -251,4 +255,18 @@ def replace_PQR_with_m101(df):
         new_col = df["branch"].replace(["P", "Q", "R"], [-1, 0, 1])
         df["branch"] = new_col
 
-    assert df.dtypes["branch"] == np.int64
+    try:
+        assert df.dtypes["branch"] == np.int64
+    except AssertionError:
+        warn(
+            message=(
+                f"Expected branch data type to be 'int64', "
+                f"got '{df.dtypes['branch']}' instead."
+                f"This warning is safe to ignore although it is going to "
+                f"reduce the performance of your calculations. "
+                f"For further details, see:"
+                f"https://github.com/radis/radis/issues/65"
+            ),
+            category=PerformanceWarning,
+        )
+


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to remove an assertion error being raised by `radis/api/tools.py:replace_PQR_with_m101
` when the data type for the `'branch'` column is other than `int64`, and instead issue a warning.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #544 
