### PR TITLE
Vaex compatible up to python<=3.12

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 - astropy
 - plotly
 dependencies:
-- python=3.10
+- python
 - astropy>=4.3.1  # Unit aware calculations
 - astroquery>=0.4.6  # to fetch HITRAN databases
 - beautifulsoup4>=4.10.0 # parse ExoMol website

--- a/examples/0_Database_handling/plot_explore_database_vaex.py
+++ b/examples/0_Database_handling/plot_explore_database_vaex.py
@@ -22,7 +22,7 @@ import matplotlib.pyplot as plt
 from radis.io.hitemp import fetch_hitemp
 
 #%% Adapt this example if vaex is installed or not
-# June 2024: vaex is not compatible with python>=3.11, see https://github.com/radis/radis/pull/656
+# November 2024: vaex is now compatible up to python>=3.12
 try:
     import vaex
 

--- a/radis/api/dbmanager.py
+++ b/radis/api/dbmanager.py
@@ -51,7 +51,9 @@ LAST_VALID_DATE = (
 def get_auto_MEMORY_MAPPING_ENGINE():
     """see https://github.com/radis/radis/issues/653
 
-    Use Vaex by default if it exists (only Python <= 3.11 as of June 2024) ,
+    Use Vaex by default if it exists (compatible up to Python 3.12
+      - see https://github.com/vaexio/vaex/pull/2331#issuecomment-2357580016) and
+      TO-DO ADD RELEASE LINK
     else use PyTables"""
     try:
         import vaex

--- a/radis/levels/partfunc.py
+++ b/radis/levels/partfunc.py
@@ -233,7 +233,7 @@ class RovibParFuncCalculator(RovibPartitionFunction):
                 vaex  # to avoid linting errors
             except ImportError:
                 raise ImportError(
-                    "On-the-fly tabulation of partition functions require Vaex. Install it. /!\ as of June 2024 Vaex is not available on Python>=3.11 "
+                    "On-the-fly tabulation of partition functions require Vaex. Install it. /!\ As of November 2024: vaex is now compatible up to python>=3.12 "
                 )
 
         self.mode = mode

--- a/radis/misc/utils.py
+++ b/radis/misc/utils.py
@@ -180,7 +180,7 @@ class NotInstalled(object):
 not_installed_vaex_args = (
     "vaex",
     "You must install Vaex to use these features. Vaex is a fast, "
-    + "memory-mapped DataFrame library. However is not available yet on latest Python versions. "
+    + "memory-mapped DataFrame library. However is not always available on latest Python versions. "
     + "Use Pytables (slower) as an alternative in your Radis.json config file. To use Pytables, set "
     + '"MEMORY_MAPPING_ENGINE": "pytables" and "DATAFRAME_ENGINE": "pandas"',
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ mpldatacursor
 nvidia-cufft-cu11
 periodictable
 # tuna            # to generate visual/interactive performance profiles
-vaex-core ; python_version < '3.11'
-vaex-hdf5 ; python_version < '3.11'
-vaex-viz ; python_version < '3.11'
+vaex-core ; python_version < '3.13'
+vaex-hdf5 ; python_version < '3.13'
+vaex-viz ; python_version < '3.13'


### PR DESCRIPTION
### Description

This pull request allows the install of vaex up to `python<=3.12`. 

- [ ] Adapt comments written when vaex was **not** compatible with python 3.11 and 3.12
- [ ] Allow install of vaex up to `python<=3.12`
- [ ] Travis tests can be run on only 1 python version. Stop random pytest.
- [ ] Add link to vaex release for documentation.

Documentation:

- Pull request: https://github.com/vaexio/vaex/pull/2331
- Release: (waiting) 
