### PR TITLE
trying without docs/requirements.txt

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -24,12 +24,5 @@ formats:
     - pdf
 #    - epub
 
-# Optional but recommended, declare the Python requirements required
-# to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-python:
-   install:
-   - extra_requirements: docs/requirements.txt
-
 conda:
-  environment: environment.yml
+  environment: docs/doc_environment.yml


### PR DESCRIPTION
indeed Readthedocs states that reuqirement.txt is not compatible with conda :  https://docs.readthedocs.io/en/stable/config-file/v2.html#conda

![image](https://github.com/radis/radis/assets/16088743/2f1097d3-85c3-4bf2-870f-7418d20d9de8)
