### PR TITLE
Exomolapi broadening bug

### DIFF
--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -550,27 +550,29 @@ def read_broad(broadf):
     return bdat
 
 
-# def check_bdat(bdat):
-#     """checking codes in .broad
-#     Args:
-#        bdat: exomol .broad data given by exomolapi.read_broad
-#     Returns:
-#        code level: None, a0, a1, other codes unavailable currently,
-#     """
+def check_bdat(bdat):
+    """checking codes in .broad
+    Args:
+        bdat: exomol .broad data given by exomolapi.read_broad
+    
+    Returns:
+        code level: None, a0, a1, other codes unavailable currently,
+        if a0 and a1 are available, a1 is returned.
+    """
 
-#     def checkcode(code):
-#         cmask = bdat["code"] == code
-#         if len(bdat["code"][cmask]) > 0:
-#             return True
-#         else:
-#             return False
+    def checkcode(code):
+        cmask = bdat["code"] == code
+        if len(bdat["code"][cmask]) > 0:
+            return True
+        else:
+            return False
 
-#     codelv = None
-#     for code in ["a0", "a1"]:
-#         if checkcode(code):
-#             codelv = code
+    codelv = None
+    for code in ["a0", "a1"]:
+        if checkcode(code):
+            codelv = code
 
-#     return codelv
+    return codelv
 
 
 def make_j2b(bdat, alpha_ref_default=0.07, n_Texp_default=0.5, jlower_max=None):

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -557,14 +557,17 @@ def check_bdat(bdat):
     Returns:
         code level: None, a0, a1, other codes unavailable currently,
         if a0 and a1 are available, a1 is returned.
+        the other cases returns None
     """
-    input_list = bdat["code"]
-    if input_list == ["a0"]:
+    input_array = np.unique(np.array(bdat["code"]))
+    if np.array_equal(input_array, np.array(["a0"])):
         return "a0"
-    elif input_list == ["a1"] or set(input_list) == {"a0", "a1"}:
+    elif np.array_equal(input_array, np.array(["a1"])):
         return "a1"
-    return None  # Default case for other inputs
-
+    elif np.array_equal(np.sort(input_array), np.array(["a0", "a1"])):
+        return "a1"
+    return None
+    
 
 def make_j2b(bdat, alpha_ref_default=0.07, n_Texp_default=0.5, jlower_max=None):
     """compute j2b (code a0, map from jlower to alpha_ref)
@@ -619,15 +622,15 @@ def make_jj2b(bdat, j2alpha_ref_def, j2n_Texp_def, jupper_max=None):
     """compute jj2b (code a1, map from (jlower, jupper) to alpha_ref and n_Texp)
 
     Args:
-       bdat: exomol .broad data given by exomolapi.read_broad
-       j2alpha_ref_def: default value from a0
-       j2n_Texp_def: default value from a0
-       jupper_max: maximum number of jupper
+        bdat: exomol .broad data given by exomolapi.read_broad
+        j2alpha_ref_def: default value from a0
+        j2n_Texp_def: default value from a0
+        jupper_max: maximum number of jupper
     Returns:
-       jj2alpha_ref[jlower,jupper] provides alpha_ref for (jlower, jupper)
-       jj2n_Texp[jlower,jupper]  provides nT_exp for (jlower, jupper)
+        jj2alpha_ref[jlower,jupper] provides alpha_ref for (jlower, jupper)
+        jj2n_Texp[jlower,jupper]  provides nT_exp for (jlower, jupper)
     Note:
-       The pair of (jlower, jupper) for which broadening parameters are not given, jj2XXX contains None.
+        The pair of (jlower, jupper) for which broadening parameters are not given, jj2XXX contains None.
     """
     # a1
     cmask = bdat["code"] == "a1"
@@ -1254,16 +1257,11 @@ class MdbExomol(DatabaseManager):
                     "The file `{}` is used.".format(os.path.basename(self.broad_file))
                 )
 
-            # codelv = check_bdat(bdat)
-            codelv = np.unique(bdat["code"])
+            codelv = check_bdat(bdat)
             if self.verbose:
                 print("Broadening code level:", codelv)
 
-            if len(codelv) > 1:
-                warnings.warn(
-                    f"The broadening file contains more than one broadening code: {codelv}. This feature is NOT implemented yet."
-                )
-            elif codelv == "a0":
+            if codelv == "a0":
                 j2alpha_ref, j2n_Texp = make_j2b(
                     bdat,
                     alpha_ref_default=self.alpha_ref_def,

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -549,11 +549,12 @@ def read_broad(broadf):
 
     return bdat
 
+
 def check_code_level(bdat):
     """checking code level in .broad
     Args:
         bdat: exomol .broad data given by exomolapi.read_broad
-    
+
     Returns:
         code level: None, a0, a1, other codes unavailable currently,
         if a0 and a1 are available, a1 is returned.
@@ -567,7 +568,7 @@ def check_code_level(bdat):
     elif np.array_equal(np.sort(input_array), np.array(["a0", "a1"])):
         return "a1"
     return None
-    
+
 
 def make_j2b(bdat, alpha_ref_default=0.07, n_Texp_default=0.5, jlower_max=None):
     """compute j2b (code a0, map from jlower to alpha_ref)

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -549,8 +549,8 @@ def read_broad(broadf):
 
     return bdat
 
-def check_bdat(bdat):
-    """checking codes in .broad
+def check_code_level(bdat):
+    """checking code level in .broad
     Args:
         bdat: exomol .broad data given by exomolapi.read_broad
     
@@ -1257,7 +1257,7 @@ class MdbExomol(DatabaseManager):
                     "The file `{}` is used.".format(os.path.basename(self.broad_file))
                 )
 
