### PR TITLE
Mac OS: testing and compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   #- "2.7"    # not tested anymore starting from 0.9.19
   #- "3.8" #end of life, Novembre 2024, https://devguide.python.org/versions/
   - "3.10"
-  - "3.11"
+  #- "3.11"
 os: linux
 dist: focal #needed for python 3.10 (xenial is default for Travis-CI, but does not support python 3.10)
 
@@ -15,7 +15,8 @@ install:
   # version is the same.
   # For now use http instead of https according to this comment:
   # https://github.com/mamba-org/mamba/issues/1675#issuecomment-1127160021
-  - wget -qO- https://micro.mamba.pm/api/micromamba/linux-64/1.5.8 | tar -xvj bin/micromamba
+  # - wget -qO- https://micro.mamba.pm/api/micromamba/linux-64/1.5.8 | tar -xvj bin/micromamba
+  - "${SHELL}" <(curl -L micro.mamba.pm/install.sh)
   - ./bin/micromamba shell init -s bash -p ~/micromamba
   - source ~/.bashrc
   - micromamba activate base
@@ -64,6 +65,8 @@ after_success:
 
 
 stages: #This sequence defines the order of the stages
+  - name: MacOS_py310
+    if: branch = master OR branch = develop
   - name: test
     if: branch = master OR branch = develop
   - name: lint
@@ -74,19 +77,17 @@ stages: #This sequence defines the order of the stages
     if: branch = master
   - name: Py312
     if: branch = master
-  # - name: MacOS_py310
-  #   if: branch = master OR branch = develop
   # - name: Win_py310
   #   if: branch = master OR branch = develop
 
 jobs:
   include: #start by testing other OS - TO-DO sort install of micromamba https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html
-    # - stage: MacOS_py310
-    #   name: Python 3.10 on macOS
-    #   python: "3.10"
-    #   os: osx
-    #   osx_image: xcode11.2
-    #   language: shell
+    - stage: MacOS_py310
+      name: Python 3.10 on macOS
+      python: "3.10"
+      os: osx
+      osx_image: xcode11.2
+      language: shell
     # - stage: Win_py310 #https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-win-64
     #   name: Python 3.10 on Windows
     #   python: "3.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ stages: #This sequence defines the order of the stages
   - name: Py312
     if: branch = master
   - name: MacOS_py310
-    if: branch = master OR branch = develop
+    if: branch = master
   # - name: Win_py310
   #   if: branch = master OR branch = develop
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,7 @@ jobs:
         - ./micromamba shell init -s zsh -p ~/micromamba
         - source ~/.zshrc
         # - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ( sudo Xvfb :99 -ac -screen 0 1024x768x8; echo ok )& fi # start Xvfb - https://github.com/travis-ci/travis-ci/issues/7313
+      before_script: skip
       script:
         - pytest -m "fast and not needs_db_CDSD_HITEMP_PCN and not needs_db_CDSD_HITEMP and not needs_db_CDSD_HITEMP_PC" --durations=10
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,10 @@ jobs:
         - mv bin/micromamba ./micromamba
         - ./micromamba shell init -s zsh -p ~/micromamba
         - source ~/.zshrc
-        - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ( sudo Xvfb :99 -ac -screen 0 1024x768x8; echo ok )& fi # start Xvfb - https://github.com/travis-ci/travis-ci/issues/7313
+        # - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ( sudo Xvfb :99 -ac -screen 0 1024x768x8; echo ok )& fi # start Xvfb - https://github.com/travis-ci/travis-ci/issues/7313
+      script:
+        - pytest -m "fast and not needs_db_CDSD_HITEMP_PCN and not needs_db_CDSD_HITEMP and not needs_db_CDSD_HITEMP_PC" --durations=10
+
     # - stage: Win_py310 #https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-win-64
     #   name: Python 3.10 on Windows
     #   python: "3.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,8 +89,8 @@ jobs:
       osx_image: xcode11.2
       language: shell
       before_install:
-        - export HOMEBREW_NO_AUTO_UPDATE=1 #to avoid brew update
-        - brew install micromamba
+        # - export HOMEBREW_NO_AUTO_UPDATE=1 #to avoid brew update
+        - HOMEBREW_NO_AUTO_UPDATE=1 brew install micromamba
     # - stage: Win_py310 #https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-win-64
     #   name: Python 3.10 on Windows
     #   python: "3.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,7 @@ jobs:
       osx_image: xcode11.2
       language: shell
       before_install:
+        - export HOMEBREW_NO_AUTO_UPDATE=1 #to avoid brew update
         - brew install micromamba
     # - stage: Win_py310 #https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-win-64
     #   name: Python 3.10 on Windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   #- "2.7"    # not tested anymore starting from 0.9.19
   #- "3.8" #end of life, Novembre 2024, https://devguide.python.org/versions/
   - "3.10"
-  #- "3.11"
+  - "3.11"
 os: linux
 dist: focal #needed for python 3.10 (xenial is default for Travis-CI, but does not support python 3.10)
 
@@ -65,8 +65,6 @@ after_success:
 
 
 stages: #This sequence defines the order of the stages
