### PR TITLE
Matlab Interface

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -209,6 +209,21 @@ RADIS internals are described in the `Developer Guide <https://radis.readthedocs
      :alt: https://radis.readthedocs.io/en/latest/_images/RADIS_flow_chart.svg
 
 
+### Matlab
+
+Matlab users can seamlessly access Python modules
+
+Here's what's you'll need:
+
+1. [Setup Python &harr; Matlab interface](https://www.scivision.dev/matlab-python-user-module-import/).
+2. Install RADIS in Python as at the top of this Readme.
+3. From Matlab, verify everything is working by:
+
+        ```
+        py.radis.calc_spectrum()
+        ```
+
+
 License
 -------
 


### PR DESCRIPTION
This is to solve #349 
To add matlab interface we just have to set python environment in matlab and after that we call all the python modules installed on the system.
To call RADIS : py.radis.cal_spectrum() or can other functions  of RADIS can be accessed using same syntax 

I have updated ReadMe file and added details of setting up python environment in matlab by attaching the links of relevant documentation.

![matlab2](https://user-images.githubusercontent.com/78527441/218275198-6bf36649-40a7-42ed-aba2-0c16b22e9ce0.png)

Fixes:#349