-            codelv = check_bdat(bdat)
+            codelv = check_code_level(bdat)
             if self.verbose:
                 print("Broadening code level:", codelv)
 

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -549,7 +549,6 @@ def read_broad(broadf):
 
     return bdat
 
-
 def check_bdat(bdat):
     """checking codes in .broad
     Args:
@@ -559,33 +558,25 @@ def check_bdat(bdat):
         code level: None, a0, a1, other codes unavailable currently,
         if a0 and a1 are available, a1 is returned.
     """
-
-    def checkcode(code):
-        cmask = bdat["code"] == code
-        if len(bdat["code"][cmask]) > 0:
-            return True
-        else:
-            return False
-
-    codelv = None
-    for code in ["a0", "a1"]:
-        if checkcode(code):
-            codelv = code
-
-    return codelv
+    input_list = bdat["code"]
+    if input_list == ["a0"]:
+        return "a0"
+    elif input_list == ["a1"] or set(input_list) == {"a0", "a1"}:
+        return "a1"
+    return None  # Default case for other inputs
 
 
 def make_j2b(bdat, alpha_ref_default=0.07, n_Texp_default=0.5, jlower_max=None):
     """compute j2b (code a0, map from jlower to alpha_ref)
 
     Args:
-       bdat: exomol .broad data given by exomolapi.read_broad
-       alpha_ref_default: default value
-       n_Texp_default: default value
-       jlower_max: maximum number of jlower
+        bdat: exomol .broad data given by exomolapi.read_broad
+        alpha_ref_default: default value
+        n_Texp_default: default value
+        jlower_max: maximum number of jlower
     Returns:
-       j2alpha_ref[jlower] provides alpha_ref for jlower
-       j2n_Texp[jlower]  provides nT_exp for jlower
+        j2alpha_ref[jlower] provides alpha_ref for jlower
+        j2n_Texp[jlower]  provides nT_exp for jlower
     """
     # a0
     cmask = bdat["code"] == "a0"

--- a/radis/test/api/test_exomolapi.py
+++ b/radis/test/api/test_exomolapi.py
@@ -1,0 +1,22 @@
+import pytest
+from radis.api.exomolapi import check_code_level
+
+
+@pytest.mark.parametrize("bdat_list", [["a1"], ["a0", "a1"], ["a1", "a0"]])
+def test_check_bdat_a1(bdat_list):
+    bdat = {}
+    bdat["code"] = bdat_list
+    assert check_code_level(bdat) == "a1"
+
+@pytest.mark.parametrize("bdat_list", [["a0"]])
+def test_check_bdat_a0(bdat_list):
+    bdat = {}
+    bdat["code"] = bdat_list
+    assert check_code_level(bdat) == "a0"
+
+@pytest.mark.parametrize("bdat_list", [["a0","a1","a2"]])
+def test_check_bdat_a0(bdat_list):
+    bdat = {}
+    bdat["code"] = bdat_list
+    assert check_code_level(bdat) == None
+

--- a/radis/test/api/test_exomolapi.py
+++ b/radis/test/api/test_exomolapi.py
@@ -8,15 +8,16 @@ def test_check_bdat_a1(bdat_list):
     bdat["code"] = bdat_list
     assert check_code_level(bdat) == "a1"
 
+
 @pytest.mark.parametrize("bdat_list", [["a0"]])
 def test_check_bdat_a0(bdat_list):
     bdat = {}
     bdat["code"] = bdat_list
     assert check_code_level(bdat) == "a0"
 
-@pytest.mark.parametrize("bdat_list", [["a0","a1","a2"]])
+
+@pytest.mark.parametrize("bdat_list", [["a0", "a1", "a2"]])
 def test_check_bdat_a0(bdat_list):
     bdat = {}
     bdat["code"] = bdat_list
     assert check_code_level(bdat) == None
-

--- a/radis/test/api/test_exomolapi.py
+++ b/radis/test/api/test_exomolapi.py
@@ -17,7 +17,8 @@ def test_check_bdat_a0(bdat_list):
 
 
 @pytest.mark.parametrize("bdat_list", [["a0", "a1", "a2"]])
-def test_check_bdat_a0(bdat_list):
+def test_check_bdat_no_code_level(bdat_list):
+    """a2 is not a valid code level"""
     bdat = {}
     bdat["code"] = bdat_list
     assert check_code_level(bdat) == None

--- a/radis/test/api/test_exomolapi.py
+++ b/radis/test/api/test_exomolapi.py
@@ -1,4 +1,5 @@
 import pytest
+
 from radis.api.exomolapi import check_code_level
 
 


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address #690 and https://github.com/HajimeKawahara/exojax/issues/519
i.e. the bug for the multiple case of the broadening code level, `np.unique(bdat["code"]) = ["a0", "a1"]`.
In this case, the code level should be `codelv = "a1"`.

Also, this PR started to have the unittest for the common API (#597 and https://github.com/HajimeKawahara/exojax/issues/408 ,) .

<!-- If the pull request closes any open issues you can add this.
If you replace #690 with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #690
