### PR TITLE
(too) simple solution to accelerate potential halt of travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,21 @@ jobs:
         # Your test script goes here
         - echo ">>> Run tests"
         # use XVFB to have headless display port, and still run the Matplotlib tests.
-        - xvfb-run -a pytest --cov=./ --durations=10
+        - xvfb-run -a pytest -m "fast" --cov=./ --durations=10
         # --durations=N to print the slowest N tests
         # lookup 'addopts' in setup.cfg>[tools:pytest] for default tests
+
+      services:
+        - xvfb
+
+      before_script:
+        - export MPLBACKEND=Agg
+
+    - stage: long_tests
+      name: Long Tests
+      script:
+        - echo ">>> Run tests which are long "
+        - xvfb-run -a pytest -m "not fast" --cov=./ --durations=10
 
       services:
         - xvfb


### PR DESCRIPTION
### Description
Here is a simple solution to accelerate the potential crash of Travis during the development phases of a PR. In the first stage, only the tests marked as "fast" are performed. If they pass, only the others "not fast", are tested.

Let me know what you think @erwanp @dcmvdbekerom 