### PR TITLE
[bug] S (-2) and O (+2) branchs were not converted to numeric columns - apply to N2 in HITRAN

### DIFF
--- a/radis/api/tools.py
+++ b/radis/api/tools.py
@@ -254,7 +254,7 @@ def drop_object_format_columns(df, verbose=True):
 
 
 def replace_PQR_with_m101(df):
-    """Return P, Q, R in column ``branch`` with -1, 0, 1 to get a fully numeric
+    """Return O, P, Q, R, S in column ``branch`` with -2, -1, 0, 1, 2 to get a fully numeric
     database. This improves performances quite a lot, as Pandas doesnt have a
     fixed-string dtype hence would use the slow ``object`` dtype.
 
@@ -288,7 +288,7 @@ def replace_PQR_with_m101(df):
 
     # Then do the actual mapping
     if df.dtypes["branch"] != np.int64:
-        mapping = {"P": -1, "Q": 0, "R": 1}
+        mapping = {"P": -1, "Q": 0, "R": 1, "O": -2, "S": 2}
         if df_type == pd.DataFrame:  # pandas
             new_col = df["branch"].replace(mapping)
         else:  # vaex


### PR DESCRIPTION
### Description
The following code was failing when attempting to save to hdf5 because the "S" branch of N2 2nd isotopologue was not converted to a numeric.
```python
from radis import calc_spectrum

s = calc_spectrum(wavelength_min=1000,
    wavelength_max=20000,
    Tgas=300,
    pressure=1,
    path_length=100e2, #100 km
    molecule='N2',
    cutoff=1e-32,
    # isotope='2'
    )
s.plot('absorbance')
```

Fixes #662 
![image](https://github.com/user-attachments/assets/be1fabf3-b2f0-417e-ad2d-0405f9440919)
