### PR TITLE
Bug fix for downloading the HDO exomol database

### DIFF
--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -98,7 +98,7 @@ def read_def(deff):
         tag for wavelength ranges.
 
     Note:
-       For some molecules, ExoMol provides multiple trans files. numinf and numtag are the ranges and identifiers for the multiple trans files.
+        For some molecules, ExoMol provides multiple trans files. numinf and numtag are the ranges and identifiers for the multiple trans files.
 
     """
 
@@ -161,6 +161,11 @@ def read_def(deff):
 
 
 def wavenumber_range_HDO_VTT():
+    """wave number range for HDO VTT as an exception
+    
+    Returns:
+        float: numinf
+    """
     numinf = np.array(
         [
             0.0,
@@ -186,6 +191,15 @@ def wavenumber_range_HDO_VTT():
 
 
 def compute_wavenumber_ranges(ntransf, maxnu):
+    """wavenumber range for general case
+    
+    Args:
+        ntransf: number of the trans files
+        maxnu: maximum wavenumber
+
+    Returns:
+        float: numinf
+    """
     if ntransf > 1:
         dnufile = maxnu / ntransf
         numinf = dnufile * np.array(range(ntransf + 1))
@@ -196,6 +210,15 @@ def compute_wavenumber_ranges(ntransf, maxnu):
 
 
 def wavenumber_tag(numinf):
+    """convert numinf to numtag (used in the name of trans file)
+    
+
+    Args:
+        numinf (_type_): wavenumber values for the range
+
+    Returns:
+        float: numtag wavenumber tag (such as 00000-00500) 
+    """
     if numinf is None:
         return ""
     numtag = []

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -52,19 +52,7 @@ def exact_molname_exomol_to_simple_molname(exact_exomol_molecule_name):
     """
 
     try:
-        t = exact_exomol_molecule_name.split("-")
-        molname_simple = ""
-        for ele in t:
-            alp = "".join(re.findall(r"\D", ele))
-            num0 = re.split("[A-Z]", ele)[1]
-            if num0.isdigit():
-                num = num0
-            else:
-                num = ""
-            molname_simple = molname_simple + alp + num
-            # ExoJAX Issue #528
-            if molname_simple == "HHO":
-                molname_simple = "H2O"
+        molname_simple = _molname_simple_no_exception(exact_exomol_molecule_name)
         return molname_simple
     except:
         print(
@@ -73,6 +61,23 @@ def exact_molname_exomol_to_simple_molname(exact_exomol_molecule_name):
             "cannot be converted to simple molname",
         )
         return exact_exomol_molecule_name
+
+def _molname_simple_no_exception(exact_exomol_molecule_name):
+    t = exact_exomol_molecule_name.split("-")
+    molname_simple = ""
+    for ele in t:
+        alp = "".join(re.findall(r"\D", ele))
+        num0 = re.split("[A-Z]", ele)[1]
+        if num0.isdigit():
+            num = num0
+        else:
+            num = ""
+        molname_simple = molname_simple + alp + num
+    
+    # ExoJAX Issue #528
+    if molname_simple == "HHO":
+        molname_simple = "H2O"
+    return molname_simple
 
 
 def read_def(deff):

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -62,6 +62,7 @@ def exact_molname_exomol_to_simple_molname(exact_exomol_molecule_name):
         )
         return exact_exomol_molecule_name
 
+
 def _molname_simple_no_exception(exact_exomol_molecule_name):
     t = exact_exomol_molecule_name.split("-")
     molname_simple = ""
@@ -73,7 +74,7 @@ def _molname_simple_no_exception(exact_exomol_molecule_name):
         else:
             num = ""
         molname_simple = molname_simple + alp + num
-    
+
     # ExoJAX Issue #528
     if molname_simple == "HHO":
         molname_simple = "H2O"
@@ -167,7 +168,7 @@ def read_def(deff):
 
 def wavenumber_range_HDO_VTT():
     """wave number range for HDO VTT as an exception
-    
+
     Returns:
         float: numinf
     """
@@ -197,7 +198,7 @@ def wavenumber_range_HDO_VTT():
 
 def compute_wavenumber_ranges(ntransf, maxnu):
     """wavenumber range for general case
-    
+
     Args:
         ntransf: number of the trans files
         maxnu: maximum wavenumber
@@ -216,13 +217,13 @@ def compute_wavenumber_ranges(ntransf, maxnu):
 
 def wavenumber_tag(numinf):
     """convert numinf to numtag (used in the name of trans file)
-    
+
 
     Args:
         numinf (_type_): wavenumber values for the range
 
     Returns:
-        float: numtag wavenumber tag (such as 00000-00500) 
+        float: numtag wavenumber tag (such as 00000-00500)
     """
     if numinf is None:
         return ""

--- a/radis/test/api/test_molecular_name.py
+++ b/radis/test/api/test_molecular_name.py
@@ -1,0 +1,15 @@
+from radis.api.exomolapi import exact_molname_exomol_to_simple_molname
+
+
+def test_exact_molname_exomol_to_simple_molname():
+    assert exact_molname_exomol_to_simple_molname("12C-1H4") == "CH4"
+    assert exact_molname_exomol_to_simple_molname("23Na-16O-1H") == "NaOH"
+    assert exact_molname_exomol_to_simple_molname("HeH_p") == "HeH_p"
+
+
+def test_exact_molname_exomol_to_simple_molname_HDO():
+    """test for HDO
+    See https://github.com/HajimeKawahara/exojax/issues/528
+    """
+
+    assert exact_molname_exomol_to_simple_molname("1H-2H-16O") == "H2O"


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address the bug fix for downloading the HDO exomol. 
The bug that Exomol's HDO database cannot be read was raised as an issue in ExoJAX. This is due to two reasons.

- 1. Name parsing. The simple name should have been `H2O`, but due to a parsing issue, it was incorrectly recognized as `HHO`.
- 2. An error caused by the non-uniform wavenumber range in the Transfile. The original code assumed the wavenumber range arrays to be uniform, such as 0-500, 500-1000, 1000-1500. However, HDO/VTT does not follow this assumption. As a temporary measure, I manually provided the array as an exception within the code. A better implementation should be considered in the future (e.g., automatically retrieving the data from the ExoMol website).

Also, I added a new unit test for the common API (https://github.com/radis/radis/issues/597 and https://github.com/HajimeKawahara/exojax/issues/408 ,)

### name change

Since the name "e2s" does not allow us to infer its function (this was a name I assigned in the past, my apologies), I have renamed it to something more descriptive: `exact_molname_exomol_to_simple_molname`

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes https://github.com/HajimeKawahara/exojax/issues/528
