### PR TITLE
Separation of fast and "not fast" tests during Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,8 @@ jobs:
         # Your test script goes here
         - echo ">>> Run tests"
         # use XVFB to have headless display port, and still run the Matplotlib tests.
-        - xvfb-run -a pytest --cov=./ --durations=10
+        - xvfb-run -a pytest -m "fast"  --cov=./ --durations=10
+        - xvfb-run -a pytest -m "not fast"  --cov=./ --durations=10
         # --durations=N to print the slowest N tests
         # lookup 'addopts' in setup.cfg>[tools:pytest] for default tests
 

--- a/radis/test/lbl/test_broadening.py
+++ b/radis/test/lbl/test_broadening.py
@@ -23,7 +23,7 @@ from radis.spectrum.spectrum import Spectrum
 from radis.test.utils import setup_test_line_databases
 
 
-@pytest.mark.fast
+# @pytest.mark.fast
 @pytest.mark.needs_connection
 def test_broadening_vs_hapi(rtol=1e-2, verbose=True, plot=False, *args, **kwargs):
     """


### PR DESCRIPTION
### Description
Travis testing can be relatively long. This PR proposes to run the pytests labeled "fast" first, then the others.