-  - name: MacOS_py310
-    if: branch = master OR branch = develop
   - name: test
     if: branch = master OR branch = develop
   - name: lint
@@ -77,6 +75,8 @@ stages: #This sequence defines the order of the stages
     if: branch = master
   - name: Py312
     if: branch = master
+  - name: MacOS_py310
+    if: branch = master OR branch = develop
   # - name: Win_py310
   #   if: branch = master OR branch = develop
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,7 @@ jobs:
         - mv bin/micromamba ./micromamba
         - ./micromamba shell init -s zsh -p ~/micromamba
         - source ~/.zshrc
+        - sudo Xvfb :99 -ac -screen 0 1024x768x8 # start Xvfb - https://github.com/travis-ci/travis-ci/issues/7313
     # - stage: Win_py310 #https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-win-64
     #   name: Python 3.10 on Windows
     #   python: "3.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ os: linux
 dist: focal #needed for python 3.10 (xenial is default for Travis-CI, but does not support python 3.10)
 
 name: Test and Coverage
-install:
+before_install:
   # Install Micromamba
   # We do this conditionally because it saves us some downloading if the
   # version is the same.
   # For now use http instead of https according to this comment:
   # https://github.com/mamba-org/mamba/issues/1675#issuecomment-1127160021
-  # - wget -qO- https://micro.mamba.pm/api/micromamba/linux-64/1.5.8 | tar -xvj bin/micromamba
-  - "${SHELL}" <(curl -L micro.mamba.pm/install.sh)
+  - wget -qO- https://micro.mamba.pm/api/micromamba/linux-64/1.5.8 | tar -xvj bin/micromamba
   - ./bin/micromamba shell init -s bash -p ~/micromamba
   - source ~/.bashrc
+install:
   - micromamba activate base
   # Update python version in environment
   - sed -i -E 's/^- python$/- python='$TRAVIS_PYTHON_VERSION'/' ./environment.yml
@@ -88,6 +88,8 @@ jobs:
       os: osx
       osx_image: xcode11.2
       language: shell
+      before_install:
+        - brew install micromamba
     # - stage: Win_py310 #https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-win-64
     #   name: Python 3.10 on Windows
     #   python: "3.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,9 +94,12 @@ jobs:
         - ./micromamba shell init -s zsh -p ~/micromamba
         - source ~/.zshrc
         # - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ( sudo Xvfb :99 -ac -screen 0 1024x768x8; echo ok )& fi # start Xvfb - https://github.com/travis-ci/travis-ci/issues/7313
-      before_script: skip
-      script:
+      before_script:
+        - echo ">>> Run fast tests first"
         - pytest -m "fast and not needs_db_CDSD_HITEMP_PCN and not needs_db_CDSD_HITEMP and not needs_db_CDSD_HITEMP_PC" --durations=10
+      script:
+        - echo ">>> Run long tests now"
+        - pytest -m "not fast and not needs_cuda and not download_large_databases and not needs_db_CDSD_HITEMP and not needs_db_CDSD_HITEMP_PCN and not needs_db_CDSD_HITEMP_PC and not needs_db_HITEMP_CO2_DUNHAM and not needs_db_HITEMP_CO_DUNHAM" --durations=10
 
     # - stage: Win_py310 #https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-win-64
     #   name: Python 3.10 on Windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,10 +88,11 @@ jobs:
       os: osx
       osx_image: xcode11.2
       language: shell
-      before_install:
+      before_install: #https://gist.github.com/wolfv/fe1ea521979973ab1d016d95a589dcde#os-x
         - curl -Ls https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
         - mv bin/micromamba ./micromamba
         - ./micromamba shell init -s zsh -p ~/micromamba
+        - source ~/.zshrc
     # - stage: Win_py310 #https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-win-64
     #   name: Python 3.10 on Windows
     #   python: "3.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ jobs:
         - mv bin/micromamba ./micromamba
         - ./micromamba shell init -s zsh -p ~/micromamba
         - source ~/.zshrc
-        - sudo Xvfb :99 -ac -screen 0 1024x768x8 # start Xvfb - https://github.com/travis-ci/travis-ci/issues/7313
+        - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ( sudo Xvfb :99 -ac -screen 0 1024x768x8; echo ok )& fi # start Xvfb - https://github.com/travis-ci/travis-ci/issues/7313
     # - stage: Win_py310 #https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-win-64
     #   name: Python 3.10 on Windows
     #   python: "3.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,8 +89,9 @@ jobs:
       osx_image: xcode11.2
       language: shell
       before_install:
-        # - export HOMEBREW_NO_AUTO_UPDATE=1 #to avoid brew update
-        - HOMEBREW_NO_AUTO_UPDATE=1 brew install micromamba
+        - curl -Ls https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
+        - mv bin/micromamba ./micromamba
+        - ./micromamba shell init -s zsh -p ~/micromamba
     # - stage: Win_py310 #https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-win-64
     #   name: Python 3.10 on Windows
     #   python: "3.10"

--- a/radis/gpu/cuda/driver.py
+++ b/radis/gpu/cuda/driver.py
@@ -18,9 +18,14 @@ if os_name == "nt":
 else:
     from ctypes import cdll as dllobj
 
