### PR TITLE
Make codebase Pandas 2.0-ready

### DIFF
--- a/radis/test/utils.py
+++ b/radis/test/utils.py
@@ -386,7 +386,10 @@ def define_Evib_as_min_of_polyad(levels, keys):
         return grp
 
     levels = levels.groupby(keys).apply(fill_EvibErot)
-    levels.reset_index()
+    # Note: The `allow_duplicates` parameter controls whether duplicate column
+    #   labels are allowed. The `True` behaviour used to be the default in
+    #   Pandas <2.0.
+    levels.reset_index(allow_duplicates=True)
 
     return levels
 


### PR DESCRIPTION
### Description

Fixes #600.

This PR fixes the parts of the codebase that are currently preventing an upgrade to Pandas 2.0 and later. Two things worth noting:

* The machine on which I ran the code doesn't have an nVidia GPU, so I did not run the full test suite.
* I only fixed the code itself, I did not bump requirements. FWIW, the Python version support list is as follows:
  * [2.0.x: 3.8 to 3.11](https://pandas.pydata.org/pandas-docs/version/2.0/getting_started/install.html#python-version-support)
  * [2.1.x: 3.9 to 3.11](https://pandas.pydata.org/pandas-docs/version/2.1/getting_started/install.html#python-version-support)
  * [2.2.x: 3.9 to 3.12](https://pandas.pydata.org/docs/getting_started/install.html#python-version-support)
* Happy to add more to this PR in case you're aware of more parts in the code that would need a fix. 