### PR TITLE
Allowing to use non numeric columns in HITRAN

### DIFF
--- a/radis/api/hitranapi.py
+++ b/radis/api/hitranapi.py
@@ -1175,7 +1175,7 @@ class HITRANDatabaseManager(DatabaseManager):
         else:
             raise NotImplementedError()
 
-    def download_and_parse(self, local_file, cache=True, parse_quanta=True):
+    def download_and_parse(self, local_file, cache=True, parse_quanta=True, drop_non_numeric=True):
         """Download from HITRAN and parse into ``local_file``.
         Also add metadata
 
@@ -1320,6 +1320,7 @@ class HITRANDatabaseManager(DatabaseManager):
                 df,
                 molecule=molecule,
                 parse_quanta=parse_quanta,
+                drop_non_numeric=drop_non_numeric
             )
 
             wmin_final = min(wmin_final, df.wav.min())

--- a/radis/api/hitranapi.py
+++ b/radis/api/hitranapi.py
@@ -292,6 +292,7 @@ def post_process_hitran_data(
     verbose=True,
     drop_non_numeric=True,
     parse_quanta=True,
+    add_HITRAN_uncertainty_code=False
 ):
     """Parsing non-equilibrum parameters in HITRAN/HITEMP [1]_ file to and return final Pandas Dataframe
 
@@ -313,6 +314,8 @@ def post_process_hitran_data(
     parse_quanta: bool
         if ``True``, parse local & global quanta (required to identify lines
         for non-LTE calculations ; but sometimes lines are not labelled.)
+    add_HITRAN_uncertainty_code: bool
+        if ``True``, a column which contains HITRAN uncertainty code is converted to integer and not dropped.
 
     Returns
     -------
@@ -396,6 +399,8 @@ def post_process_hitran_data(
     if drop_non_numeric:
         if "branch" in df:
             replace_PQR_with_m101(df)
+        if ("ierr" in df) and add_HITRAN_uncertainty_code:
+            df["ierr"] = df["ierr"].astype(int64)
         df = drop_object_format_columns(df, verbose=verbose)
 
     return df
@@ -1175,7 +1180,7 @@ class HITRANDatabaseManager(DatabaseManager):
         else:
             raise NotImplementedError()
 
-    def download_and_parse(self, local_file, cache=True, parse_quanta=True, drop_non_numeric=True):
+    def download_and_parse(self, local_file, cache=True, parse_quanta=True, add_HITRAN_uncertainty_code=False):
         """Download from HITRAN and parse into ``local_file``.
         Also add metadata
 
@@ -1320,7 +1325,7 @@ class HITRANDatabaseManager(DatabaseManager):
                 df,
                 molecule=molecule,
                 parse_quanta=parse_quanta,
-                drop_non_numeric=drop_non_numeric
+                add_HITRAN_uncertainty_code=add_HITRAN_uncertainty_code
             )
 
             wmin_final = min(wmin_final, df.wav.min())

--- a/radis/api/hitranapi.py
+++ b/radis/api/hitranapi.py
@@ -292,7 +292,7 @@ def post_process_hitran_data(
     verbose=True,
     drop_non_numeric=True,
     parse_quanta=True,
-    add_HITRAN_uncertainty_code=False
+    add_HITRAN_uncertainty_code=False,
 ):
     """Parsing non-equilibrum parameters in HITRAN/HITEMP [1]_ file to and return final Pandas Dataframe
 
@@ -1180,7 +1180,13 @@ class HITRANDatabaseManager(DatabaseManager):
         else:
             raise NotImplementedError()
 
-    def download_and_parse(self, local_file, cache=True, parse_quanta=True, add_HITRAN_uncertainty_code=False):
+    def download_and_parse(
+        self,
+        local_file,
+        cache=True,
+        parse_quanta=True,
+        add_HITRAN_uncertainty_code=False,
+    ):
         """Download from HITRAN and parse into ``local_file``.
         Also add metadata
 
@@ -1325,7 +1331,7 @@ class HITRANDatabaseManager(DatabaseManager):
                 df,
                 molecule=molecule,
                 parse_quanta=parse_quanta,
-                add_HITRAN_uncertainty_code=add_HITRAN_uncertainty_code
+                add_HITRAN_uncertainty_code=add_HITRAN_uncertainty_code,
             )
 
             wmin_final = min(wmin_final, df.wav.min())


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to use additional columns of the HITRAN database. I wanted to use the column "ierr" (uncertainty indices of transition parameters, as described in https://hitran.org/docs/uncertainties/) in ExoJAX, but it seems to be automatically removed in the downloading process.
I would like to make the existing option `drop_non_numeric` available in the function `download_and_parse`.

(I am sorry but the commit comment was wrong. It is not HITEMP, but HITRAN.)

