### PR TITLE
Remove install dependency + support Python 3.9, 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ os: linux
 stages:
   - name: test
     if: branch = master OR branch = develop
+  - name: test_slow
+    if: branch = master OR branch = develop
     # we dont test on other branches
   - name: lint
     if: branch = master OR branch = develop
@@ -59,13 +61,26 @@ jobs:
       services:
         - xvfb
 
+      before_script:
+        - export MPLBACKEND=Agg
+
+    - stage: test_slow
+      name: Test and Coverage
+
+      script:
+        # Your test script goes here
+        - echo ">>> Run tests"
+        # use XVFB to have headless display port, and still run the Matplotlib tests.
+        - xvfb-run -a pytest --cov=./ --durations=10 # re-run the fast tests as well... but it should be fast!
+        # lookup 'addopts' in setup.cfg>[tools:pytest] for default tests
+
+      services:
+        - xvfb
+
       after_success:
         # codecoverage
         - pip install codecov
         - codecov
-
-      before_script:
-        - export MPLBACKEND=Agg
 
     - stage: lint
       name: Code Quality Checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ stages:
 jobs:
   include:
     - stage: test
-      name: Test and Coverage
+      name: Test and Coverage (fast)
       install:
         # Install Micromamba
         # We do this conditionally because it saves us some downloading if the
@@ -54,24 +54,7 @@ jobs:
         - echo ">>> Run tests"
         # use XVFB to have headless display port, and still run the Matplotlib tests.
         - xvfb-run -a pytest -m "fast" --cov=./ --durations=10
-        - xvfb-run -a pytest -m "not fast" --cov=./ --durations=10
         # --durations=N to print the slowest N tests
-        # lookup 'addopts' in setup.cfg>[tools:pytest] for default tests
-
-      services:
-        - xvfb
-
-      before_script:
-        - export MPLBACKEND=Agg
-
-    - stage: test_slow
-      name: Test and Coverage
-
-      script:
-        # Your test script goes here
-        - echo ">>> Run tests"
-        # use XVFB to have headless display port, and still run the Matplotlib tests.
-        - xvfb-run -a pytest --cov=./ --durations=10 # re-run the fast tests as well... but it should be fast!
         # lookup 'addopts' in setup.cfg>[tools:pytest] for default tests
 
       services:
@@ -81,6 +64,32 @@ jobs:
         # codecoverage
         - pip install codecov
         - codecov
+
+      before_script:
+        - export MPLBACKEND=Agg
+
+    - stage: test_slow
+      name: Test and Coverage (slow)
+
+      script:
+        # Your test script goes here
+        - echo ">>> Run tests"
+        # use XVFB to have headless display port, and still run the Matplotlib tests.
+        - xvfb-run -a pytest --cov=./ --durations=10
+        # --durations=N to print the slowest N tests
+        # lookup 'addopts' in setup.cfg>[tools:pytest] for default tests
+
+      services:
+        - xvfb
+
+      after_success:
+        # codecoverage
+        - pip install codecov
+        - codecov
+
+      before_script:
+        - export MPLBACKEND=Agg
+
 
     - stage: lint
       name: Code Quality Checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ stages:
     if: branch = master OR branch = develop
   - name: test_slow
     if: branch = master OR branch = develop
-  - name: test_slow
-    if: branch = master OR branch = develop
     # we dont test on other branches
   - name: lint
     if: branch = master OR branch = develop
@@ -112,29 +110,6 @@ jobs:
 
       before_script:
         - export MPLBACKEND=Agg
-
-    - stage: test_slow
-      name: Test and Coverage (slow)
-
-      script:
-        # Your test script goes here
-        - echo ">>> Run tests"
-        # use XVFB to have headless display port, and still run the Matplotlib tests.
-        - xvfb-run -a pytest --cov=./ --durations=10
-        # --durations=N to print the slowest N tests
-        # lookup 'addopts' in setup.cfg>[tools:pytest] for default tests
-
-      services:
-        - xvfb
-
-      after_success:
-        # codecoverage
-        - pip install codecov
-        - codecov
-
-      before_script:
-        - export MPLBACKEND=Agg
-
 
     - stage: lint
       name: Code Quality Checks

--- a/environment.yml
+++ b/environment.yml
@@ -5,13 +5,13 @@ channels:
 - astropy
 - plotly
 dependencies:
-- python=3.8  # Needed by vaex - https://github.com/vaexio/vaex/issues/2397
+- python=3.8  # Needed by vaex 4.17 - https://github.com/vaexio/vaex/issues/2397
 - astropy>=4.3.1  # Unit aware calculations
 - astroquery>=0.4.6  # to fetch HITRAN databases
 - beautifulsoup4>=4.10.0 # parse ExoMol website
 - cantera>=2.5.1   # for chemical equilibrium computations
 - configparser
