### PR TITLE
Add an option to normalize at one point

### DIFF
--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -5307,7 +5307,7 @@ class Spectrum(object):
 
         if isinstance(wrange, (int, float)):
             # Use user provided point. Only makes sense to normalize using
-            # normalize_how='max', but seems dramatic to raise an error.
+            # normalize_how='max', otherwise raise an error.
             w, I = s.get(
                 var, wunit=wunit, Iunit=s.units[var], copy=False
             )  # (faster not to copy)
@@ -5316,10 +5316,10 @@ class Spectrum(object):
                 norm = I[np.argmin(np.abs(w - wrange))]
                 norm_unit = s.units[var]
             elif normalize_how == "mean" or normalize_how == "area":
-                warn(
+                raise ValueError(
+                    "Unexpected `normalize_how`: {0}. "
                     "For a single value wrange only `normalize_how='max'` is "
-                    "defined."
-                    "Ignoring `normalize_how='{0}'`".format(normalize_how)
+                    "defined.".format(normalize_how)
                 )
             else:
                 raise ValueError(

--- a/radis/test/spectrum/test_spectrum.py
+++ b/radis/test/spectrum/test_spectrum.py
@@ -536,9 +536,17 @@ def test_normalization(*args, **kwargs):
         s3.crop(2125, 2150).get_integral("radiance", wunit=s3.get_waveunit()), 1
     )
 
+    # Test the spectrum can be normalized at a single point,
     w, I = s.get("radiance")
     s4 = s.normalize(wrange=w[18047])
     assert np.isclose(s4.get("radiance")[1][18047], 1)
+
+    # and the errors are raised if a user tries to pass nonsense options.
+    with pytest.raises(ValueError):
+        s.normalize(wrange=w[18047], normalize_how="mean")
+
+    with pytest.raises(ValueError):
+        s.normalize(wrange=w[18047], normalize_how="area")
 
 
 @pytest.mark.fast

--- a/radis/test/spectrum/test_spectrum.py
+++ b/radis/test/spectrum/test_spectrum.py
@@ -536,6 +536,10 @@ def test_normalization(*args, **kwargs):
         s3.crop(2125, 2150).get_integral("radiance", wunit=s3.get_waveunit()), 1
     )
 
+    w, I = s.get("radiance")
+    s4 = s.normalize(wrange=w[18047])
+    assert np.isclose(s4.get("radiance")[1][18047], 1)
+
 
 @pytest.mark.fast
 def test_sort(*args, **kwargs):


### PR DESCRIPTION
### Description

This pull request is to address #127, adding an option to normalize at a single point. I've also added a few more lines to `test_spectrum` to test this.

I made two choices when doing this that might not be ideal:
1. No matter what the supplied `wrange` value is, we find the closest point in the spectrum and normalise to that. Other options could include testing if the given point is close enough to an existing one or using interpolation between existing points, but that makes it all much more complicated. Seems simplest to leave it up to the user to check they're happy.
2. Using the `"max"`, `"mean"` or `"area"` options for the `normalize_how` argument don't make sense to me because it's only one value. As `"max"` is the default option nothing happens using this. If you use `"mean"` or `"area"` then it'll warn you that it's ignoring them and uses `"max"` anyway. This again seems like the simplest option.

The test is simple, I've taken a wavelength value at a given index, normalized around this point, and tested in the normalized spectrum at this index is close to 1.