### PR TITLE
Unexpected behavior of plot_diff

### DIFF
--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -744,7 +744,8 @@ def plot_diff(
         Default is ``False``. By default won't save anything, type the path of the
         destination if you want to save it (format in the name).
     show: Bool
-        Default is ``True``. Will show the plots : bad if there are more than 20.
+        Default is ``True``. Will show the plots. You should switch to ``False`` if there are more than 20 calls of this function to avoid memory load during execution.
+        If ``False``, you can show the plot(s) with ``plt.show()``
     show_residual: bool
         if ``True``, calculates and shows on the graph the residual in L2 norm.
         See :func:`~radis.spectrum.compare.get_residual`. ``diff_window`` is
@@ -828,13 +829,6 @@ def plot_diff(
     from matplotlib.widgets import MultiCursor
 
     from radis.misc.plot import fix_style, set_style
-
-    if (not show) and (
-        not save
-    ):  # I added this line to avoid calculus in the case there is nothing to do (Minou)
-        if verbose:
-            print("plot_diff : Nothing to do")
-        return None, None
 
     var, wunit, Iunit = get_default_units(s1, s2, var=var, wunit=wunit, Iunit=Iunit)
 


### PR DESCRIPTION
### Description
```python
from radis import calc_spectrum, plot_diff

s1 = calc_spectrum(1900, 2300,         # cm-1
                  molecule='CO',
                  isotope='1,2,3',
                  pressure=1.01325,   # bar
                  Tgas=1000,
                  mole_fraction=0.1,
                  databank='hitran',  # or 'hitemp'
                  diluent = "air"     # or {'CO2': 0.1, 'air':0.8}
                  )
s2 = calc_spectrum(1900, 2300,         # cm-1
                  molecule='CO',
                  isotope='1,2,3',
                  pressure=1.01325,   # bar
                  Tgas=1100,
                  mole_fraction=0.1,
                  databank='hitran',  # or 'hitemp'
                  diluent = "air"     # or {'CO2': 0.1, 'air':0.8}
                  )
#%%
fig, [ax0, ax1] = plot_diff(s1, s2, show=False)
```
In this example, the plot_diff function did not output the figure attributes because of the `show=False` argument. The block that created this unexpected behavior is removed in this PR.
