### PR TITLE
fix wrongly filtered paths in loader.py

### DIFF
--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -1765,7 +1765,7 @@ class DatabankLoader(object):
                     splitext(fname)[0] + ".hdf5",
                     fname + ".hdf5",
                 ]:
-                    if likely_fname_cache in path and likely_fname_cache != fname:
+                    if likely_fname_cache in filtered_path and likely_fname_cache != fname:
                         filtered_path.remove(likely_fname_cache)
             new_paths += filtered_path
 


### PR DESCRIPTION
Line 1768, the small change of "path" to "filtered_path"

When I tried to run the code, the "h5" was deleted and error was shown that the desired "h5" file was not found. I got the follwoing error: 


Loading Line databank
Opening file C:\Users\mraga\Databases\cdsd4000\CDSD4000_4150_5650\cdsd_01768_01770.h5 (format=CDSD 4000, cache=True)
Last Modification time: Mon Feb 20 15:58:05 2023
File C:\Users\mraga\Databases\cdsd4000\CDSD4000_4150_5650\cdsd_01768_01770.h5 deprecated:
Metadata in file C:\Users\mraga\Databases\cdsd4000\CDSD4000_4150_5650\cdsd_01768_01770.h5 dont match expected values. See comparison below:
	Expected	File
Key            Expected         	Got
----------------------------------------
last_modificationMon Feb 20 15:58:05 2023	Mon May 31 07:59:56 2010
----------------------------------------
Deleting it!
Traceback (most recent call last):
  File "C:\Users\mraga\Mragank_tuto_CO2_CDSD.py", line 32, in <module>
    sf.load_databank('CDSD4000_4150_5650', load_energies=True, load_columns='all')
  File "C:\Users\mraga\anaconda3\lib\site-packages\radis\lbl\loader.py", line 1625, in load_databank
    self.df0 = self._load_databank(
  File "C:\Users\mraga\anaconda3\lib\site-packages\radis\lbl\loader.py", line 2354, in _load_databank
    df = load_and_concat(database)
  File "C:\Users\mraga\anaconda3\lib\site-packages\radis\lbl\loader.py", line 2242, in load_and_concat
    df = cdsd2df(
  File "C:\Users\mraga\anaconda3\lib\site-packages\radis\api\cdsdapi.py", line 283, in cdsd2df
    df = parse_hitran_file(fname, columns)
  File "C:\Users\mraga\anaconda3\lib\site-packages\radis\api\tools.py", line 45, in parse_hitran_file
    data = _read_hitran_file(
  File "C:\Users\mraga\anaconda3\lib\site-packages\radis\api\tools.py", line 130, in _read_hitran_file
    return np.fromfile(fname, dtype=dt, count=count)
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\mraga\\Databases\\cdsd4000\\CDSD4000_4150_5650\\cdsd_01768_01770.h5'
[4:40](https://em2cdocs.slack.com/archives/D04LBNUULVA/p1678462840712929)

So basically, it deleted the file by itself and gave me the error that the file was not found!
.
.
.

<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>
