### PR TITLE
Missing GPU files in deploy and xsection rescaling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -165,5 +165,5 @@ jobs:
       - VERSION_RADIS=$(cat radis/__version__.txt)
       - pip install radis==$VERSION_RADIS
       - pip install pytest
-      - xvfb-run -a pytest -m "not fast and not needs_cuda and not download_large_databases and not needs_db_CDSD_HITEMP and not needs_db_CDSD_HITEMP_PCN and not needs_db_CDSD_HITEMP_PC and not needs_db_HITEMP_CO2_DUNHAM and not needs_db_HITEMP_CO_DUNHAM" --durations=10
+      - xvfb-run -a pytest -m "fast and not needs_cuda and not download_large_databases and not needs_db_CDSD_HITEMP and not needs_db_CDSD_HITEMP_PCN and not needs_db_CDSD_HITEMP_PC and not needs_db_HITEMP_CO2_DUNHAM and not needs_db_HITEMP_CO_DUNHAM" --durations=10
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,8 +138,15 @@ jobs:
 
     - stage: deploy
       name: Deploy to PyPI
+      services:
+        - xvfb
       install:
         - sudo apt-get update
+        #Next is to test after deploy
+        - wget -qO- https://micro.mamba.pm/api/micromamba/linux-64/1.5.8 | tar -xvj bin/micromamba
+        - ./bin/micromamba shell init -s bash -p ~/micromamba
+        - source ~/.bashrc
+        - micromamba activate base
       before_script: skip #do NOT run the before_script of "tests" stage
       script:
         - echo "Deploying to PyPI"
@@ -154,3 +161,9 @@ jobs:
         skip_existing: true
         skip_cleanup: true    # to keep wheels (in the ./dist folder?)
         distributions: "sdist bdist_wheel"
+      after_deploy:
+      - VERSION_RADIS=$(cat radis/__version__.txt)
+      - pip install radis==$VERSION_RADIS
+      - pip install pytest
+      - xvfb-run -a pytest -m "not fast and not needs_cuda and not download_large_databases and not needs_db_CDSD_HITEMP and not needs_db_CDSD_HITEMP_PCN and not needs_db_CDSD_HITEMP_PC and not needs_db_HITEMP_CO2_DUNHAM and not needs_db_HITEMP_CO_DUNHAM" --durations=10
+

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -1172,7 +1172,7 @@ class DatabankLoader(object):
         if [parfuncfmt, source].count("exomol") == 1:
             self.warn(
                 f"Using lines from {source} but partition functions from {parfuncfmt}"
-                + "for consistency we recommend using lines and partition functions from the same database",
+                + " for consistency we recommend using lines and partition functions from the same database",
                 "AccuracyWarning",
             )
         if memory_mapping_engine == "default":

