### PR TITLE
wavenum_file

### DIFF
--- a/radis/api/cdsdapi.py
+++ b/radis/api/cdsdapi.py
@@ -322,10 +322,22 @@ def cdsd2df(
     # but files that have partly relevant lines are fully loaded.
     # Note : cache file is generated with the full line list.
 
+    def load_spectrum(h5_path, load_only_wavenum_above=None, load_only_wavenum_below=None):
+        df = load_h5_cache_file(h5_path)
+        if load_only_wavenum_above is not None:
+            df = df[df['wav'] > load_only_wavenum_above]
+        if load_only_wavenum_below is not None:
+            df = df[df['wav'] < load_only_wavenum_below]
+        return df
+
+    
+
     return df
+
 
 
 if __name__ == "__main__":
     from radis.test.io.test_hitran_cdsd import _run_testcases
-
     print("Testing cdsd: ", _run_testcases())
+
+# %%


### PR DESCRIPTION

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address the given TODO in cdsdapi.py

    # TODO : get only wavenum above/below 'load_only_wavenum_above', 'load_only_wavenum_below'
    # by parsing df.wav.  Completely irrelevant files are discarded in 'load_h5_cache_file'
    # but files that have partly relevant lines are fully loaded.
    # Note : cache file is generated with the full line list.

I tried solving this myself 
