### PR TITLE
Solution to rounding issue while summing mole fractions

### DIFF
--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -358,8 +358,8 @@ def pressure_broadening_HWHM(
         gamma_lb += (
             (Tref / Tgas) ** n_i * gamma_i * pressure_atm * diluent_mole_fraction
         )
-
-    assert mole_fraction + sum(diluent.values()) == 1
+    total_mole_fraction = mole_fraction + sum(diluent.values())
+    assert np.isclose(total_mole_fraction, 1)
 
     # Adding self (resonant) broadening and temperature dependance self coefficient
     # ... if Tdpsel is not in `dg` then Tdpair is used.

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -1943,19 +1943,12 @@ class SpectrumFactory(BandFactory):
 
         # Checking mole_fraction of molecule and diluent
         total_mole_fraction = mole_fraction + sum(list(diluents.values()))
-        if total_mole_fraction > 1:
-            raise MoleFractionError(
-                "Total molefraction = {0} of molecule and diluents greater than 1. Please set appropriate molefraction value of molecule and diluents.".format(
-                    total_mole_fraction
-                )
-            )
-        elif total_mole_fraction < 1:
-            raise MoleFractionError(
-                "Total molefraction = {0} of molecule and diluents less than 1. Please set appropriate molefraction value of molecule and diluents".format(
-                    total_mole_fraction
-                )
-            )
-
+        if not np.isclose(total_mole_fraction, 1):
+            if total_mole_fraction > 1:
+                message = "Total molefraction = {0} of molecule and diluents greater than 1. Please set appropriate molefraction value of molecule and diluents.".format(total_mole_fraction)
+            else:
+                message = "Total molefraction = {0} of molecule and diluents less than 1. Please set appropriate molefraction value of molecule and diluents".format(total_mole_fraction)
+            raise MoleFractionError(message)
         self._diluent = diluents
 
     def predict_time(self):


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->
Solution to issue #640 

The rounding error is solved by checking if `total_mole_fraction` _is close_ to 1

For the example : 
```
from radis import MergeSlabs, calc_spectrum

x_H2O = 0.2
x_CO2 = 0.1
x_air = 1 - x_H2O - x_CO2 #for rounding errors
Tgas = 500
common_conditions = {"pressure":2, "path_length":4, "isotope":"all","wstep":'auto',
                     "Tgas":Tgas}
s_H2O = calc_spectrum(1200, 4000,         # cm-1
                  molecule='H2O',
                  mole_fraction=x_H2O,
                  databank='hitran',  # 'hitemp' more precise but long to download
                  diluent = {'CO2': x_CO2, 'air': x_air},    
                  name=f"H2O - T = {Tgas} K",
                  **common_conditions,
                  )
s_CO2 = calc_spectrum(1200, 4000,         # cm-1
                  molecule='CO2',
                  mole_fraction=x_CO2,
                  databank='hitran',  # 'hitemp' more precise but long to download
                  diluent = {'H2O': x_H2O, 'air': x_air},    
                  name=f"CO2 - T = {Tgas} K",
                  **common_conditions,
                  )
s_H2O.plot('absorbance', nfig="same")
s_CO2.plot('absorbance', nfig="same")
```

The Output obtained is : 

![image](https://github.com/radis/radis/assets/90528630/860bcf1a-3fe1-46a8-979e-25be3fe8a66f)
![image](https://github.com/radis/radis/assets/90528630/f323e1db-85c0-4b0d-b8c4-8f41f208cdde)




Fixes #640 