--- a/radis/spectrum/rescale.py
+++ b/radis/spectrum/rescale.py
@@ -2017,6 +2017,20 @@ def _recalculate(
         recompute.append("abscoeff")
     recompute = set(recompute)  # remove duplicates
 
+    # check the slab is homogeneous to compute the cross-section
+    for key in ["Tgas", "pressure", "mole_fraction"]:
+        good = isinstance(spec.conditions[key], (int, float)) and not isinstance(
+            spec.conditions[key], bool
+        )
+        if "xsection" in recompute and not good:
+            recompute.remove("xsection")
+            warn(
+                f"Rescaling the 'xsection' of Spectrum {spec.get_name()} but"
+                + " the spectrum is not homogeneous or not defined:\n"
+                + f"s.conditions[{key}] = 'N/A'\n"
+                + "If you are merging two spectra, make sure cross-sections are not included in the initial spectra, see https://github.com/radis/radis/issues/682."
+            )
+
     # Get units
     rescaled_units = spec.units.copy()
 
@@ -2272,7 +2286,7 @@ def _recalculate(
     for q in wanted:
         if not q in rescaled_list:
             raise AssertionError(
-                "{0} could not be rescaled as wanted. ".format(q)
+                "'{0}' could not be rescaled as wanted. ".format(q)
                 + "The following properties were rescaled: {0}".format(rescaled_list)
             )
     # ... everyone was added in the Spectrum properly
@@ -2280,14 +2294,14 @@ def _recalculate(
     for q in wanted:
         if not q in final_list:
             raise AssertionError(
-                "{0} is not in the final Spectrum. ".format(q)
+                "'{0}' is not in the final Spectrum. ".format(q)
                 + "Rescaled spectrum contains: {0}".format(final_list)
             )
     # ... "everyone was rescaled": check we didnt scale only part of the spectrum
     for q in initial:
         if not q in rescaled_list:
             raise AssertionError(
-                "{0} was initially in the Spectrum but was not ".format(q)
+                "'{0}' was initially in the Spectrum but was not ".format(q)
                 + "rescaled. This can lead to error. Rescaled spectrum "
                 + "contains: {0}".format(rescaled_list)
             )

--- a/radis/spectrum/rescale.py
+++ b/radis/spectrum/rescale.py
@@ -2019,9 +2019,12 @@ def _recalculate(
 
     # check the slab is homogeneous to compute the cross-section
     for key in ["Tgas", "pressure", "mole_fraction"]:
-        good = isinstance(spec.conditions[key], (int, float)) and not isinstance(
-            spec.conditions[key], bool
-        )
+        if key in spec.conditions:
+            good = isinstance(spec.conditions[key], (int, float)) and not isinstance(
+                spec.conditions[key], bool
+            )
+        else:
+            continue
         if "xsection" in recompute and not good:
             recompute.remove("xsection")
             warn(

--- a/radis/test/lbl/test_loader.py
+++ b/radis/test/lbl/test_loader.py
@@ -24,9 +24,11 @@ except ImportError:
 
 pytestmark = pytest.mark.random_order(
     disabled=True
-)  # to make sure HITEMP-CO2-TEST is downloaded for every test
+)  # to make sure HITEMP-CO2-TEST is downloaded in 1st test and used after
 
 
+@pytest.mark.needs_connection
+@pytest.mark.fast
 def test_retrieve_from_database(
     plot=False, verbose=True, warnings=True, *args, **kwargs
 ):
@@ -233,6 +235,8 @@ def test_custom_abundance(verbose=True, plot=False, *args, **kwargs):
     assert s.compare_with((3 * s3.take("abscoeff")), "abscoeff", rtol=0.5e-2, plot=True)
 
 
+@pytest.mark.needs_connection
+@pytest.mark.download_large_databases
 @pytest.mark.skipif(isinstance(vaex, NotInstalled), reason="Vaex not available")
 def test_vaex_and_pandas_dataframe_fetch_databank():
     """
@@ -254,9 +258,10 @@ def test_vaex_and_pandas_dataframe_fetch_databank():
         1500,
         2000,
         molecule="CO",
-        isotope="1,2,3",
+        isotope="1,2",  # testing only 2 isotopes to save (a bit of) time
         pressure=1.01325,  # bar
         path_length=1,  # cm
+        verbose=3,
     )
 
     def compare_dataframe(df_vaex, df_pandas, columns):
@@ -338,6 +343,7 @@ def test_vaex_and_pandas_dataframe_fetch_databank():
     # Comparing the dataframe fetched from GEISA
     assert compare_dataframe(df1, df2, df2.columns)
 
+    # Kurucz
     # Using an atom rather than molecule:
     sf = SpectrumFactory(
         1500,
@@ -438,12 +444,12 @@ def test_vaex_and_pandas_dataframe_load_databank():
 
 def _run_testcases(verbose=True, plot=False):
 
-    test_retrieve_from_database(plot=plot, verbose=verbose)
-    test_ignore_cached_files()
-    test_ignore_irrelevant_files(verbose=verbose)
-    test_custom_abundance()
+    # test_retrieve_from_database(plot=plot, verbose=verbose)
+    # test_ignore_cached_files()
+    # test_ignore_irrelevant_files(verbose=verbose)
+    # test_custom_abundance()
     test_vaex_and_pandas_dataframe_fetch_databank()
-    test_vaex_and_pandas_dataframe_load_databank()
+    # test_vaex_and_pandas_dataframe_load_databank()
 
 
 if __name__ == "__main__":

--- a/radis/test/lbl/test_loader.py
+++ b/radis/test/lbl/test_loader.py
@@ -22,6 +22,10 @@ try:
 except ImportError:
     vaex = NotInstalled(*not_installed_vaex_args)
 
+pytestmark = pytest.mark.random_order(
+    disabled=True
+)  # to make sure HITEMP-CO2-TEST is downloaded for every test
+
 
 def test_retrieve_from_database(
     plot=False, verbose=True, warnings=True, *args, **kwargs

--- a/radis/test/spectrum/test_rescale.py
+++ b/radis/test/spectrum/test_rescale.py
@@ -551,14 +551,14 @@ def test_astropy_units(verbose=True, warnings=True, *args, **kwargs):
 
 
 def _run_all_tests(verbose=True, warnings=True, *args, **kwargs):
-    test_compression(verbose=verbose, warnings=warnings, *args, **kwargs)
+    # test_compression(verbose=verbose, warnings=warnings, *args, **kwargs)
     test_update_transmittance(verbose=verbose, warnings=warnings, *args, **kwargs)
-    test_get_recompute(verbose=verbose, warnings=warnings, *args, **kwargs)
-    test_rescale_vs_direct_computation(verbose=verbose, *args, **kwargs)
-    test_recompute_equilibrium(verbose=verbose, warnings=warnings, *args, **kwargs)
-    test_rescale_all_quantities(verbose=verbose, *args, **kwargs)
-    test_xsections(*args, **kwargs)
-    test_astropy_units(verbose=True, warnings=True, *args, **kwargs)
+    # test_get_recompute(verbose=verbose, warnings=warnings, *args, **kwargs)
+    # test_rescale_vs_direct_computation(verbose=verbose, *args, **kwargs)
+    # test_recompute_equilibrium(verbose=verbose, warnings=warnings, *args, **kwargs)
+    # test_rescale_all_quantities(verbose=verbose, *args, **kwargs)
+    # test_xsections(*args, **kwargs)
+    # test_astropy_units(verbose=True, warnings=True, *args, **kwargs)
     return True
 
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ import sys
 from os.path import abspath, dirname, exists, join
 
 # from setuptools import Extension, find_packages, setup #for cython - unused after v0.15
-from setuptools import find_packages, setup
+from setuptools import setup
 
 # Build description from README (PyPi compatible)
 # -----------------------------------------------
@@ -144,85 +144,86 @@ def show_message(*lines):
     print("=" * 74, file=sys.stderr)
 
 
-def get_ext_modules(with_binaries):
-    """
-    Parameters
-    ----------
-    with_binaries: bool
-        if False, do not try to build Cython extensions
-    """
-    # Based on code from https://github.com/pallets/markupsafe/blob/main/setup.py
+# Deprecated - See Main install routine for radis<0.15
+# def get_ext_modules(with_binaries):
+#     """
+#     Parameters
+#     ----------
+#     with_binaries: bool
+#         if False, do not try to build Cython extensions
+#     """
+#     # Based on code from https://github.com/pallets/markupsafe/blob/main/setup.py
 
-    print(sys.version)
-    ext_modules = []
-    cmdclass = {}
+#     print(sys.version)
+#     ext_modules = []
+#     cmdclass = {}
 
-    if not with_binaries:
-        # skip building extensions
-        return {"cmdclass": cmdclass, "ext_modules": ext_modules}
+#     if not with_binaries:
+#         # skip building extensions
+#         return {"cmdclass": cmdclass, "ext_modules": ext_modules}
 
-    # TO-DO: set language level
+#     # TO-DO: set language level
 
-    #### Cython is now completely removed - August 2024 - Radis 0.15 ###
-    # try:
-    #     import cython
-    # except (ModuleNotFoundError) as err:
-    #     raise BuildFailed(
-    #         "Cython not found : Skipping all Cython extensions...!"
-    #     ) from err
+#     #### Cython is now completely removed - August 2024 - Radis 0.15 ###
+#     # try:
+#     #     import cython
+#     # except (ModuleNotFoundError) as err:
+#     #     raise BuildFailed(
+#     #         "Cython not found : Skipping all Cython extensions...!"
+#     #     ) from err
 
-    # print("Cython " + cython.__version__)
+#     # print("Cython " + cython.__version__)
 
-    # from Cython.Distutils import build_ext
+#     # from Cython.Distutils import build_ext
 
-    # class build_ext_subclass(build_ext):
-    #     def build_extensions(self):
-    #         c = self.compiler.compiler_type
-    #         copt = {
-    #             "msvc": ["/openmp", "/Ox", "/fp:fast", "/favor:INTEL64"],
-    #             "mingw32": ["-fopenmp", "-O3", "-ffast-math", "-march=native"],
-    #         }
+#     # class build_ext_subclass(build_ext):
+#     #     def build_extensions(self):
+#     #         c = self.compiler.compiler_type
+#     #         copt = {
+#     #             "msvc": ["/openmp", "/Ox", "/fp:fast", "/favor:INTEL64"],
+#     #             "mingw32": ["-fopenmp", "-O3", "-ffast-math", "-march=native"],
+#     #         }
 
-    #         lopt = {"mingw32": ["-fopenmp"]}
+#     #         lopt = {"mingw32": ["-fopenmp"]}
 
-    #         print("Compiling with " + c + "...")
-    #         try:
-    #             for e in self.extensions:
-    #                 e.extra_compile_args = copt[c]
-    #         except (KeyError):
-    #             pass
-    #         try:
-    #             for e in self.extensions:
-    #                 e.extra_link_args = lopt[c]
-    #         except (KeyError):
-    #             pass
-    #         try:
-    #             build_ext.build_extensions(self)
-    #         except (CCompilerError, DistutilsExecError, DistutilsPlatformError) as err:
-    #             raise BuildFailed() from err
+#     #         print("Compiling with " + c + "...")
+#     #         try:
+#     #             for e in self.extensions:
+#     #                 e.extra_compile_args = copt[c]
+#     #         except (KeyError):
+#     #             pass
+#     #         try:
+#     #             for e in self.extensions:
+#     #                 e.extra_link_args = lopt[c]
+#     #         except (KeyError):
+#     #             pass
+#     #         try:
+#     #             build_ext.build_extensions(self)
+#     #         except (CCompilerError, DistutilsExecError, DistutilsPlatformError) as err:
+#     #             raise BuildFailed() from err
 
-    # from numpy import get_include
+#     # from numpy import get_include
 
-    # ext_modules.append(
-    #     Extension(
-    #         "radis_cython_extensions",
-    #         sources=[
-    #             "./radis/cython/radis_cython_extensions.pyx",
-    #         ],
-    #         include_dirs=[get_include()],
-    #         language="c++",
-    #         extra_link_args=[],
-    #         define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
-    #     )
-    # )
+#     # ext_modules.append(
+#     #     Extension(
+#     #         "radis_cython_extensions",
+#     #         sources=[
+#     #             "./radis/cython/radis_cython_extensions.pyx",
+#     #         ],
+#     #         include_dirs=[get_include()],
+#     #         language="c++",
+#     #         extra_link_args=[],
+#     #         define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
+#     #     )
+#     # )
 
-    # cmdclass["build_ext"] = build_ext_subclass
+#     # cmdclass["build_ext"] = build_ext_subclass
 
-    return {"cmdclass": cmdclass, "ext_modules": ext_modules}
+#     return {"cmdclass": cmdclass, "ext_modules": ext_modules}
 
 
 #%% Main install routine
-def run_setup(with_binary):
+def run_setup():
     setup(
         name="radis",
         version=__version__,
@@ -246,7 +247,7 @@ def run_setup(with_binary):
             "exomol",
             "line-by-line",
         ],
-        packages=find_packages(),
+        # packages=find_packages(), #this misses the gpu folder, see https://github.com/radis/radis/issues/681
         install_requires=[
             # Although it seems like a duplicate of requirements.txt, it is NECESSARY to tell pip what are the dependencies, issue #680.
             # (requirements.txt is only for the user, not for pip, see https://packaging.python.org/discussions/install-requires-vs-requirements/ and https://stackoverflow.com/questions/14399534/reference-requirements-txt-for-the-install-requires-kwarg-in-setuptools-setup-py)
@@ -319,7 +320,7 @@ def run_setup(with_binary):
             "Programming Language :: Python :: 3.12",
             "Operating System :: OS Independent",
         ],
-        **get_ext_modules(with_binary),
+        # **get_ext_modules(with_binary), #see Main install routine for radis<0.15
         include_package_data=True,  # add non .py data files in MANIFEST.in
         # package_data={'radis': ['radis/phys/units.txt']},
         zip_safe=False,  # impossible as long as we have external files read with __file__ syntax
@@ -328,21 +329,23 @@ def run_setup(with_binary):
 
 
 # %% Run Main install routine
-try:
-    run_setup(with_binary=False)  # radis 0.15 - Cython is not implemented anymore
-except BuildFailed:
-    import traceback
+run_setup()
+# %% Run Main install routine for radis<0.15 - Cython is not implemented anymore
+# try:
+#     run_setup(with_binary=False)
+# except BuildFailed:
+#     import traceback
 
-    traceback.print_exc()
-    show_message(
-        "WARNING: RADIS C-extension could not be compiled, speedups",
-        " are not enabled.",
-        "Failure information, if any, is above.",
-        "Retrying the build without the C extension now.",
-    )
-    run_setup(with_binary=False)
-    show_message(
-        "WARNING: RADIS C-extension could not be compiled, speedups"
-        " are not enabled.",
-        "Plain-Python build succeeded.",
-    )
+#     traceback.print_exc()
+#     show_message(
+#         "WARNING: RADIS C-extension could not be compiled, speedups",
+#         " are not enabled.",
+#         "Failure information, if any, is above.",
+#         "Retrying the build without the C extension now.",
+#     )
+#     run_setup(with_binary=False)
+#     show_message(
+#         "WARNING: RADIS C-extension could not be compiled, speedups"
+#         " are not enabled.",
+#         "Plain-Python build succeeded.",
+#     )


### PR DESCRIPTION
### Description - Bug 1

This pull request is to address the missing files in the deployment of `radis 0.15`. The file setup.py is now simplified and do not exclude the gpu files, see #681.

Everything seems fine in the **tar.gz section**. However, here is an example of the output when running `python -m build`  in the **wheel section**:
```
[... a lot of stuff ...]
C:\Users\Nicolas Minesi\AppData\Local\Temp\build-env-br19d3_h\lib\site-packages\setuptools\command\build_py.py:215: _Warning: Package 'radis.gpu' is absent from the `packages` configuration.
!!

        ********************************************************************************
        ############################
        # Package would be ignored #
        ############################
        Python recognizes 'radis.gpu' as an importable package[^1],
        but it is absent from setuptools' `packages` configuration.

        This leads to an ambiguous overall configuration. If you want to distribute this
        package, please make sure that 'radis.gpu' is explicitly added
        to the `packages` configuration field.

        Alternatively, you can also rely on setuptools' discovery methods
        (for example by using `find_namespace_packages(...)`/`find_namespace:`
        instead of `find_packages(...)`/`find:`).

        You can read more about "package discovery" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

        If you don't want 'radis.gpu' to be distributed and are
        already explicitly excluding 'radis.gpu' via
        `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
        you can try to use `exclude_package_data`, or `include-package-data=False` in
        combination with a more fine grained `package-data` configuration.

        You can read more about "package data files" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


        [^1]: For Python, any directory (with suitable naming) can be imported,
              even if it does not contain any `.py` files.
              On the other hand, currently there is no concept of package data
              directory, all directories are treated like packages.
        ********************************************************************************

!!
  check.warn(importable)
```
