### PR TITLE
Added example for examples gallery

### DIFF
--- a/examples/hitemp_h20_calculations.py
+++ b/examples/hitemp_h20_calculations.py
@@ -5,8 +5,10 @@
 Calculate a High Temperature H20 Spectrum
 =========================================
 
-This example uses the calc_spectrum function to calculate the H20 spectra at 3000K using the 
-HITEMP databank. Wavenumbers are set between 3125 and 3703 (corresponding to a wavelength range between 2700nm - 3200nm). 
+This example demonstrates using the calc_spectrum function to calculate the H20 spectra at 3000K using the 
+HITEMP databank. Due to HITEMP databank file size considerations, this example has been preset to using the HITRAN database instead. 
+To use HITEMP files for accurate results at high temperatures like the one in this example, modify databank='hitemp' in the code below. 
+Wavenumbers are set between 3125 and 3703 (corresponding to a wavelength range between 2700nm - 3200nm). 
 
 Warning: Please be aware that the HITEMP databank files for H20 is pretty large. Expect ~10Gb. See more under HITEMP [here](https://radis.readthedocs.io/en/latest/lbl/lbl.html#line-databases)
 """
@@ -23,7 +25,7 @@ s = calc_spectrum(wavenum_min = 3125 / u.cm,
                   mole_fraction = 1,
                   path_length = 1 * u.cm,
                   Tgas=3000, 
-                  databank='hitemp',
+                  databank='hitran',  #change to databank='hitemp' for accurate results, but be aware of size requirements (see warning above)
                   verbose=3,        # adding some extra info for the first computation
                   )
 #Without verbose=False this will show all the input parameters. 

--- a/examples/hitemp_h20_calculations.py
+++ b/examples/hitemp_h20_calculations.py
@@ -6,17 +6,17 @@ Calculate a High Temperature H20 Spectrum
 =========================================
 
 This example uses the calc_spectrum function to calculate the H20 spectra at 3000K using the 
-HITEMP databank. Wavenumbers are set between 2000 and 4000.
+HITEMP databank. Wavenumbers are set between 3125 and 3703 (corresponding to a wavelength range between 2700nm - 3200nm). 
 
-
+Warning: Please be aware that the HITEMP databank files for H20 is pretty large. Expect ~10Gb. See more under HITEMP [here](https://radis.readthedocs.io/en/latest/lbl/lbl.html#line-databases)
 """
 
 #%%
 
 from radis import calc_spectrum
 from astropy import units as u
-s = calc_spectrum(wavenum_min = 2000 / u.cm, 
-                  wavenum_max = 4000 / u.cm,
+s = calc_spectrum(wavenum_min = 3125 / u.cm, 
+                  wavenum_max = 3703 / u.cm,
                   molecule = 'H2O',
                   isotope = '1,2,3',
                   pressure = 1.01325 * u.bar,

--- a/examples/hitemp_h20_calculations.py
+++ b/examples/hitemp_h20_calculations.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""
+
+=========================================
+Calculate a High Temperature H20 Spectrum
+=========================================
+
+This example uses the calc_spectrum function to calculate the H20 spectra at 3000K using the 
+HITEMP databank. Wavenumbers are set between 2000 and 4000.
+
+
+"""
+
+#%%
+
+from radis import calc_spectrum
+from astropy import units as u
+s = calc_spectrum(wavenum_min = 2000 / u.cm, 
+                  wavenum_max = 4000 / u.cm,
+                  molecule = 'H2O',
+                  isotope = '1,2,3',
+                  pressure = 1.01325 * u.bar,
+                  mole_fraction = 1,
+                  path_length = 1 * u.cm,
+                  Tgas=3000, 
+                  databank='hitemp',
+                  verbose=3,        # adding some extra info for the first computation
+                  )
+#Without verbose=False this will show all the input parameters. 
+#With verbose=2,3,etc... we get increasing number of details about the calculation. 
+
+#%% 
+#We then plot the results:
+#
+import matplotlib.pyplot as plt 
+
+s.plot('transmittance_noslit', wunit='nm')
+
+


### PR DESCRIPTION
Added HITEMP H20 spectra calculations for example gallery

<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address [issue 136](https://github.com/radis/radis/issues/136), adding a HITEMP H20 spectra calculation example using the calc_spectrum function. This is already a [Radis Lab example](https://github.com/radis/radis-lab/blob/main/examples/calculate_H2O_HITEMP.ipynb) that does the same, but was not present in the main Radis repository's examples gallery yet. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes issue https://github.com/radis/radis/issues/136
