### PR TITLE
Allowing arbitrary units in some methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,20 @@ or with *mamba*::
 
     mamba install radis
 
+
+**Remark**
+Depending on your platform you should write 
+
+# For Linux:
+pip install radis
+
+# For macOS:
+pip install -U radis --user
+
+# For Windows:
+python -m pip install radis
+
+
 **That's it!** You can now run your first example below.
 If you encounter any issue, or to upgrade the package later, please refer to the
 `detailed installation procedure <https://radis.readthedocs.io/en/latest/dev/developer.html#label-install>`__ .

--- a/README.rst
+++ b/README.rst
@@ -34,19 +34,6 @@ or with *mamba*::
     mamba install radis
 
 
-**Remark**
-Depending on your platform you should write 
-
-# For Linux:
-pip install radis
-
-# For macOS:
-pip install -U radis --user
-
-# For Windows:
-python -m pip install radis
-
-
 **That's it!** You can now run your first example below.
 If you encounter any issue, or to upgrade the package later, please refer to the
 `detailed installation procedure <https://radis.readthedocs.io/en/latest/dev/developer.html#label-install>`__ .

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -317,6 +317,44 @@ class SpectrumFactory(BandFactory):
     .. minigallery:: radis.SpectrumFactory
         :add-heading:
 
+    Plotting
+    -----
+    
+    The `plot` method can be used to visualize the resulting spectrum. Available plot types are:
+    
+    - 'absorption': plot absorption coefficient vs. wavenumber
+    - 'transmittance': plot transmittance vs. wavenumber
+    - 'radiance': plot radiance vs. wavenumber
+    - 'intensity': plot spectral intensity vs. wavenumber
+    - 'lines': plot individual spectral lines
+    
+    Each plot type also has additional optional parameters that can be passed to `plot_options`.
+    
+    Parameters
+    ----------
+    kind : str, optional
+        The type of plot to generate. Defaults to 'absorption'.
+        Valid options are 'absorption', 'transmittance', 'radiance', 'intensity', and 'lines'.
+    plot_options : dict, optional
+        A dictionary of additional plot options. Valid keys and their descriptions are:
+        
+        - 'figsize' : (width, height) tuple in inches for the plot figure size. Defaults to (10, 6).
+        - 'xlim' : (xmin, xmax) tuple in cm-1 for the x-axis limits. Defaults to (0, 5000).
+        - 'ylim' : (ymin, ymax) tuple for the y-axis limits. Defaults to 'auto'.
+        - 'linewidth' : float value for the line width. Defaults to 1.0.
+        - 'color' : string or tuple value for the line color. Defaults to 'k'.
+        - 'title' : string value for the plot title. Defaults to an automatically generated title.
+        - 'xlabel' : string value for the x-axis label. Defaults to 'Wavenumber (cm$^{-1}$)'.
+        - 'ylabel' : string value for the y-axis label. Defaults to 'Absorption Coefficient (cm$^{-1}$/(molecule cm$^{-2}$))' for 'absorption' plots,
+                      'Transmittance' for 'transmittance' plots,
+                      'Radiance (W/(cm$^{-1}$ sr))' for 'radiance' plots,
+                      'Spectral Intensity (W/(cm$^{-1}$ sr))' for 'intensity' plots.
+    
+    def plot(self, kind='absorption', plot_options=None):
+
+
+    
+
     Notes
     -----
 

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -317,43 +317,8 @@ class SpectrumFactory(BandFactory):
     .. minigallery:: radis.SpectrumFactory
         :add-heading:
 
-    Plotting
-    -----
     
-    The `plot` method can be used to visualize the resulting spectrum. Available plot types are:
-    
-    - 'absorption': plot absorption coefficient vs. wavenumber
-    - 'transmittance': plot transmittance vs. wavenumber
-    - 'radiance': plot radiance vs. wavenumber
-    - 'intensity': plot spectral intensity vs. wavenumber
-    - 'lines': plot individual spectral lines
-    
-    Each plot type also has additional optional parameters that can be passed to `plot_options`.
-    
-    Parameters
-    ----------
-    kind : str, optional
-        The type of plot to generate. Defaults to 'absorption'.
-        Valid options are 'absorption', 'transmittance', 'radiance', 'intensity', and 'lines'.
-    plot_options : dict, optional
-        A dictionary of additional plot options. Valid keys and their descriptions are:
-        
-        - 'figsize' : (width, height) tuple in inches for the plot figure size. Defaults to (10, 6).
-        - 'xlim' : (xmin, xmax) tuple in cm-1 for the x-axis limits. Defaults to (0, 5000).
-        - 'ylim' : (ymin, ymax) tuple for the y-axis limits. Defaults to 'auto'.
-        - 'linewidth' : float value for the line width. Defaults to 1.0.
-        - 'color' : string or tuple value for the line color. Defaults to 'k'.
-        - 'title' : string value for the plot title. Defaults to an automatically generated title.
-        - 'xlabel' : string value for the x-axis label. Defaults to 'Wavenumber (cm$^{-1}$)'.
-        - 'ylabel' : string value for the y-axis label. Defaults to 'Absorption Coefficient (cm$^{-1}$/(molecule cm$^{-2}$))' for 'absorption' plots,
-                      'Transmittance' for 'transmittance' plots,
-                      'Radiance (W/(cm$^{-1}$ sr))' for 'radiance' plots,
-                      'Spectral Intensity (W/(cm$^{-1}$ sr))' for 'intensity' plots.
-    
-    def plot(self, kind='absorption', plot_options=None):
 
-
-    
 
     Notes
     -----


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address [#57 Allow arbitrary units in Spectrum methods](https://github.com/radis/radis/issues/57) and suggests some solutions for the given methods : 
-crop
-rescale_mole_fraction
-rescale_path_length
-get_wavenumber
-get_radiance
-update (still a draft)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


