### PR TITLE
A bug related to map_add

### DIFF
--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -460,7 +460,7 @@ def pickup_gE(states, trans, dic_def, skip_optional_data=True, engine="vaex"):
             return column.hasnans
 
     if not "nu_lines" in trans or has_nan(trans["nu_lines"]):
-        map_add("E", "eupper", "i_upper")
+        trans = map_add(trans, "E", "eupper", "i_upper")
         trans["nu_lines"] = trans["eupper"] - trans["elower"]
 
     ### Step 2. Extra quantum numbers (e/f parity, vib and rot numbers)
@@ -1203,7 +1203,7 @@ class MdbExomol(DatabaseManager):
 
                 # Complete transition data with lookup on upper & lower state :
                 # In particular, compute gup and elower
-
+                
                 trans = pickup_gE(
                     states,
                     trans,

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -423,7 +423,7 @@ def pickup_gE(states, trans, dic_def, skip_optional_data=True, engine="vaex"):
         --------
         ::
 
-            map_add("E", "E_lower", "i_lower")
+            trans = map_add(trans, "E", "E_lower", "i_lower")
         """
         if engine == "pytables":
             # Rename the columns in the states DataFrame
@@ -467,8 +467,8 @@ def pickup_gE(states, trans, dic_def, skip_optional_data=True, engine="vaex"):
     # -----------------------------------------------------------------
     if not skip_optional_data:
         for q in dic_def["quantum_labels"]:
-            map_add(q, f"{q}_l", "i_lower")
-            map_add(q, f"{q}_u", "i_upper")
+            trans = map_add(trans, q, f"{q}_l", "i_lower")
+            trans = map_add(trans, q, f"{q}_u", "i_upper")
 
     return trans
 

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -1203,7 +1203,7 @@ class MdbExomol(DatabaseManager):
 
                 # Complete transition data with lookup on upper & lower state :
                 # In particular, compute gup and elower
-                
+
                 trans = pickup_gE(
                     states,
                     trans,


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->





### Description
<!-- Provide a general description of what your pull request does. -->

Some updates to the `exomolapy.py` file were not made to accommodate the additional arguments due to changes in the `map_add` specification. This causes a serious bug when downloading specific molecules.

```python
        map_add("E", "eupper", "i_upper")
```
should be 
```python
        trans = map_add(trans, "E", "eupper", "i_upper")
```

Specifically, when the `trans` file does not include `nu_lines`, `exomolapi` is designed to calculate `nu_lines` from `eupper` and `elower`, but this is not functioning correctly. For example, H2S is such a molecule, so initialization fails. For more details, please see https://github.com/HajimeKawahara/exojax/issues/504 .

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes https://github.com/HajimeKawahara/exojax/issues/504