-
 import numpy as np
-from nvidia.cufft import __path__ as cufft_path
+
+from radis.misc.utils import NotInstalled, not_installed_nvidia_args
+
+try:
+    from nvidia.cufft import __path__ as cufft_path
+except ImportError:
+    cufft_path = NotInstalled(*not_installed_nvidia_args)
 
 _verbose = False
 

--- a/radis/misc/utils.py
+++ b/radis/misc/utils.py
@@ -184,6 +184,12 @@ not_installed_vaex_args = (
     + "Use Pytables (slower) as an alternative in your Radis.json config file. To use Pytables, set "
     + '"MEMORY_MAPPING_ENGINE": "pytables" and "DATAFRAME_ENGINE": "pandas"',
 )
+not_installed_nvidia_args = (
+    "nvidia-cufft",
+    "Nvidia was not installed on your computer. `nvidia-cufft` is"
+    + "not available on Mac OS. ALternative solutions are being developped "
+    + "with Vulkan, see https://github.com/radis/radis/pull/624. (latest update Oct. 2024). ",
+)
 
 
 def get_files_from_regex(path):

--- a/radis/misc/utils.py
+++ b/radis/misc/utils.py
@@ -146,7 +146,7 @@ class DatabankNotFound(FileNotFoundError):
 
 
 class NotInstalled(object):
-    """A class to deal with optional packages Will raise an error only if the
+    """A class to deal with optional packages. Will raise an error only if the
     package is used (but not if imported only)
 
     Examples

--- a/radis/test/gpu/test_gpu.py
+++ b/radis/test/gpu/test_gpu.py
@@ -15,10 +15,20 @@ import pytest
 import radis
 from radis import SpectrumFactory, get_residual
 from radis.misc.printer import printm
+from radis.misc.utils import NotInstalled, not_installed_nvidia_args
 from radis.misc.warning import NoGPUWarning
 from radis.test.utils import getTestFile
 
+try:
+    from nvidia.cufft import __path__ as cufft_path
+except ImportError:
+    cufft_path = NotInstalled(*not_installed_nvidia_args)
 
+
+@pytest.mark.skipif(
+    isinstance(cufft_path, NotInstalled),
+    reason="nvidia package not installed. Probably because on MAC OS",
+)
 @pytest.mark.fast
 def test_eq_spectrum_emulated_gpu(
     backend="cpu-cuda", verbose=False, plot=False, *args, **kwargs
@@ -86,6 +96,10 @@ def test_eq_spectrum_emulated_gpu(
         s_cpu.print_perf_profile()
 
 
+@pytest.mark.skipif(
+    isinstance(cufft_path, NotInstalled),
+    reason="nvidia package not installed. Probably because on MAC OS",
+)
 @pytest.mark.needs_cuda
 def test_eq_spectrum_gpu(plot=False, *args, **kwargs):
     """Compare Spectrum calculated in the GPU code
@@ -98,6 +112,10 @@ def test_eq_spectrum_gpu(plot=False, *args, **kwargs):
         test_eq_spectrum_emulated_gpu(backend="gpu-cuda", plot=plot, *args, **kwargs)
 
 
+@pytest.mark.skipif(
+    isinstance(cufft_path, NotInstalled),
+    reason="nvidia package not installed. Probably because on MAC OS",
+)
 @pytest.mark.fast
 def test_multiple_gpu_calls():
     from radis import SpectrumFactory

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ peakutils
 ruamel.yaml
 json-tricks>=3.15.0  # to deal with non jsonable formats
 mpldatacursor
-nvidia-cufft-cu11; platform_machine != "darwin"
+nvidia-cufft-cu11; sys_platform != "darwin"
 periodictable
 # tuna            # to generate visual/interactive performance profiles
 vaex-core ; python_version < '3.11'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ peakutils
 ruamel.yaml
 json-tricks>=3.15.0  # to deal with non jsonable formats
 mpldatacursor
-nvidia-cufft-cu11
+nvidia-cufft-cu11; platform_machine != "darwin"
 periodictable
 # tuna            # to generate visual/interactive performance profiles
 vaex-core ; python_version < '3.11'

--- a/setup.py
+++ b/setup.py
@@ -281,7 +281,7 @@ def run_setup():
             "ruamel.yaml",
             "json-tricks>=3.15.0",  # to deal with non jsonable formats
             "mpldatacursor",
-            "nvidia-cufft-cu11",
+            'nvidia-cufft-cu11; sys_platform != "darwin" ',
             "periodictable",
             'vaex-core ; python_version < "3.11"',
             'vaex-hdf5 ; python_version < "3.11"',


### PR DESCRIPTION
### Description
<!-- Provide a general description of what your pull request does. -->

This pull request will allow mac users to install RADIS, but without the nvidia gpu capabilities of version `0.15`. If the MAC OS user attempt to use gpu capabilities, they will get a error message to explain that nvidia cannot be installed on their machine. 

This procedure is similar to what was done when vaex was incompatible with python 3.11 and 3.12 (note: vaex is now compatible with python up to 3.12 - October 2024)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #696 