-- cython          # EP : really needed? pipreqs doesn't say so
+#- cython          # Not needed, see #647
 - habanero>=1.2.0  # CrossRef API to retrieve data from doi
 - h5py>=3.2.1   # load HDF5
 - joblib  # for parallel loading of SpecDatabase
@@ -28,8 +28,7 @@ dependencies:
 - seaborn   # other matplotlib themes
 - termcolor  # terminal colors
 - specutils
-- vaex-core
-#- vaex-core>=4.17.0   # load HDF5 files  (version needed to fix https://github.com/radis/radis/issues/598)
+- vaex-core>=4.17.0   # load HDF5 files  (version needed to fix https://github.com/radis/radis/issues/598)
 - vaex-hdf5
 - vaex-viz
 - pip

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 - astropy
 - plotly
 dependencies:
-#- python=3.8 #NM not really needed
+- python=3.8  # Needed by vaex - https://github.com/vaexio/vaex/issues/2397
 - astropy>=4.3.1  # Unit aware calculations
 - astroquery>=0.4.6  # to fetch HITRAN databases
 - beautifulsoup4>=4.10.0 # parse ExoMol website

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
 - matplotlib
 - numpy
 - numba  # just-in-time compiler
-- pandas<2.0.0   # not ready for 2.0 yet ; some breaking compatibility, see issue #600
+#- pandas<2.0.0   # solved in #641
 - plotly>=2.5.1  # for line survey HTML output
 - progressbar2    # used in vaex
 - psutil # to get user RAM
@@ -28,7 +28,8 @@ dependencies:
 - seaborn   # other matplotlib themes
 - termcolor  # terminal colors
 - specutils
-- vaex-core>=4.17.0   # load HDF5 files  (version needed to fix https://github.com/radis/radis/issues/598)
+- vaex-core
+#- vaex-core>=4.17.0   # load HDF5 files  (version needed to fix https://github.com/radis/radis/issues/598)
 - vaex-hdf5
 - vaex-viz
 - pip

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
 - numba  # just-in-time compiler
 - pandas
 - plotly>=2.5.1  # for line survey HTML output
-- progressbar2    # used in vaex
+#- progressbar2    # used in vaex
 - psutil # to get user RAM
 - pytables # for pandas to HDF5 export
 - scipy>=1.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 - astropy
 - plotly
 dependencies:
-- python=3.8
+#- python=3.8 #NM not really needed
 - astropy>=4.3.1  # Unit aware calculations
 - astroquery>=0.4.6  # to fetch HITRAN databases
 - beautifulsoup4>=4.10.0 # parse ExoMol website

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Installed by "pip install -e .[dev]" as well as "conda env create --file environment.yml"
 lxml           # parser used for ExoMol website
 hjson          # Json with comments (for default_radis.json)
-publib>=0.3.2  # Plotting styles for Matplotlib
+publib>=0.4.0  # Plotting styles for Matplotlib. Version, see #647
 hitran-api     # HAPI, used to access TIPS partition functions
 peakutils
 ruamel.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Installed by "pip install -e .[dev]" as well as "conda env create --file environment.yml"
 lxml           # parser used for ExoMol website
 hjson          # Json with comments (for default_radis.json)
-publib>=0.4.0  # Plotting styles for Matplotlib. Version, see #647
+publib>=0.3.2  # Plotting styles for Matplotlib. Version, update to 0.4.0 needed for matplotlib==3.8. However, only 0.3.2 is compatible with python==3.8 (see #647)
 hitran-api     # HAPI, used to access TIPS partition functions
 peakutils
 ruamel.yaml

--- a/setup.py
+++ b/setup.py
@@ -246,6 +246,7 @@ def run_setup(with_binary):
         ],
         packages=find_packages(),
         install_requires=[],
+        python_requires="<3.9",  # this limit is introduced by vaex, see https://github.com/radis/radis/pull/647
         # do not add requirements here, add them directly in the requirements.txt file
         # note EP : generate a requirement.txt by Mamba & pip freeze for Pypi deployment ? see https://stackoverflow.com/a/75239980/5622825
         extras_require={


### PR DESCRIPTION
This PR is to attempt to remove dependencies in the install of RADIS. Each push will be tested for one of the requirements of `environment.yaml`

- [x] python=3.8  - required by vaex, see https://github.com/vaexio/vaex/issues/2397
- [x] cython
- [x] pandas < 2.0 - solved in #641
- [x] publib - Not possible with python>3.8
- [x] progressbar2 - noted as needed by vaex, so it should be automatically managed by vaex (not us)

Also:

- [x] add limit `python<3.9` in `setup.py` for pip install 