### PR TITLE
organized verbose message of hitemp

### DIFF
--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -12,7 +12,7 @@ https://stupidpythonideas.blogspot.com/2014/07/three-ways-to-read-files.html
 
 import re
 import urllib.request
-from os.path import basename, join
+from os.path import basename, commonpath, join
 from typing import Union
 
 import numpy as np
@@ -50,9 +50,7 @@ HITEMP_MOLECULES = ["H2O", "CO2", "N2O", "CO", "CH4", "NO", "NO2", "OH"]
 
 
 def keep_only_relevant(
-    inputfiles,
-    wavenum_min=None,
-    wavenum_max=None,
+    inputfiles, wavenum_min=None, wavenum_max=None, verbose=True
 ) -> Union[list, float, float]:
     """Parser file names for ``wavenum_format`` (min and max) and only keep
     relevant files if the requested range is ``[wavenum_min, wavenum_max]``
@@ -90,7 +88,16 @@ def keep_only_relevant(
             files_wmin = min(float(fname_wmin), files_wmin)
             files_wmax = max(float(fname_wmax), files_wmax)
 
-    print(f"HITEMP keep only relevant input files: {relevantfiles}")
+    if verbose and relevantfiles != []:
+        if len(relevantfiles) > 1:
+            folder = commonpath(relevantfiles)
+            # file_list = [x.replace(folder+'\\', '') for x in relevantfiles]
+            # print(f"In {folder} keep only relevant input files: {file_list}")
+            print(f"In ``{folder}`` keep only relevant input files:")
+            for file in relevantfiles:
+                print(file.replace(folder + "\\", ""))
+        else:
+            print(f"Keep only relevant input file: {relevantfiles}")
 
     return relevantfiles, files_wmin, files_wmax
 
@@ -241,17 +248,16 @@ class HITEMPDatabaseManager(DatabaseManager):
         return urlnames
 
     def keep_only_relevant(
-        self,
-        inputfiles,
-        wavenum_min=None,
-        wavenum_max=None,
+        self, inputfiles, wavenum_min=None, wavenum_max=None, verbose=True
     ) -> list:
         """For CO2 and H2O, return only relevant files for given wavenumber range.
 
         If other molecule, return the file anyway.
         see :py:func:`radis.api.hitempapi.keep_only_relevant`"""
         if self.molecule in ["CO2", "H2O"]:
-            inputfiles, _, _ = keep_only_relevant(inputfiles, wavenum_min, wavenum_max)
+            inputfiles, _, _ = keep_only_relevant(
+                inputfiles, wavenum_min, wavenum_max, verbose
+            )
         return inputfiles
 
     def get_linereturn_format(self, opener, urlname, columns):

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -141,7 +141,7 @@ def fetch_hitemp(
 
     # Delete files if needed:
     relevant_files = ldb.keep_only_relevant(
-        local_files, load_wavenum_min, load_wavenum_max
+        local_files, load_wavenum_min, load_wavenum_max, verbose=(verbose > 1)
     )
     if cache == "regen":
         ldb.remove_local_files(relevant_files)
@@ -153,7 +153,7 @@ def fetch_hitemp(
     # Get missing files
     download_files = ldb.get_missing_files(local_files)
     download_files = ldb.keep_only_relevant(
-        download_files, load_wavenum_min, load_wavenum_max
+        download_files, load_wavenum_min, load_wavenum_max, verbose=(verbose > 1)
     )
     # do not re-download files if they exist in another format :
     if engine in ["vaex", "auto", "default"]:
@@ -204,7 +204,7 @@ def fetch_hitemp(
 
     # Load and return
     files_loaded = ldb.keep_only_relevant(
-        local_files, load_wavenum_min, load_wavenum_max
+        local_files, load_wavenum_min, load_wavenum_max, verbose=verbose
     )
 
     if isotope and type(isotope) == int:


### PR DESCRIPTION
### Description / Old version
The `fetch_database` of HITEMP was a bit messy, displaying several times the same or different outputs (even if `verbose=0`. For instance:
```python
from radis.io.hitemp import fetch_hitemp
df = fetch_hitemp("CO2", output="vaex", verbose = 0,
                  load_wavenum_min=2400, load_wavenum_max=2500,
                  )
```
produced:
```
HITEMP keep only relevant input files: ['C:\\Users\\Nicolas Minesi\\.radisdb\\hitemp\\CO2-02_02250-02500_HITEMP2010.hdf5']
HITEMP keep only relevant input files: []
HITEMP keep only relevant input files: ['C:\\Users\\Nicolas Minesi\\.radisdb\\hitemp\\CO2-02_02250-02500_HITEMP2010.hdf5']
```

### New version
Now the print is shown only once and more is organized if multiple files are loaded:
```python
from radis.io.hitemp import fetch_hitemp
df = fetch_hitemp("CO2", output="vaex", verbose = 1,
                  load_wavenum_min=2000, load_wavenum_max=2500,
                  )
```
```
In ``C:\Users\Nicolas Minesi\.radisdb\hitemp`` keep only relevant input files:
CO2-02_02000-02125_HITEMP2010.hdf5
CO2-02_02125-02250_HITEMP2010.hdf5
CO2-02_02250-02500_HITEMP2010.hdf5
```
If a new file needs to be downloaded, the print is coherent as well:
```
Downloading 02_01500-02000_HITEMP2010.zip for CO2 (1/1).
Download complete. Parsing CO2 database to C:\Users\Nicolas Minesi\.radisdb\hitemp\CO2-02_01500-02000_HITEMP2010.hdf5
In ``C:\Users\Nicolas Minesi\.radisdb\hitemp`` keep only relevant input files:
CO2-02_01500-02000_HITEMP2010.hdf5
CO2-02_02000-02125_HITEMP2010.hdf5
CO2-02_02125-02250_HITEMP2010.hdf5
CO2-02_02250-02500_HITEMP2010.hdf5
```