### PR TITLE
[bug fix] Interactive plotting failed

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10" #as of July 2024, vaex is compatible up to python==3.10 and we want the doc to run vaex examples
+    python: "mambaforge-4.10"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "mambaforge-4.10"
+    python: "3.10" #as of July 2024, vaex is compatible up to python==3.10 and we want the doc to run vaex examples
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/radis/tools/fitting.py
+++ b/radis/tools/fitting.py
@@ -449,7 +449,7 @@ def fit_legacy(
                 x, y = lineValues[k].get_data()
                 lineValues[k].set_data((np.hstack((x, ite)), np.hstack((y, v))))
             # Plot last
-            lineLast.set_data((ite, res))
+            lineLast.set_data([ite], [res])
 
             if blit:
                 # ... from https://stackoverflow.com/questions/40126176/fast-live-plotting-in-matplotlib-pyplot


### PR DESCRIPTION
The interactive plot during the fitting, (e.g. `plot4_legacyFit_Tgas.py`) failed when building the documentation.

Extract of error from readthedocs
```
../examples/3_Fitting/plot4_legacyFit_Tgas.py failed leaving traceback:

    Traceback (most recent call last):
      File "/home/docs/checkouts/readthedocs.org/user_builds/radis/checkouts/652/examples/3_Fitting/plot4_legacyFit_Tgas.py", line 100, in <module>
        s_best, best = sf.fit_legacy(
                       ^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/radis/checkouts/652/radis/lbl/factory.py", line 2408, in fit_legacy
        return fit_legacy(
               ^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/radis/checkouts/652/radis/tools/fitting.py", line 486, in fit_legacy
        best = minimize(
               ^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/radis/conda/652/lib/python3.12/site-packages/scipy/optimize/_minimize.py", line 731, in minimize
        res = _minimize_lbfgsb(fun, x0, args, jac, bounds,
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/radis/conda/652/lib/python3.12/site-packages/scipy/optimize/_lbfgsb_py.py", line 347, in _minimize_lbfgsb
        sf = _prepare_scalar_function(fun, x0, jac=jac, args=args, epsilon=eps,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/radis/conda/652/lib/python3.12/site-packages/scipy/optimize/_optimize.py", line 288, in _prepare_scalar_function
        sf = ScalarFunction(fun, x0, args, grad, hess,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/radis/conda/652/lib/python3.12/site-packages/scipy/optimize/_differentiable_functions.py", line 222, in __init__
        self._update_fun()
      File "/home/docs/checkouts/readthedocs.org/user_builds/radis/conda/652/lib/python3.12/site-packages/scipy/optimize/_differentiable_functions.py", line 294, in _update_fun
        fx = self._wrapped_fun(self.x)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/radis/conda/652/lib/python3.12/site-packages/scipy/optimize/_differentiable_functions.py", line 20, in wrapped
        fx = fun(np.copy(x), *args)
             ^^^^^^^^^^^^^^^^^^^^^^
      File "/home/docs/checkouts/readthedocs.org/user_builds/radis/checkouts/652/radis/tools/fitting.py", line 452, in cost_and_plot_function
        lineLast.set_data((ite, res))
      File "/home/docs/checkouts/readthedocs.org/user_builds/radis/conda/652/lib/python3.12/site-packages/matplotlib/lines.py", line 665, in set_data
        self.set_xdata(x)
      File "/home/docs/checkouts/readthedocs.org/user_builds/radis/conda/652/lib/python3.12/site-packages/matplotlib/lines.py", line 1289, in set_xdata
        raise RuntimeError('x must be a sequence')
    RuntimeError: x must be a sequence
```