### PR TITLE
Removed manual exceptions in exomolapi and fixed broadf option

### DIFF
--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -129,58 +129,12 @@ def read_def(deff):
             unc = int(dat["VAL"][i]) == 1
 
     # SOME DEF FILES CONTAINS ERRORS. THESE ARE THE EXCEPTIONS
-    if deff.stem == "12C-16O2__UCL-4000":
-        ntransf = 20
-    if deff.stem == "1H3-16O_p__eXeL":
-        # fixes https://github.com/radis/radis/pull/531
-        ntransf = 100
-    if deff.stem == "14N-1H3__CoYuTe":
-        maxnu = 20000.0
-    if deff.stem == "40Ca-16O-1H__OYT6":
-        ntransf = 18
-        maxnu = 36000.0
-    if deff.stem == "32S-16O2__ExoAmes":
-        maxnu = 8000.0
     if deff.stem == "1H-35Cl__HITRAN-HCl":
         quantum_labels = ["v"]
         # See https://github.com/HajimeKawahara/exojax/issues/330
     if deff.stem == "16O-1H__MoLLIST":
         quantum_labels = ["e/f", "v", "F1/F2", "Es"]
-    if deff.stem == "12C2-1H2__aCeTY":
-        if molmass == 12.0:
-            molmass = 26.0
-            print(
-                f"Known error in ExoMol def file, molmass corrected from 12.0 to {molmass}"
-            )
-        if quantum_labels == [
-            "totalSym",
-            "v1",
-            "v2",
-            "v3",
-            "v4",
-            "v5",
-            "v5",
-            "v7",
-            "vibSym",
-            "K",
-            "rotSym",
-        ]:
-            quantum_labels = [
-                "totalSym",
-                "v1",
-                "v2",
-                "v3",
-                "v4",
-                "v5",
-                "v6",
-                "v7",
-                "vibSym",
-                "K",
-                "rotSym",
-            ]
-            print(
-                f"Known error in ExoMol def file, quantum_labels corrected from '['totalSym', 'v1', 'v2', 'v3', 'v4', 'v5', 'v5', 'v7', 'vibSym', 'K', 'rotSym']' to {quantum_labels}"
-            )
+
 
     if ntransf > 1:
         dnufile = maxnu / ntransf

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -135,7 +135,6 @@ def read_def(deff):
     if deff.stem == "16O-1H__MoLLIST":
         quantum_labels = ["e/f", "v", "F1/F2", "Es"]
 
-
     if ntransf > 1:
         dnufile = maxnu / ntransf
         numinf = dnufile * np.array(range(ntransf + 1))

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -139,6 +139,8 @@ def read_def(deff):
     if deff.stem == "40Ca-16O-1H__OYT6":
         ntransf = 18
         maxnu = 36000.0
+    if deff.stem == "32S-16O2__ExoAmes":
+        maxnu = 8000.0
     if deff.stem == "1H-35Cl__HITRAN-HCl":
         quantum_labels = ["v"]
         # See https://github.com/HajimeKawahara/exojax/issues/330
@@ -1171,7 +1173,7 @@ class MdbExomol(DatabaseManager):
             self.download(molec, extension=[".pf"])
         if not self.states_file.exists():
             self.download(molec, extension=[".states.bz2"])
-        if not self.broad_file.exists():
+        if (not self.broad_file.exists()) and self.broadf:
             self.download(molec, extension=[".broad"])
 
         # Add molecule name

--- a/radis/db/classes.py
+++ b/radis/db/classes.py
@@ -349,6 +349,7 @@ EXOMOL_MOLECULES = [
     "LiF",
     "LiH",
     "LiH_p",
+    "LiOH",
     "MgF",
     "MgH",
     "MgO",


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

(This is my first pull request to radis. I am a user of radis through exojax which is developed by Hajime Kawahara. Thank you in advance.)
- This pull request is to address a wrong value in [def file of SO2 in Exomol](https://www.exomol.com/db/SO2/32S-16O2/ExoAmes/32S-16O2__ExoAmes.def). 
```
14999.68                                                                        # Maximum wavenumber (in cm-1)
```
I added a manual exception in `exomol.api` to use the actual value (8000.0).

- I also fixed the use of `broadf` option. According to the parameter description, if False, the default parameters in .def file are used. I fixed the code to apply this option not to download .def file if False.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


