### PR TITLE
Added ExoMol self broadening coefficients

### DIFF
--- a/examples/0_Database_handling/plot_explore_database_vaex.py
+++ b/examples/0_Database_handling/plot_explore_database_vaex.py
@@ -19,10 +19,10 @@ In this example, we plot the dependance of the broadening coefficients to the ro
 """
 import matplotlib.pyplot as plt
 
-from radis.io.hitemp import fetch_hitemp
+from radis.io.hitran import fetch_hitran
 
 #%% Adapt this example if vaex is installed or not
-# June 2024: vaex is not compatible with python>=3.11, see https://github.com/radis/radis/pull/656
+# June 2024: vaex is not compatible with python>=3.11, see https://github.com/radis/radis/pull/656 and the WIP solution here https://github.com/radis/radis/pull/698
 try:
     import vaex
 
@@ -31,7 +31,7 @@ try:
 except ImportError:
     output = "pytables"  # standard pandas format
 
-df = fetch_hitemp("CO2", output=output, load_wavenum_min=2150, load_wavenum_max=2450)
+df = fetch_hitran("CO2", output=output, load_wavenum_min=100, load_wavenum_max=10000)
 print(f"{len(df)} lines in HITEMP CO2; 2150 - 2450 cm-1")
 
 #%%

--- a/examples/0_Database_handling/plot_hitemp_OH_database.py
+++ b/examples/0_Database_handling/plot_hitemp_OH_database.py
@@ -17,9 +17,9 @@ RADIS allows you to use a Vaex DataFrame instead (out-of-RAM).
 See the :ref:`Explore Database with Vaex example <example_explore_database_vaex>`
 """
 
-from radis.io.hitemp import fetch_hitemp
+from radis.io.hitran import fetch_hitran
 
-df = fetch_hitemp("OH")
+df = fetch_hitran("OH")
 print(df.columns)
 
 
@@ -37,5 +37,5 @@ print(df.columns)
 # function. The already downloaded database will be used:
 #
 
-df = fetch_hitemp("OH", load_wavenum_min=31500, load_wavenum_max=33000, isotope="1")
+df = fetch_hitran("OH", load_wavenum_min=31500, load_wavenum_max=33000, isotope="1")
 df.plot("wav", "int")

--- a/examples/0_Database_handling/plot_linestrengths.py
+++ b/examples/0_Database_handling/plot_linestrengths.py
@@ -5,7 +5,7 @@ Scale Linestrengths of carbon-monoxide
 ================================================
 
 This example scales the linestrengths of CO to Tgas=300 from Tref = 296 and then plots
-the linestrengths against the wavenumbers. We are using :py:func:`~radis.io.hitemp.fetch_hitemp`
+the linestrengths against the wavenumbers. We are using :py:func:`~radis.io.hitemp.fetch_hitran`
 function to retrieve the dataframe from the HITEMP-CO databank.
 
 References
@@ -24,7 +24,7 @@ from matplotlib import pyplot as plt
 from numpy import exp
 
 from radis.db.classes import get_molecule, get_molecule_identifier
-from radis.io.hitemp import fetch_hitemp
+from radis.io.hitran import fetch_hitran
 from radis.levels.partfunc import PartFuncTIPS
 from radis.phys.constants import hc_k
 
@@ -76,7 +76,7 @@ def scale_linestrength_eq(df, Tref, Tgas):
 
 if __name__ == "__main__":
     Tref = 296
-    df = fetch_hitemp(
+    df = fetch_hitran(
         molecule="CO",
         isotope="1, 2, 3",
         load_wavenum_min=2000,

--- a/examples/1_Spectra_handling/plot_compare_CO_exomol_hitemp.py
+++ b/examples/1_Spectra_handling/plot_compare_CO_exomol_hitemp.py
@@ -46,16 +46,9 @@ ax0.set_ylim(ymax=ax0.get_ylim()[1] * 10)  # more space for legend
 
 # Note: these two spectra are alike.
 
-#%% ExoMol VS HITEMP
-s_exomol = calc_spectrum(
-    **conditions, databank="exomol", name="ExoMol's HITEMP (default broadening)"
-)
-s_hitemp = calc_spectrum(
-    **conditions,
-    databank="hitemp",
-    name="HITEMP (Air broadened)",
-)
-fig, [ax0, ax1] = plot_diff(s_exomol, s_hitemp, "xsection", yscale="log")
+#%% ExoMol VS HITRAN
+s_exomol = calc_spectrum(**conditions, databank="exomol", name="ExoMol - recommended")
+fig, [ax0, ax1] = plot_diff(s_exomol, s_hitran, "xsection", yscale="log")
 # Adjust diff plot to be in linear scale
 ax1.set_yscale("linear")
 ax0.set_ylim(ymax=ax0.get_ylim()[1] * 10)  # more space for legend
@@ -64,5 +57,5 @@ ax0.set_ylim(ymax=ax0.get_ylim()[1] * 10)  # more space for legend
 # end up being very different; however the areas under the lines should be the same.
 # We verify this :
 print(
-    f"Ratio of integrated area = {s_exomol.get_integral('xsection')/s_hitemp.get_integral('xsection'):.2f}"
+    f"Ratio of integrated area = {s_exomol.get_integral('xsection')/s_hitran.get_integral('xsection'):.2f}"
 )

--- a/examples/1_Spectra_handling/plot_merged_large_spectrum.py
+++ b/examples/1_Spectra_handling/plot_merged_large_spectrum.py
@@ -32,7 +32,7 @@ for (wmin, wmax) in [(50, 3000), (3000, 7000), (7000, 10000)]:
             path_length=1,
             mole_fraction=0.1,
             wstep=0.1,
-            databank="hitemp",
+            databank="hitran",
             verbose=False,
         )
     )

--- a/examples/1_Spectra_handling/plot_merged_large_spectrum.py
+++ b/examples/1_Spectra_handling/plot_merged_large_spectrum.py
@@ -40,7 +40,3 @@ for (wmin, wmax) in [(50, 3000), (3000, 7000), (7000, 10000)]:
 s = MergeSlabs(*spectra, resample="full", out="transparent")
 print(s)
 s.plot("transmittance_noslit", wunit="nm")
-
-import matplotlib.pyplot as plt
-
-plt.ylim(0, 1)

--- a/examples/2_Experimental_spectra/plot_fit_lineshape.py
+++ b/examples/2_Experimental_spectra/plot_fit_lineshape.py
@@ -18,7 +18,7 @@ import numpy as np
 from radis import Spectrum, calc_spectrum
 from radis.test.utils import getTestFile
 
-real_experiment = False
+real_experiment = True
 if real_experiment:
     T_ref = 7515  # for index 9
     # Using a real experiment (CO in argon) from Minesi et al. (2022) - doi:10.1007/s00340-022-07931-7
@@ -37,6 +37,7 @@ else:
         2010.6,
         2011.6,  # cm-1
         molecule="CO",
+        isotope=1,
         pressure=1,  # bar
         Tgas=T_ref,
         mole_fraction=1,
@@ -141,7 +142,7 @@ for index in [0, 1]:
 msg = """
 **Result**: this fitting routine and the R(8,24)/(P(1,25) line pair
 are appropriate for temperature measurement. The R(4,7)/(P(1,25)
-line pair requires a more sophiscated fitting routine, due to the
+line pair may require a more sophiscated fitting routine, due to the
 underlying transition at 2011 cm-1 from R(10,115), see Minesi et al. (2022)
 """
 print(msg)

--- a/examples/3_Fitting/plot2_fit_Tgas-molfrac.py
+++ b/examples/3_Fitting/plot2_fit_Tgas-molfrac.py
@@ -53,7 +53,7 @@ experimental_conditions = {
     * u.bar,  # Total pressure of gas, in "bar" unit by default, but you can use Astropy units too.
     "path_length": 10
     * u.cm,  # Experimental path length, in "cm" unit by default, but you can use Astropy units too.
-    "databank": "hitemp",  # Databank used for calculation. Must be stated.
+    "databank": "exomol",  # hitemp is recommended
     "wstep": "auto",
 }
 
@@ -62,7 +62,7 @@ fit_parameters = {
     "Tgas": 5000,  # Fit parameter, accompanied by its initial value.
     "mole_fraction": 0.05,  # Species mole fraction, from 0 to 1.
     "offset": "0 cm-1",  # Experimental offset, must be a blank space separating offset amount and unit.
-    # "pressure": 0.8,
+    "pressure": 0.8,
 }
 
 # List of bounding ranges applied for those fit parameters above.
@@ -70,7 +70,7 @@ bounding_ranges = {
     "Tgas": [2000, 9000],
     "mole_fraction": [0, 1],
     "offset": [-0.03, 0.02],
-    # "pressure": [0.1, 2],
+    "pressure": [0.1, 2],
 }
 
 # Fitting pipeline setups.

--- a/examples/3_Fitting/plot3_fit_Trot-Tvib-molfrac.py
+++ b/examples/3_Fitting/plot3_fit_Trot-Tvib-molfrac.py
@@ -129,25 +129,28 @@ You can see the benchmark result of these algorithms here:
 
 # -------------------- Step 3. Run the fitting and retrieve results -------------------- #
 
+try:
+    # Conduct the fitting process!
+    s_best, result, log = fit_spectrum(
+        s_exp=s_experimental,  # Experimental spectrum.
+        fit_params=fit_parameters,  # Fit parameters.
+        bounds=bounding_ranges,  # Bounding ranges for those fit parameters.
+        model=experimental_conditions,  # Experimental ground-truths conditions.
+        pipeline=fit_properties,  # # Fitting pipeline references.
+    )
 
-# Conduct the fitting process!
-s_best, result, log = fit_spectrum(
-    s_exp=s_experimental,  # Experimental spectrum.
-    fit_params=fit_parameters,  # Fit parameters.
-    bounds=bounding_ranges,  # Bounding ranges for those fit parameters.
-    model=experimental_conditions,  # Experimental ground-truths conditions.
-    pipeline=fit_properties,  # # Fitting pipeline references.
-)
+    # Now investigate the result logs for additional information about what's going on during the fitting process
 
+    print("\nResidual history: \n")
+    print(log["residual"])
 
-# Now investigate the result logs for additional information about what's going on during the fitting process
+    print("\nFitted values history: \n")
+    for fit_val in log["fit_vals"]:
+        print(fit_val)
 
-print("\nResidual history: \n")
-print(log["residual"])
-
-print("\nFitted values history: \n")
-for fit_val in log["fit_vals"]:
-    print(fit_val)
-
-print("\nTotal fitting time: ")
-print(log["time_fitting"], end=" s\n")
+    print("\nTotal fitting time: ")
+    print(log["time_fitting"], end=" s\n")
+except OSError as err:
+    print("HITEMP files must be downloaded manually. See error message.")
+    print(err)
+    s_experimental.plot()

--- a/examples/4_GPU/plot_gpu.py
+++ b/examples/4_GPU/plot_gpu.py
@@ -25,11 +25,13 @@ sf = SpectrumFactory(
     2150,
     2450,  # cm-1
     molecule="CO2",
-    isotope="1,2,3",
+    isotope="1",
     wstep=0.002,
 )
 
-sf.fetch_databank("hitemp")
+sf.fetch_databank(
+    source="hitran"
+)  # use hitemp or exomol for accuracy at high tempertatures
 
 T = 1500.0  # K
 p = 1.0  # bar

--- a/examples/4_GPU/plot_gpu_recalc.py
+++ b/examples/4_GPU/plot_gpu_recalc.py
@@ -28,7 +28,7 @@ sf = SpectrumFactory(
     wstep=0.002,
 )
 
-sf.fetch_databank("hitemp")
+sf.fetch_databank("hitran")  # use hitemp or exomol for accuracy at high tempertatures
 
 T_list = [1000.0, 1500.0, 2000.0]
 

--- a/examples/4_GPU/plot_gpu_widgets.py
+++ b/examples/4_GPU/plot_gpu_widgets.py
@@ -35,7 +35,7 @@ sf = SpectrumFactory(
     wstep=0.002,
 )
 
-sf.fetch_databank("hitemp")
+sf.fetch_databank("hitran")
 
 s = sf.eq_spectrum_gpu_interactive(
     var="radiance",

--- a/examples/6_Misc/plot_SpecDatabase.py
+++ b/examples/6_Misc/plot_SpecDatabase.py
@@ -43,7 +43,7 @@ sf = SpectrumFactory(
     wstep=0.1,
 )
 sf.warnings = {"AccuracyError": "ignore"}
-sf.fetch_databank("hitemp")
+sf.fetch_databank("hitran")
 
 # Generating a Spectrum
 s1 = sf.eq_spectrum(Tgas=300, path_length=1)
@@ -69,15 +69,15 @@ db.add(s1)
 sf.init_database(my_folder)
 
 wstep = np.linspace(0.1, 0.001, 4)
-Tgas = np.linspace(300, 3000, 4)
+Tgas_arr = np.linspace(300, 700, 7)
 
 
 # Multiple Spectrum calculation based on different values of Tgas and wstep
 for i in wstep:
     sf._wstep = i
     sf.params.wstep = i
-    for j in Tgas:
-        sf.eq_spectrum(Tgas=j, path_length=1)
+    for Tgas in Tgas_arr:
+        sf.eq_spectrum(Tgas=Tgas, path_length=1)
 
 
 # Loading SpecDatabase

--- a/radis/api/dbmanager.py
+++ b/radis/api/dbmanager.py
@@ -392,8 +392,28 @@ class DatabaseManager(object):
             try:
                 self.ds.open(urlname)
             except Exception as err:
+                if str(err) == "File is not a zip file":
+                    print("\n### RADIS - ISSUE 717 ###\n")
+                    print(
+                        f'Error: "{err}".\nThis issue occurs because HITEMP requires a login, which is not currently implemented in RADIS.\nFor more information and to contribute to resolving this issue, please visit: https://github.com/radis/radis/issues/717 \n'
+                    )
+
+                    print(
+                        "*** Temporary fix ***\nDownload manualy the following file and put it in the following location:"
+                    )
+                    temp_folder = os.path.join(
+                        os.path.dirname(local_file),
+                        "downloads__can_be_deleted",
+                        "hitran.org",
+                        "files",
+                        "HITEMP",
+                        "HITEMP-2010",
+                        f"{self.molecule}_line_list",
+                    )
+                    print(f"{urlname} ==> {temp_folder} \n")
+
                 raise OSError(
-                    f"Problem opening : {self.ds._findfile(urlname)}. See above. You may want to delete the downloaded file."
+                    f"Problem opening : {self.ds._findfile(urlname)}. See potential solution above!!! You may want to delete the downloaded file."
                 ) from err
 
             try:
@@ -427,7 +447,9 @@ class DatabaseManager(object):
                     )
                     print(f"{urlname} ==> {temp_folder} \n")
 
-                raise OSError(err)
+                raise OSError(
+                    f"Problem opening : {self.ds._findfile(urlname)}. See potential solution above!!! You may want to delete the downloaded file."
+                ) from err
 
             return Nlines
 

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -1494,10 +1494,10 @@ class MdbExomol(DatabaseManager):
                 self.alpha_ref = np.array(self.alpha_ref_def * np.ones(len(df)))
                 self.n_Texp = np.array(self.n_Texp_def * np.ones(len(df)))
         else:
-            if not os.path.exists(self.broad_file):
+            if not os.path.exists(file):
                 warnings.warn(
                     "Could not load `{}`. The default broadening parameters are used.\n".format(
-                        os.path.basename(self.broad_file)
+                        os.path.basename(file)
                     )
                 )
             print("The default broadening parameters are used.")

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -1347,7 +1347,7 @@ class MdbExomol(DatabaseManager):
         n_Texp_def=None,
         output=None,
         add_columns=True,
-        file=None,
+        species=None,
     ):
         """setting broadening parameters
 
@@ -1357,7 +1357,7 @@ class MdbExomol(DatabaseManager):
         alpha_ref: set default alpha_ref and apply it. None=use self.alpha_ref_def
         n_Texp_def: set default n_Texp and apply it. None=use self.n_Texp_def
         add_columns: adds alpha_ref and n_Texp columns to df
-        file: to select which file, and which broadener will be used. Default is None which indicate that the default broadening file will be used: self.broad_file
+        species: to select which broadener will be used. Default is "air".
 
         Returns
         -------
@@ -1370,8 +1370,7 @@ class MdbExomol(DatabaseManager):
         if n_Texp_def:
             self.n_Texp_def = n_Texp_def
 
-        if file is None:
-            file = self.broad_files["air"]
+        file = self.broad_files[species]
 
         if self.broadf and os.path.exists(file):
             bdat = read_broad(file)
@@ -1432,9 +1431,16 @@ class MdbExomol(DatabaseManager):
             self.n_Texp = np.array(self.n_Texp_def * np.ones(len(df)))
 
         if add_columns:
-            # Add values
-            self.add_column(df, "alpha_ref", self.alpha_ref)
-            self.add_column(df, "n_Texp", self.n_Texp)
+            if species == "air":
+                self.add_column(df, "alpha_ref", self.alpha_ref)
+                self.add_column(df, "n_Texp", self.n_Texp)
+            elif species == "self":
+                self.add_column(df, "selbrd", self.alpha_ref)
+                self.add_column(df, "selbrd_Tdpair", self.n_Texp)
+            else:
+                raise NotImplementedError(
+                    "Please post on https://github.com/radis/radis to ask for this feature."
+                )
 
     def QT_interp(self, T):
         """interpolated partition function

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -1507,8 +1507,8 @@ class MdbExomol(DatabaseManager):
 
         if add_columns:
             if species == "air":
-                self.add_column(df, "alpha_ref", self.alpha_ref)
-                self.add_column(df, "n_Texp", self.n_Texp)
+                self.add_column(df, "airbrd", self.alpha_ref)
+                self.add_column(df, "Tdpair", self.n_Texp)
             elif species == "self":
                 self.add_column(df, "selbrd", self.alpha_ref)
                 self.add_column(df, "selbrd_Tdpair", self.n_Texp)

--- a/radis/api/hdf5.py
+++ b/radis/api/hdf5.py
@@ -251,14 +251,12 @@ class DataFileManager(object):
             if key == "default":
                 key = r"/table"
             df = vaex.open(self._temp_batch_files, group=key)
+
             # Removing NaN values columns
             if delete_nan_columns:
-                import numpy as np
-
-                for column in df.columns:
-                    col = df[column].values
-                    if type(col[0]) in [np.int32, np.float64] and np.isnan(np.sum(col)):
-                        del df[column]
+                for column in df.get_column_names():
+                    if df[column].isna().sum() > 0:
+                        df = df.drop(column)
 
             if sort_values:
                 df.sort(by=sort_values).export_hdf5(file, group=key, mode="w")

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -363,7 +363,13 @@ class HITEMPDatabaseManager(DatabaseManager):
                     # with End of file flag) so nbytes != 0
                     b = get_last(b)
 
-                df = _ndarray2df(b, columns, linereturnformat)
+                df = _ndarray2df(b, columns, linereturnformat, molecule=self.molecule)
+
+                # 19722
+                if molecule == "CO2":
+                    df["iso"] = (
+                        df["iso"].replace({"A": 10, "B": 11, "C": 12}).astype(int)
+                    )  # in HITEMP2024, isotopologue 10, 11, 12 are A, B, C. Converted later
 
                 # Post-processing :
                 # ... Add local quanta attributes, based on the HITRAN group

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -351,6 +351,16 @@ class HITEMPDatabaseManager(DatabaseManager):
 
             if verbose:
                 print(f"Download complete. Parsing {molecule} database to {local_file}")
+                print(
+                    "This step is executed only ONCE and will considerably accelerate the computation of spectra. It will also dramatically reduce the memory usage. The parsing/conversion can be very fast (e.g. HITEMP OH takes a few seconds) or extremely long (e.g. HITEMP CO2 takes approximately 1 hour)."
+                )
+            if molecule == "CO2":
+                from warnings import warn
+
+                warn(
+                    "Parsing will take approximately 1 hour for HITEMP CO2 (compressed = 6 GB",
+                    UserWarning,
+                )
 
             # assert not(exists(local_file))
 
@@ -369,7 +379,7 @@ class HITEMPDatabaseManager(DatabaseManager):
                 if molecule == "CO2":
                     df["iso"] = (
                         df["iso"].replace({"A": 10, "B": 11, "C": 12}).astype(int)
-                    )  # in HITEMP2024, isotopologue 10, 11, 12 are A, B, C. Converted later
+                    )  # in HITEMP2024, isotopologue 10, 11, 12 are A, B, C.
 
                 # Post-processing :
                 # ... Add local quanta attributes, based on the HITRAN group

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -232,14 +232,28 @@ class HITEMPDatabaseManager(DatabaseManager):
 
         molecule = self.molecule
 
-        if molecule in ["H2O", "CO2"]:
+        if molecule in ["H2O"]:  # CO2 is a single file since 01/2025
 
             base_url, Ntotal_lines_expected, _, _ = self.fetch_url_Nlines_wmin_wmax()
-            response = urllib.request.urlopen(base_url)
-            response_string = response.read().decode()
-            inputfiles = re.findall(r'href="(\S+.zip)"', response_string)
 
-            urlnames = [join(base_url, f) for f in inputfiles]
+            ### Issue 717 - https://github.com/radis/radis/issues/717
+
+            # response = urllib.request.urlopen(base_url)
+            # response_string = response.read().decode()
+            # inputfiles = re.findall(r'href="(\S+.zip)"', response_string)
+            # urlnames = [join(base_url, f) for f in inputfiles]
+
+            from radis.misc.utils import getProjectRoot
+
+            with open(
+                join(getProjectRoot(), "db", "H2O", "HITRANpage_january2025.htm")
+            ) as file:
+                response_string = file.read()
+
+            inputfiles = re.findall(r'href="(\S+.zip)"', response_string)
+            base_url = "https://hitran.org"
+            urlnames = [f"{base_url}{f}" for f in inputfiles]
+            ### Issue 717 [end]
 
         elif molecule in HITEMP_MOLECULES:
             url, Ntotal_lines_expected, _, _ = self.fetch_url_Nlines_wmin_wmax()
@@ -260,7 +274,7 @@ class HITEMPDatabaseManager(DatabaseManager):
 
         If other molecule, return the file anyway.
         see :py:func:`radis.api.hitempapi.keep_only_relevant`"""
-        if self.molecule in ["CO2", "H2O"]:
+        if self.molecule in ["H2O"]:  # CO2 is a single file since 01/2025
             inputfiles, _, _ = keep_only_relevant(
                 inputfiles, wavenum_min, wavenum_max, verbose
             )

--- a/radis/api/tools.py
+++ b/radis/api/tools.py
@@ -293,10 +293,12 @@ def replace_PQR_with_m101(df):
         raise NotImplementedError(df_type)
 
     # Then do the actual mapping
-    if df.dtypes["branch"] != np.int64:
+    if df.dtypes["branch"] != np.float64:
         mapping = {"P": -1, "Q": 0, "R": 1, "O": -2, "S": 2}
         if df_type == pd.DataFrame:  # pandas
+            pd.set_option("future.no_silent_downcasting", True)
             new_col = df["branch"].replace(mapping).infer_objects(copy=False)
+            pd.set_option("future.no_silent_downcasting", False)
         else:  # vaex
             new_col = df["branch"].map(mapping, allow_missing=True)
         df["branch"] = new_col

--- a/radis/api/tools.py
+++ b/radis/api/tools.py
@@ -105,7 +105,7 @@ def _get_linereturnformat(data, columns, fname=""):
     return linereturnformat
 
 
-def _ndarray2df(data, columns, linereturnformat):
+def _ndarray2df(data, columns, linereturnformat, molecule):
     """ """
 
     # ... Cast to new type
@@ -116,6 +116,11 @@ def _ndarray2df(data, columns, linereturnformat):
     dtype = list(zip(list(columns.keys()), newtype)) + [
         ("_linereturn", linereturnformat)
     ]
+    if molecule == "CO2":
+        dtype[1] = (
+            "iso",
+            "<U1",
+        )  # in HITEMP2024, isotopologue 10, 11, 12 are a, b, c. Converted later
     data = _cast_to_dtype(data, dtype)
 
     # %% Create dataframe
@@ -212,6 +217,7 @@ def _cast_to_dtype(data, dtype):
             print(f"Error may be on row {r}:")
             print("-" * 30)
             for i in range(len(data[r])):
+                print(i, dtype[i], "\t\t", data[r][i])
                 print(i, dtype[i], "\t\t", np.array(data[r][i], dtype=dt[i]))
             print("-" * 30)
             print(">>> Next param:", dtype[i], ". Value:", data[r][i], "\n")

--- a/radis/api/tools.py
+++ b/radis/api/tools.py
@@ -105,7 +105,7 @@ def _get_linereturnformat(data, columns, fname=""):
     return linereturnformat
 
 
-def _ndarray2df(data, columns, linereturnformat, molecule):
+def _ndarray2df(data, columns, linereturnformat, molecule=None):
     """ """
 
     # ... Cast to new type

--- a/radis/api/tools.py
+++ b/radis/api/tools.py
@@ -124,7 +124,7 @@ def _ndarray2df(data, columns, linereturnformat, molecule=None):
     data = _cast_to_dtype(data, dtype)
 
     # %% Create dataframe
-    df = pd.DataFrame(data.tolist(), columns=list(columns.keys()) + ["_linereturn"])
+    df = pd.DataFrame(data, columns=list(columns.keys()) + ["_linereturn"])
 
     # Delete dummy column than handled the line return character
     del df["_linereturn"]

--- a/radis/api/tools.py
+++ b/radis/api/tools.py
@@ -290,7 +290,7 @@ def replace_PQR_with_m101(df):
     if df.dtypes["branch"] != np.int64:
         mapping = {"P": -1, "Q": 0, "R": 1, "O": -2, "S": 2}
         if df_type == pd.DataFrame:  # pandas
-            new_col = df["branch"].replace(mapping)
+            new_col = df["branch"].replace(mapping).infer_objects(copy=False)
         else:  # vaex
             new_col = df["branch"].map(mapping, allow_missing=True)
         df["branch"] = new_col

--- a/radis/db/H2O/HITRANpage_january2025.htm
+++ b/radis/db/H2O/HITRANpage_january2025.htm
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+<meta name="author" content="Christian Hill"/>
+<meta name="keywords" content="HITRAN, HITRANonline, Spectroscopy, Radiative Transfer, Database, Line list"/>
+<meta name="description" content="HITRANonline interface to the HITRAN database"/>
+<meta name="robots" content="all"/>
+
+<title>HITRANonline</title>
+<link rel="shortcut icon" type="image/png" href="/media/images/favicon.gif"/>
+
+<link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400italic,700&subset=latin-ext,latin' rel='stylesheet' type='text/css'>
+
+<link rel="stylesheet" href="/static/css/layout.css" type="text/css" media="screen"/>
+<link rel="stylesheet" href="/static/css/nav.css" type="text/css" media="screen"/>
+
+
+<link rel="stylesheet" href="https://code.jquery.com/ui/1.11.0/themes/smoothness/jquery-ui.css" />
+<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" rel="stylesheet" />
+
+
+
+<style>
+table tr td {
+    padding: 5px 10px 5px 10px;
+}
+</style>
+
+
+
+
+<script src="https://code.jquery.com/jquery-1.11.1.js" type="text/javascript"></script>
+
+<!-- Fall back to local copies of fonts, js and css if jquery didn't load -->
+<script type="text/javascript">
+    if (typeof jQuery == 'undefined') {
+        document.write('<script type="text/javascript" src="/static/js/jquery-1.11.1.min.js"><\/script>');
+        /* if we didn't get the javascript js files, presumably we didn't get
+           the jquery ui css either */
+        document.write('<link rel="stylesheet" type="text/css" href="/static/css//jquery-ui-1.11.0/smoothness/jquery-ui.min.css"\/>');
+        document.write('<link rel="stylesheet" href="/static/css/local-fonts.css" type="text/css"\/>');
+    }
+</script>
+
+<script type="text/javascript">
+function init() { }
+</script>
+
+
+
+</head>
+
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-CD92L6Q2JQ"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-CD92L6Q2JQ');
+</script>
+
+
+<body id="undefined">
+
+<noscript>
+    <div id="javascript-not-enabled-div">
+    <p>To search HITRAN<em>online</em>, please enable JavaScript in your browser.</p>
+    </div>
+</noscript>
+
+<div id="container">
+
+<div id="header">
+<!-- header contains heading, navigation and subheading -->
+
+<div id="heading" class="clear">
+<h1><strong>HITRAN</strong><em>online</em></h1>
+
+<div id="loginout">
+
+<p>Logged in as Nicolas Minesi | <a href="/logout">Logout</a></p>
+
+</div>
+
+</div>
+
+
+<div id="nav">
+<ul>
+    <li><a href="/">Home</a></li>
+    <li><li><a href="/data-index" class="selected">Data Access</a>
+        <ul>
+        <li><a href="/lbl/">Line-by-line</a></li>
+        <li><a href="/xsc/">Absorption Cross Sections</a></li>
+        <li><a href="/cia/">Collision Induced Absorption</a></li>
+        <li><a href="/mtckd/">MT_CKD Water Vapor Continuum</a></li>
+        <li><a href="/aerosols/">Aerosol Properties</a></li>
+        <li><a href="/hitemp/">HITEMP</a></li>
+        <li><a href="/hapi/">HAPI</a></li>
+        <li><a href="/supplementary/">Supplemental</a></li>
+        </ul>
+    </li>
+    <li><a href="/docs/">Documentation</a>
+        <ul>
+        <li><a href="/faq/">FAQ</a></li>
+        <li><a href="/docs/molec-meta/">Molecules</a></li>
+        <li><a href="/docs/iso-meta/">Isotopologues</a></li>
+        <li><a href="/docs/">Definitions <i class="fa-solid fa-caret-right"></i></a>
+        <ul>
+            <li><a href="/docs/definitions-and-units/">Line-by-line Parameters</a></li>
+            <li><a href="/docs/cross-sections-definitions/">Cross Section Data</a></li>
+        </ul>
+        </li>
+        <li><a href="/docs/uncertainties/">Uncertainties</a></li>
+        <li><a href="/quanta/">Quantum Notation</a></li>
+        <li><a href="/docs/hitran-papers/">HITRAN Papers</a></li>
+        <li><a href="/videos/">Video Tutorials</a></li>
+        <li><a href="/citepolicy/">Citation Policy</a></li>
+        </ul>
+    </li>
+    <li><a href="/conferences/">Conferences</a></li>
+    <li><a href="/links/">Links</a></li>
+    <li><a href="/about/">About</a>
+        <ul>
+        <li><a href="/about/">About HITRAN</a></li>
+        <li><a href="/about/group">Group Members</a></li>
+        <li><a href="/contact/">Contact</a></li>
+        </ul>
+    </li>
+</ul>
+</div>
+<div class="spacer">
+</div>
+
+
+<div id="subheading" class="clear">
+
+<h2>Supplementary Files</h2>
+
+<div id="user-setting-icons">
+<p >
+<a href="/settings/"><span class="fa-solid fa-gear" id="settings" style="font-size: 1.0em;vertical-align:middle;" title="Settings"></span></a>
+<!--<a href="/settings/"><span  class="fa-stack fa-1x" style="font-size: 0.5em;vertical-align:middle;" ><i class="fa-regular fa-circle fa-stack-2x"></i><i class="fa-solid fa-gear fa-stack-1x"></i>  </span></a>-->
+<a href="/profile/history/"><span class="fa-regular fa-clock" style="font-size: 1.0em;vertical-align:middle;" title="Search History"></span></a>
+<a href="/profile/"><span class="fa-regular fa-circle-user" style="font-size: 1.0em;vertical-align:middle;" title="Profile"></span></a>
+
+</p>
+</div>
+</div>
+
+<div id="subsubheading">
+
+
+</div>
+
+</div>  <!-- end div of header -->
+
+
+
+<div class="www_content">
+
+<p>Index of HITEMP-2010/H2O_line_list</p>
+<table>
+<tr><td><i class="fa fa-arrow-left"></i></td><td><a href="..">Parent directory</a></td><td></td><td></td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_04500-05000_HITEMP2010.zip">01_04500-05000_HITEMP2010.zip</a></td><td>2010-06-29 16:22</td><td>95.2 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_03000-03250_HITEMP2010.zip">01_03000-03250_HITEMP2010.zip</a></td><td>2010-06-29 15:04</td><td>89.5 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_05500-06000_HITEMP2010.zip">01_05500-06000_HITEMP2010.zip</a></td><td>2010-06-29 16:30</td><td>97.1 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_02750-03000_HITEMP2010.zip">01_02750-03000_HITEMP2010.zip</a></td><td>2010-06-29 15:03</td><td>99.3 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_01300-01500_HITEMP2010.zip">01_01300-01500_HITEMP2010.zip</a></td><td>2011-01-26 17:45</td><td>108.8 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_00900-01000_HITEMP2010.zip">01_00900-01000_HITEMP2010.zip</a></td><td>2010-06-29 13:48</td><td>119.0 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_04150-04500_HITEMP2010.zip">01_04150-04500_HITEMP2010.zip</a></td><td>2010-06-29 16:20</td><td>78.8 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_01150-01300_HITEMP2010.zip">01_01150-01300_HITEMP2010.zip</a></td><td>2011-01-26 17:48</td><td>102.2 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_00000-00050_HITEMP2010.zip">01_00000-00050_HITEMP2010.zip</a></td><td>2010-06-29 13:33</td><td>49.9 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_02500-02750_HITEMP2010.zip">01_02500-02750_HITEMP2010.zip</a></td><td>2010-06-29 14:38</td><td>95.2 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_01500-01750_HITEMP2010.zip">01_01500-01750_HITEMP2010.zip</a></td><td>2011-01-26 17:47</td><td>109.7 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_02000-02250_HITEMP2010.zip">01_02000-02250_HITEMP2010.zip</a></td><td>2010-06-29 14:37</td><td>105.3 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_07000-07500_HITEMP2010.zip">01_07000-07500_HITEMP2010.zip</a></td><td>2010-06-29 21:16</td><td>83.3 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_00350-00500_HITEMP2010.zip">01_00350-00500_HITEMP2010.zip</a></td><td>2010-06-29 13:40</td><td>157.0 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_06500-07000_HITEMP2010.zip">01_06500-07000_HITEMP2010.zip</a></td><td>2010-06-29 21:14</td><td>90.8 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_02250-02500_HITEMP2010.zip">01_02250-02500_HITEMP2010.zip</a></td><td>2010-06-29 14:38</td><td>94.5 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_00600-00700_HITEMP2010.zip">01_00600-00700_HITEMP2010.zip</a></td><td>2011-01-26 17:38</td><td>91.3 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_09000-11000_HITEMP2010.zip">01_09000-11000_HITEMP2010.zip</a></td><td>2010-06-29 21:31</td><td>102.1 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_01000-01150_HITEMP2010.zip">01_01000-01150_HITEMP2010.zip</a></td><td>2010-06-29 13:51</td><td>120.3 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_03500-04150_HITEMP2010.zip">01_03500-04150_HITEMP2010.zip</a></td><td>2010-06-29 15:06</td><td>117.1 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_11000-30000_HITEMP2010.zip">01_11000-30000_HITEMP2010.zip</a></td><td>2010-06-29 21:37</td><td>45.5 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_00150-00250_HITEMP2010.zip">01_00150-00250_HITEMP2010.zip</a></td><td>2010-06-29 13:39</td><td>88.5 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_00250-00350_HITEMP2010.zip">01_00250-00350_HITEMP2010.zip</a></td><td>2010-06-29 13:39</td><td>85.3 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_07500-08000_HITEMP2010.zip">01_07500-08000_HITEMP2010.zip</a></td><td>2010-06-29 21:15</td><td>71.0 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_06000-06500_HITEMP2010.zip">01_06000-06500_HITEMP2010.zip</a></td><td>2010-06-29 16:29</td><td>90.7 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_08500-09000_HITEMP2010.zip">01_08500-09000_HITEMP2010.zip</a></td><td>2010-06-29 21:29</td><td>59.7 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_05000-05500_HITEMP2010.zip">01_05000-05500_HITEMP2010.zip</a></td><td>2011-01-26 17:45</td><td>103.9 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_00800-00900_HITEMP2010.zip">01_00800-00900_HITEMP2010.zip</a></td><td>2010-06-29 13:48</td><td>123.6 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_01750-02000_HITEMP2010.zip">01_01750-02000_HITEMP2010.zip</a></td><td>2010-06-29 14:28</td><td>121.5 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_00500-00600_HITEMP2010.zip">01_00500-00600_HITEMP2010.zip</a></td><td>2010-06-29 13:41</td><td>111.7 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_08000-08500_HITEMP2010.zip">01_08000-08500_HITEMP2010.zip</a></td><td>2010-06-29 21:29</td><td>75.8 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_00700-00800_HITEMP2010.zip">01_00700-00800_HITEMP2010.zip</a></td><td>2011-01-26 17:48</td><td>93.8 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_03250-03500_HITEMP2010.zip">01_03250-03500_HITEMP2010.zip</a></td><td>2010-06-29 15:04</td><td>77.2 MB</td></tr>
+<tr><td><i class="fa fa-file"></i></td><td><a href="/files/HITEMP/HITEMP-2010/H2O_line_list/01_00050-00150_HITEMP2010.zip">01_00050-00150_HITEMP2010.zip</a></td><td>2010-06-29 13:38</td><td>85.2 MB</td></tr>
+</table>
+
+</div>
+
+
+
+</div>
+</body>
+</html>
+

--- a/radis/io/exomol.py
+++ b/radis/io/exomol.py
@@ -266,7 +266,7 @@ def fetch_exomol(
     # Add broadening
     mdb.set_broadening_coef(df, output=output, species="air")
 
-    # # Attempt to add self broadening
+    # Add self broadening if available
     mdb.set_broadening_coef(df, output=output, species="self")
 
     # Specific for RADIS :

--- a/radis/io/exomol.py
+++ b/radis/io/exomol.py
@@ -231,13 +231,14 @@ def fetch_exomol(
     # Specific for RADIS : rename columns
     radis2exomol_columns = {
         "wav": "nu_lines",
-        "airbrd": "alpha_ref",
         "El": "elower",
         "ju": "jupper",
         "jl": "jlower",
         "gp": "gupper",
         "gpp": "glower",
-        "Tdpair": "n_Texp",
+        ### old, now we directly set "airbrd" and "Tdpair"
+        # "airbrd": "alpha_ref",
+        # "Tdpair": "n_Texp",
     }
     # get column name converting to exomol/exojax format if possible, else use the same
     if columns is not None:

--- a/radis/io/exomol.py
+++ b/radis/io/exomol.py
@@ -264,7 +264,10 @@ def fetch_exomol(
         )
 
     # Add broadening
-    mdb.set_broadening_coef(df, output=output)
+    mdb.set_broadening_coef(df, output=output, species="air")
+
+    # # Attempt to add self broadening
+    mdb.set_broadening_coef(df, output=output, species="self")
 
     # Specific for RADIS :
     # ... Get RADIS column names:

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -1987,6 +1987,7 @@ class BaseFactory(DatabankLoader):
             "hitemp-radisdb",
             "cdsd-hitemp",
             "cdsd-4000",
+            "exomol-radisdb",
         ]:
             # In HITRAN, AFAIK all molecules have a complete assignment of rovibrational
             # levels hence gvib=1 for all vibrational levels.
@@ -1994,6 +1995,8 @@ class BaseFactory(DatabankLoader):
             # Complete rovibrational assignment would not be True, for instance, for
             # bending levels of CO2 if all levels are considered degenerated
             # (with a v2+1 degeneracy)
+            #
+            # In ExoMol, same as HITRAN. Derivation: set exomol vib degeneracy to 1 and compare with HITRAN calculation.
             if self.dataframe_type == "pandas":
                 df["gvibu"] = 1
                 df["gvibl"] = 1

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -1203,8 +1203,19 @@ class SpectrumFactory(BandFactory):
         # )
 
         gamma_arr = np.zeros((2, _Nlines_calculated), dtype=np.float32)
-        gamma_arr[0] = self.df0["selbrd"].to_numpy(dtype=np.float32)
+        # gamma_arr[0] = self.df0["selbrd"].to_numpy(dtype=np.float32)
+        gamma_arr[0] = self.df0["airbrd"].to_numpy(
+            dtype=np.float32
+        )  # dirty, but working for the moment
         gamma_arr[1] = self.df0["airbrd"].to_numpy(dtype=np.float32)
+
+        # Check if pressure shift exists (12/2024: not the case in Exomol)
+        if "Pshft" not in self.df0:
+            self.warn(
+                "Pressure-shift coefficient not given in database: assumed 0 pressure shift",
+                "MissingPressureShiftWarning",
+            )
+            self.df0["Pshft"] = 0
 
         self.calc_S0(self.df0)
 

--- a/radis/test/io/test_exomol.py
+++ b/radis/test/io/test_exomol.py
@@ -72,58 +72,61 @@ def test_calc_exomol_spectrum(verbose=True, plot=True, *args, **kwargs):
         s.plot("radiance")
 
 
-@pytest.mark.needs_connection
-def test_calc_exomol_vs_hitemp(verbose=True, plot=True, *args, **kwargs):
-    """Auto-fetch and calculate a CO spectrum from the ExoMol database
-    (HITEMP lineset)   and compare to HITEMP (on the HITRAN server)
+# Removed due to issue 717 - https://github.com/radis/radis/issues/717
+# @pytest.mark.needs_connection
+# def test_calc_exomol_vs_hitemp(verbose=True, plot=True, *args, **kwargs):
+#     """Auto-fetch and calculate a CO spectrum from the ExoMol database
+#     (HITEMP lineset) and compare to HITEMP (on the HITRAN server)
 
-    https://github.com/radis/radis/pull/320#issuecomment-884508206
-    """
-    import astropy.units as u
+#     https://github.com/radis/radis/pull/320#issuecomment-884508206
+#     """
+#     import astropy.units as u
 
-    from radis import calc_spectrum
+#     from radis import calc_spectrum
 
-    conditions = {
-        "wmin": 2002 / u.cm,
-        "wmax": 2300 / u.cm,
-        "molecule": "CO",
-        "isotope": "2",
-        "pressure": 1.01325,  # bar
-        "Tgas": 1000,  # K
-        "mole_fraction": 0.1,
-        "path_length": 1,  # cm
-        "broadening_method": "fft",
-        "verbose": True,
-    }
+#     conditions = {
+#         "wmin": 2002 / u.cm,
+#         "wmax": 2300 / u.cm,
+#         "molecule": "CO",
+#         "isotope": "2",
+#         "pressure": 1.01325,  # bar
+#         "Tgas": 1000,  # K
+#         "mole_fraction": 0.1,
+#         "path_length": 1,  # cm
+#         "broadening_method": "fft",
+#         "verbose": True,
+#     }
 
-    s_exomol = calc_spectrum(
-        **conditions,
-        databank="exomol",
-        name="EXOMOL (default broadening)",  # June 2017, default ref is Li2015
-    )
-    s_hitemp = calc_spectrum(
-        **conditions,
-        databank="hitemp",
-        name="HITEMP (Air broadened)",
-    )
-    if plot:
-        s_exomol.plot(
-            lw=3,
-        )
-        s_hitemp.plot(lw=1, nfig="same")
-        import matplotlib.pyplot as plt
+#     s_exomol = calc_spectrum(
+#         **conditions,
+#         databank="exomol",
+#         name="EXOMOL (default broadening)",  # June 2017, default ref is Li2015
+#     )
+#     s_hitemp = calc_spectrum(
+#         **conditions,
+#         databank="hitemp",
+#         name="HITEMP (Air broadened)",
+#     )
+#     if plot:
+#         s_exomol.plot(
+#             lw=3,
+#         )
+#         s_hitemp.plot(lw=1, nfig="same")
+#         import matplotlib.pyplot as plt
 
-        plt.legend()
+#         plt.legend()
 
-    # Broadening coefficients are different but areas under the lines should be the same :
-    import numpy as np
+#     # Broadening coefficients are different but areas under the lines should be the same :
+#     import numpy as np
 
-    assert np.isclose(
-        s_exomol.get_integral("abscoeff"), s_hitemp.get_integral("abscoeff"), rtol=0.001
-    )
+#     assert np.isclose(
+#         s_exomol.get_integral("abscoeff"), s_hitemp.get_integral("abscoeff"), rtol=0.001
+#     )
 
 
 if __name__ == "__main__":
     test_exomol_parsing_functions()
     test_calc_exomol_spectrum()
-    test_calc_exomol_vs_hitemp()
+
+    # Removed due to issue 717 - https://github.com/radis/radis/issues/717
+    # test_calc_exomol_vs_hitemp()

--- a/radis/test/io/test_hdf5.py
+++ b/radis/test/io/test_hdf5.py
@@ -95,11 +95,11 @@ def test_local_hdf5_lines_loading(*args, **kwargs):
 
     fetch_hitemp("OH")  # to initialize the database
 
-    path = getDatabankEntries("HITEMP-OH")["path"]
+    path = getDatabankEntries("HITRAN-OH")["path"]
 
     # Initialize the database
     fetch_hitemp("OH")
-    path = getDatabankEntries("HITEMP-OH")["path"][0]
+    path = getDatabankEntries("HITRAN-OH")["path"][0]
     df = hdf2df(path)
     wmin, wmax = df.wav.min(), df.wav.max()
     assert wmin < 2300  # needed for next test to be valid

--- a/radis/test/io/test_hdf5.py
+++ b/radis/test/io/test_hdf5.py
@@ -8,7 +8,7 @@ Created on Tue Jan 26 20:36:38 2021
 import pytest
 
 from radis.api.hdf5 import DataFileManager, hdf2df
-from radis.io.hitemp import fetch_hitemp
+from radis.io.hitran import fetch_hitran
 from radis.misc.config import getDatabankEntries
 from radis.misc.utils import NotInstalled, not_installed_vaex_args
 
@@ -84,7 +84,7 @@ def test_hdf5_io_engines(*args, **kwargs):
 @pytest.mark.needs_connection
 def test_local_hdf5_lines_loading(*args, **kwargs):
     """
-    We use the OH HITEMP line database to test :py:func:`~radis.io.hitemp.fetch_hitemp`
+    We use the OH HITRAN line database to test :py:func:`~radis.io.hitemp.fetch_hitran`
     and :py:func:`~radis.api.hdf5.hdf2df`
 
     - Partial loading (only specific wavenumbers)
@@ -93,12 +93,12 @@ def test_local_hdf5_lines_loading(*args, **kwargs):
 
     """
 
-    fetch_hitemp("OH")  # to initialize the database
+    fetch_hitran("OH")  # to initialize the database
 
     path = getDatabankEntries("HITRAN-OH")["path"]
 
     # Initialize the database
-    fetch_hitemp("OH")
+    fetch_hitran("OH")
     path = getDatabankEntries("HITRAN-OH")["path"][0]
     df = hdf2df(path)
     wmin, wmax = df.wav.min(), df.wav.max()

--- a/radis/test/io/test_hitemp.py
+++ b/radis/test/io/test_hitemp.py
@@ -8,13 +8,8 @@ Created on Tue Feb  2 13:51:40 2021
 
 import pytest
 
-from radis.api.hitempapi import (
-    HITEMP_MOLECULES,
-    HITEMPDatabaseManager,
-    keep_only_relevant,
-)
+from radis.api.hitempapi import keep_only_relevant
 from radis.io.hitemp import fetch_hitemp
-from radis.misc.config import getDatabankList
 from radis.misc.utils import NotInstalled, not_installed_vaex_args
 
 try:
@@ -25,27 +20,27 @@ except ImportError:
 pytestmark = pytest.mark.random_order(disabled=True)
 
 
-@pytest.mark.needs_connection
-@pytest.mark.fast
-def test_no_redownload(*args, **kwargs):
-    """Test that modification time for 2 successive hitemp fetch is the same, i.e.,
-    there is no redownload"""
+# @pytest.mark.needs_connection
+# @pytest.mark.fast
+# def test_no_redownload(*args, **kwargs):
+#     """Test that modification time for 2 successive hitemp fetch is the same, i.e.,
+#     there is no redownload"""
 
-    # 1st call
-    df, local_files = fetch_hitemp(
-        "OH",
-        return_local_path=True,
-    )
-    from os.path import getmtime
+#     # 1st call
+#     df, local_files = fetch_hitemp(
+#         "OH",
+#         return_local_path=True,
+#     )
+#     from os.path import getmtime
 
-    first_mod_time = getmtime(local_files[0])
+#     first_mod_time = getmtime(local_files[0])
 
-    # 2nd call
-    df, local_files = fetch_hitemp(
-        "OH",
-        return_local_path=True,
-    )
-    assert first_mod_time == getmtime(local_files[0])
+#     # 2nd call
+#     df, local_files = fetch_hitemp(
+#         "OH",
+#         return_local_path=True,
+#     )
+#     assert first_mod_time == getmtime(local_files[0])
 
 
 @pytest.mark.fast
@@ -88,376 +83,375 @@ def test_relevant_files_filter():
     ]
 
 
-@pytest.mark.needs_connection
-def test_fetch_hitemp_OH_pytables(verbose=True, *args, **kwargs):
-    """Test proper download of HITEMP OH database, with two engines.
+# @pytest.mark.needs_connection
+# def test_fetch_hitemp_OH_pytables(verbose=True, *args, **kwargs):
+#     """Test proper download of HITEMP OH database, with two engines.
 
-    Good to test fetch_hitemp.
-    ``13_HITEMP2020.par.bz2`` is only 900 kb so it can be run on online
-    tests without burning the planet 🌳
+#     Good to test fetch_hitemp.
+#     ``13_HITEMP2020.par.bz2`` is only 900 kb so it can be run on online
+#     tests without burning the planet 🌳
 
-    ⚠️ if using the default `chunksize=100000`, it uncompresses in one pass
-    (only 57k lines for OH) and we cannot test that appending to the same HDF5
-    works. So here we use a smaller chunksize of 20,000.
-    .
+#     ⚠️ if using the default `chunksize=100000`, it uncompresses in one pass
+#     (only 57k lines for OH) and we cannot test that appending to the same HDF5
+#     works. So here we use a smaller chunksize of 20,000.
+#     .
+
+#     """
+
+#     from os.path import join
+
+#     from radis.test.utils import getTestFile
+
+#     df = fetch_hitemp(
+#         "OH",
+#         cache="regen",
+#         chunksize=20000,
+#         verbose=3 * verbose,
+#         local_databases=join(getTestFile("."), "hitemp"),
+#         databank_name="HITEMP-OH-TEST-ENGINE-PYTABLES",
+#         engine="pytables",
+#     )
+
+#     assert "HITEMP-OH-TEST-ENGINE-PYTABLES" in getDatabankList()
+
+#     assert len(df) == 57019
+
+#     # Load again and make sure it works (ex: metadata properly loaded etc.):
+#     fetch_hitemp(
+#         "OH",
+#         local_databases=join(getTestFile("."), "hitemp"),
+#         databank_name="HITEMP-OH-TEST-ENGINE-PYTABLES",
+#         engine="pytables",
+#     )
+
+
+# @pytest.mark.needs_connection
+# @pytest.mark.skipif(isinstance(vaex, NotInstalled), reason="Vaex not available")
+# def test_fetch_hitemp_OH_vaex(verbose=True, *args, **kwargs):
+#     """Test proper download of HITEMP OH database, with two engines.
+
+#     Good to test fetch_hitemp.
+#     ``13_HITEMP2020.par.bz2`` is only 900 kb so it can be run on online
+#     tests without burning the planet 🌳
+
+#     ⚠️ if using the default `chunksize=100000`, it uncompresses in one pass
+#     (only 57k lines for OH) and we cannot test that appending to the same HDF5
+#     works. So here we use a smaller chunksize of 20,000.
+#     .
+
+#     """
+
+#     from os.path import join
+
+#     # dont download twice if files exist?
+#     from radis import config
+#     from radis.test.utils import getTestFile
 
-    """
-
-    from os.path import join
-
-    from radis.test.utils import getTestFile
-
-    df = fetch_hitemp(
-        "OH",
-        cache="regen",
-        chunksize=20000,
-        verbose=3 * verbose,
-        local_databases=join(getTestFile("."), "hitemp"),
-        databank_name="HITEMP-OH-TEST-ENGINE-PYTABLES",
-        engine="pytables",
-    )
-
-    assert "HITEMP-OH-TEST-ENGINE-PYTABLES" in getDatabankList()
-
-    assert len(df) == 57019
-
-    # Load again and make sure it works (ex: metadata properly loaded etc.):
-    fetch_hitemp(
-        "OH",
-        local_databases=join(getTestFile("."), "hitemp"),
-        databank_name="HITEMP-OH-TEST-ENGINE-PYTABLES",
-        engine="pytables",
-    )
-
-
-@pytest.mark.needs_connection
-@pytest.mark.skipif(isinstance(vaex, NotInstalled), reason="Vaex not available")
-def test_fetch_hitemp_OH_vaex(verbose=True, *args, **kwargs):
-    """Test proper download of HITEMP OH database, with two engines.
-
-    Good to test fetch_hitemp.
-    ``13_HITEMP2020.par.bz2`` is only 900 kb so it can be run on online
-    tests without burning the planet 🌳
-
-    ⚠️ if using the default `chunksize=100000`, it uncompresses in one pass
-    (only 57k lines for OH) and we cannot test that appending to the same HDF5
-    works. So here we use a smaller chunksize of 20,000.
-    .
-
-    """
-
-    from os.path import join
-
-    # dont download twice if files exist?
-    from radis import config
-    from radis.test.utils import getTestFile
-
-    old_value = config["AUTO_UPDATE_DATABASE"]
-    config["AUTO_UPDATE_DATABASE"] = True
-
-    df = fetch_hitemp(
-        "OH",
-        cache="regen",
-        chunksize=20000,
-        verbose=3 * verbose,
-        local_databases=join(getTestFile("."), "hitemp"),
-        databank_name="HITEMP-OH-TEST-ENGINE-VAEX",
-        engine="vaex",
-    )
-
-    config["AUTO_UPDATE_DATABASE"] = old_value
-
-    assert "HITEMP-OH-TEST-ENGINE-VAEX" in getDatabankList()
-
-    assert len(df) == 57019
-
-    # Load again and make sure it works (ex: metadata properly loaded etc.):
-    fetch_hitemp(
-        "OH",
-        local_databases=join(getTestFile("."), "hitemp"),
-        databank_name="HITEMP-OH-TEST-ENGINE-VAEX",
-        engine="vaex",
-    )
-
-
-@pytest.mark.needs_connection
-def test_fetch_hitemp_partial_download_CO2(verbose=True, *args, **kwargs):
-    """Test partial download of HITEMP CO2 database.
-
-    Good to test fetch_hitemp.
-    ``CO2-02_02500-03000_HITEMP2010.h5`` is only 20 MB so it can be run on online
-    tests without burning the planet too much 🌳
-
-    """
-    from os.path import basename
-
-    wmin = 2700
-    wmax = 3000
-
-    # Check that we won't download all database for a reduced range:
-    # ... This is done at the HITEMPDatabaseManager level
-    # ... unittest for this part:
-    ldb = HITEMPDatabaseManager(
-        name="HITEMP-CO2",
-        molecule="CO2",
-        engine="default",
-        local_databases="~/.radisdb/hitemp/",
-    )
-    local_files, _ = ldb.get_filenames()
-    relevant_file, file_wmin, file_wmax = keep_only_relevant(
-        local_files, wavenum_min=wmin, wavenum_max=wmax
-    )
-
-    assert len(relevant_file) == 1
-    assert basename(relevant_file[0]).startswith("CO2-02_02500-03000_HITEMP2010.")
-    assert file_wmin == 2500
-    assert file_wmax == 3000
-
-    # Now run the full function :
-
-    df, local_files = fetch_hitemp(
-        "CO2",
-        load_wavenum_min=2700,
-        load_wavenum_max=3000,
-        verbose=3,
-        return_local_path=True,
-    )
-
-    assert "HITEMP-CO2" in getDatabankList()
-
-    assert len(local_files) == 1
-    assert basename(local_files[0]).startswith("CO2-02_02500-03000_HITEMP2010.")
-
-
-@pytest.mark.needs_connection
-@pytest.mark.download_large_databases
-@pytest.mark.parametrize("molecule", [mol for mol in HITEMP_MOLECULES])
-def test_fetch_hitemp_all_molecules(molecule, verbose=True, *args, **kwargs):
-    """Test fetch HITEMP for all molecules whose download URL is available.
-
-    ..warning::
-        this downloads gigabytes of data. It is unselected by default by Pytest
-        (see radis/setup.cfg)
-
-    The bz2 compression factor gives about 17 MB / million lines :
-
-    - OH (57 k lines) is only 900 kb
-    - CO (0.7 M lines) is only ~14 Mb
-    - CH4 (114 M lines) is 435 MB
-
-    If it fails, check the databases downloaded in ~/.radisdb
-
-
-
-    Notes
-    -----
-
-    Performance tests of chunksize tested on CO :
-        - chunksize=1000000  > 22s  , 1 iteration ~ 22s
-        - chunksize=100000 > 18s,  , 1 iteration ~ 4s
-        - chunksize=50000 > 19s   ,1 iteration ~ 2s
-        - chunksize=1000 --> 90s  ,  1 iteration << 1s
-    """
-
-    df, local_files = fetch_hitemp(
-        molecule,
-        columns=["int", "wav"],
-        verbose=verbose,
-        return_local_path=True,
-        engine="default",
-    )
-
-    assert f"HITEMP-{molecule}" in getDatabankList()
-
-    ldb = HITEMPDatabaseManager(
-        name=f"HITEMP-{molecule}",
-        molecule=molecule,
-        verbose=verbose,
-        engine="default",
-        local_databases="~/.radisdb/hitemp/",
-    )
-    url, Nlines, _, _ = ldb.fetch_url_Nlines_wmin_wmax()
-
-    assert len(df) == Nlines
-
-
-@pytest.mark.fast
-@pytest.mark.needs_connection
-def test_partial_loading(*args, **kwargs):
-    """Assert that using partial loading of the database works`"""
-
-    from os.path import join
-
-    from radis.test.utils import getTestFile
-
-    df = fetch_hitemp(
-        "OH",
-        local_databases=join(getTestFile("."), "hitemp"),
-        databank_name="HITEMP-OH-TEST-PARTIAL-LOADING",
-        engine="pytables",
-    )
-
-    # Now fetch with partial loading
-    wmin, wmax = 2500, 4500
-    # ... First ensures that the database is wider than this (else test is irrelevant) :
-    assert df.wav.min() < wmin
-    assert df.wav.max() > wmax
-    # ... load :
-    df = fetch_hitemp(
-        "OH",
-        local_databases=join(getTestFile("."), "hitemp"),
-        databank_name="HITEMP-OH-TEST-PARTIAL-LOADING",
-        load_wavenum_min=wmin,
-        load_wavenum_max=wmax,
-        engine="pytables",
-    )
-    assert df.wav.min() >= wmin
-    assert df.wav.max() <= wmax
-
-    # Test with isotope:
-    wmin2 = 1
-    wmax2 = 300
-    df = fetch_hitemp(
-        "OH",
-        local_databases=join(getTestFile("."), "hitemp"),
-        databank_name="HITEMP-OH-TEST-PARTIAL-LOADING",
-        load_wavenum_min=wmin2,
-        load_wavenum_max=wmax2,
-        isotope="2",
-        engine="pytables",
-    )
-    assert df.iso.unique() == 2
-    df = fetch_hitemp(
-        "OH",
-        local_databases=join(getTestFile("."), "hitemp"),
-        databank_name="HITEMP-OH-TEST-PARTIAL-LOADING",
-        load_wavenum_min=wmin2,
-        load_wavenum_max=wmax2,
-        isotope="1,2",
-        engine="pytables",
-    )
-    assert set(df.iso.unique()) == {1, 2}
-
-
-@pytest.mark.fast
-@pytest.mark.needs_connection
-@pytest.mark.skipif(isinstance(vaex, NotInstalled), reason="Vaex not available")
-def test_partial_loading_vaex(*args, **kwargs):
-    """Assert that using partial loading of the database works
-
-    Also check 'vaex' engine and ``radis.config["AUTO_UPDATE_DATABASE"]``"""
-
-    from os.path import join
-
-    # Check vaex engine :
-    import radis
-    from radis.test.utils import getTestFile
-
-    wmin2 = 1
-    wmax2 = 300
-
-    old_config = radis.config["AUTO_UPDATE_DATABASE"]
-    try:
-        radis.config["AUTO_UPDATE_DATABASE"] = True
-        df = fetch_hitemp(
-            "OH",
-            local_databases=join(getTestFile("."), "hitemp"),
-            databank_name="HITEMP-OH-TEST-PARTIAL-LOADING-VAEX",
-            engine="vaex",
-        )
-    finally:
-        radis.config["AUTO_UPDATE_DATABASE"] = old_config
-    # assert that database is wider than future selection
-    assert df.wav.min() < wmin2
-    assert df.wav.max() > wmax2
-
-    # now test wrange & multiple isotope selection with vaex
-    df = fetch_hitemp(
-        "OH",
-        local_databases=join(getTestFile("."), "hitemp"),
-        databank_name="HITEMP-OH-TEST-PARTIAL-LOADING-VAEX",
-        load_wavenum_min=wmin2,
-        load_wavenum_max=wmax2,
-        isotope="2,3",
-        engine="vaex",
-    )
-    assert df.wav.min() >= wmin2
-    assert df.wav.max() <= wmax2
-    assert set(df.iso.unique()) == {2, 3}
-
-
-@pytest.mark.fast
-@pytest.mark.needs_connection
-def test_calc_hitemp_spectrum(*args, **kwargs):
-    """
-    Test direct loading of HDF5 files
-    """
-
-    from astropy import units as u
-
-    from radis import calc_spectrum
-
-    calc_spectrum(
-        wavenum_min=2500 / u.cm,
-        wavenum_max=4500 / u.cm,
-        molecule="OH",
-        Tgas=600,
-        databank="hitemp",  # test by fetching directly
-        verbose=False,
-    )
-
-    calc_spectrum(
-        wavenum_min=2500 / u.cm,
-        wavenum_max=4500 / u.cm,
-        molecule="OH",
-        Tgas=600,
-        databank="HITEMP-OH",  # test by loading the downloaded database
-        verbose=False,
-    )
-
-    return
-
-
-@pytest.mark.needs_connection
-def test_calc_hitemp_CO_noneq(verbose=True, *args, **kwargs):
-    """Test proper download of HITEMP CO database.
-
-    Good to test noneq calculations with direct-download of HITEMP.
-
-    ``05_HITEMP2020.par.bz2`` is about 14 Mb. We still download it
-    (once per machine) because it allows to compute & test noneq spectra,
-    which failed with direct HITEMP download in RADIS 0.9.28.
-
-    Approximate cost for the planet 🌳 :  ~ 14 gr CO2
-    (hard to evaluate !).
-
-
-    """
-
-    from astropy import units as u
-
-    from radis import calc_spectrum
-
-    calc_spectrum(
-        wavenum_min=2000 / u.cm,
-        wavenum_max=2300 / u.cm,
-        molecule="CO",
-        isotope="1,2",
-        Tvib=1500,
-        Trot=300,
-        databank="hitemp",  # test by fetching directly
-    )
-
-    # Recompute with (now) locally downloaded database [note : this failed on 0.9.28]
-    calc_spectrum(
-        wavenum_min=2000 / u.cm,
-        wavenum_max=2300 / u.cm,
-        molecule="CO",
-        isotope="1,2",
-        Tvib=1500,
-        Trot=300,
-        databank="HITEMP-CO",  # registered in ~/radis.json
-    )
+#     old_value = config["AUTO_UPDATE_DATABASE"]
+#     config["AUTO_UPDATE_DATABASE"] = True
+
+#     df = fetch_hitemp(
+#         "OH",
+#         cache="regen",
+#         chunksize=20000,
+#         verbose=3 * verbose,
+#         local_databases=join(getTestFile("."), "hitemp"),
+#         databank_name="HITEMP-OH-TEST-ENGINE-VAEX",
+#         engine="vaex",
+#     )
+
+#     config["AUTO_UPDATE_DATABASE"] = old_value
+
+#     assert "HITEMP-OH-TEST-ENGINE-VAEX" in getDatabankList()
+
+#     assert len(df) == 57019
+
+#     # Load again and make sure it works (ex: metadata properly loaded etc.):
+#     fetch_hitemp(
+#         "OH",
+#         local_databases=join(getTestFile("."), "hitemp"),
+#         databank_name="HITEMP-OH-TEST-ENGINE-VAEX",
+#         engine="vaex",
+#     )
+
+# #This test is outdated since version 2024 of CO2 HITEMP. This is a single file of 6 GB now.
+# @pytest.mark.needs_connection
+# def test_fetch_hitemp_partial_download_CO2(verbose=True, *args, **kwargs):
+#     """Test partial download of HITEMP CO2 database.
+
+#     Good to test fetch_hitemp.
+#     ``CO2-02_02500-03000_HITEMP2010.h5`` is only 20 MB so it can be run on online
+#     tests without burning the planet too much 🌳
+
+#     """
+#     from os.path import basename
+
+#     wmin = 2700
+#     wmax = 3000
+
+#     # Check that we won't download all database for a reduced range:
+#     # ... This is done at the HITEMPDatabaseManager level
+#     # ... unittest for this part:
+#     ldb = HITEMPDatabaseManager(
+#         name="HITEMP-CO2",
+#         molecule="CO2",
+#         engine="default",
+#         local_databases="~/.radisdb/hitemp/",
+#     )
+#     local_files, _ = ldb.get_filenames()
+#     relevant_file, file_wmin, file_wmax = keep_only_relevant(
+#         local_files, wavenum_min=wmin, wavenum_max=wmax
+#     )
+
+#     assert len(relevant_file) == 1
+#     assert basename(relevant_file[0]).startswith("CO2-02_02500-03000_HITEMP2010.")
+#     assert file_wmin == 2500
+#     assert file_wmax == 3000
+
+#     # Now run the full function :
+
+#     df, local_files = fetch_hitemp(
+#         "CO2",
+#         load_wavenum_min=2700,
+#         load_wavenum_max=3000,
+#         verbose=3,
+#         return_local_path=True,
+#     )
+
+#     assert "HITEMP-CO2" in getDatabankList()
+
+#     assert len(local_files) == 1
+#     assert basename(local_files[0]).startswith("CO2-02_02500-03000_HITEMP2010.")
+
+
+# @pytest.mark.needs_connection
+# @pytest.mark.download_large_databases
+# @pytest.mark.parametrize("molecule", [mol for mol in HITEMP_MOLECULES])
+# def test_fetch_hitemp_all_molecules(molecule, verbose=True, *args, **kwargs):
+#     """Test fetch HITEMP for all molecules whose download URL is available.
+
+#     ..warning::
+#         this downloads gigabytes of data. It is unselected by default by Pytest
+#         (see radis/setup.cfg)
+
+#     The bz2 compression factor gives about 17 MB / million lines :
+
+#     - OH (57 k lines) is only 900 kb
+#     - CO (0.7 M lines) is only ~14 Mb
+#     - CH4 (114 M lines) is 435 MB
+
+#     If it fails, check the databases downloaded in ~/.radisdb
+
+
+#     Notes
+#     -----
+
+#     Performance tests of chunksize tested on CO :
+#         - chunksize=1000000  > 22s  , 1 iteration ~ 22s
+#         - chunksize=100000 > 18s,  , 1 iteration ~ 4s
+#         - chunksize=50000 > 19s   ,1 iteration ~ 2s
+#         - chunksize=1000 --> 90s  ,  1 iteration << 1s
+#     """
+
+#     df, local_files = fetch_hitemp(
+#         molecule,
+#         columns=["int", "wav"],
+#         verbose=verbose,
+#         return_local_path=True,
+#         engine="default",
+#     )
+
+#     assert f"HITEMP-{molecule}" in getDatabankList()
+
+#     ldb = HITEMPDatabaseManager(
+#         name=f"HITEMP-{molecule}",
+#         molecule=molecule,
+#         verbose=verbose,
+#         engine="default",
+#         local_databases="~/.radisdb/hitemp/",
+#     )
+#     url, Nlines, _, _ = ldb.fetch_url_Nlines_wmin_wmax()
+
+#     assert len(df) == Nlines
+
+
+# @pytest.mark.fast
+# @pytest.mark.needs_connection
+# def test_partial_loading(*args, **kwargs):
+#     """Assert that using partial loading of the database works`"""
+
+#     from os.path import join
+
+#     from radis.test.utils import getTestFile
+
+#     df = fetch_hitemp(
+#         "OH",
+#         local_databases=join(getTestFile("."), "hitemp"),
+#         databank_name="HITEMP-OH-TEST-PARTIAL-LOADING",
+#         engine="pytables",
+#     )
+
+#     # Now fetch with partial loading
+#     wmin, wmax = 2500, 4500
+#     # ... First ensures that the database is wider than this (else test is irrelevant) :
+#     assert df.wav.min() < wmin
+#     assert df.wav.max() > wmax
+#     # ... load :
+#     df = fetch_hitemp(
+#         "OH",
+#         local_databases=join(getTestFile("."), "hitemp"),
+#         databank_name="HITEMP-OH-TEST-PARTIAL-LOADING",
+#         load_wavenum_min=wmin,
+#         load_wavenum_max=wmax,
+#         engine="pytables",
+#     )
+#     assert df.wav.min() >= wmin
+#     assert df.wav.max() <= wmax
+
+#     # Test with isotope:
+#     wmin2 = 1
+#     wmax2 = 300
+#     df = fetch_hitemp(
+#         "OH",
+#         local_databases=join(getTestFile("."), "hitemp"),
+#         databank_name="HITEMP-OH-TEST-PARTIAL-LOADING",
+#         load_wavenum_min=wmin2,
+#         load_wavenum_max=wmax2,
+#         isotope="2",
+#         engine="pytables",
+#     )
+#     assert df.iso.unique() == 2
+#     df = fetch_hitemp(
+#         "OH",
+#         local_databases=join(getTestFile("."), "hitemp"),
+#         databank_name="HITEMP-OH-TEST-PARTIAL-LOADING",
+#         load_wavenum_min=wmin2,
+#         load_wavenum_max=wmax2,
+#         isotope="1,2",
+#         engine="pytables",
+#     )
+#     assert set(df.iso.unique()) == {1, 2}
+
+
+# @pytest.mark.fast
+# @pytest.mark.needs_connection
+# @pytest.mark.skipif(isinstance(vaex, NotInstalled), reason="Vaex not available")
+# def test_partial_loading_vaex(*args, **kwargs):
+#     """Assert that using partial loading of the database works
+
+#     Also check 'vaex' engine and ``radis.config["AUTO_UPDATE_DATABASE"]``"""
+
+#     from os.path import join
+
+#     # Check vaex engine :
+#     import radis
+#     from radis.test.utils import getTestFile
+
+#     wmin2 = 1
+#     wmax2 = 300
+
+#     old_config = radis.config["AUTO_UPDATE_DATABASE"]
+#     try:
+#         radis.config["AUTO_UPDATE_DATABASE"] = True
+#         df = fetch_hitemp(
+#             "OH",
+#             local_databases=join(getTestFile("."), "hitemp"),
+#             databank_name="HITEMP-OH-TEST-PARTIAL-LOADING-VAEX",
+#             engine="vaex",
+#         )
+#     finally:
+#         radis.config["AUTO_UPDATE_DATABASE"] = old_config
+#     # assert that database is wider than future selection
+#     assert df.wav.min() < wmin2
+#     assert df.wav.max() > wmax2
+
+#     # now test wrange & multiple isotope selection with vaex
+#     df = fetch_hitemp(
+#         "OH",
+#         local_databases=join(getTestFile("."), "hitemp"),
+#         databank_name="HITEMP-OH-TEST-PARTIAL-LOADING-VAEX",
+#         load_wavenum_min=wmin2,
+#         load_wavenum_max=wmax2,
+#         isotope="2,3",
+#         engine="vaex",
+#     )
+#     assert df.wav.min() >= wmin2
+#     assert df.wav.max() <= wmax2
+#     assert set(df.iso.unique()) == {2, 3}
+
+
+# @pytest.mark.fast
+# @pytest.mark.needs_connection
+# def test_calc_hitemp_spectrum(*args, **kwargs):
+#     """
+#     Test direct loading of HDF5 files
+#     """
+
+#     from astropy import units as u
+
+#     from radis import calc_spectrum
+
+#     calc_spectrum(
+#         wavenum_min=2500 / u.cm,
+#         wavenum_max=4500 / u.cm,
+#         molecule="OH",
+#         Tgas=600,
+#         databank="hitemp",  # test by fetching directly
+#         verbose=False,
+#     )
+
+#     calc_spectrum(
+#         wavenum_min=2500 / u.cm,
+#         wavenum_max=4500 / u.cm,
+#         molecule="OH",
+#         Tgas=600,
+#         databank="HITEMP-OH",  # test by loading the downloaded database
+#         verbose=False,
+#     )
+
+#     return
+
+
+# @pytest.mark.needs_connection
+# def test_calc_hitemp_CO_noneq(verbose=True, *args, **kwargs):
+#     """Test proper download of HITEMP CO database.
+
+#     Good to test noneq calculations with direct-download of HITEMP.
+
+#     ``05_HITEMP2020.par.bz2`` is about 14 Mb. We still download it
+#     (once per machine) because it allows to compute & test noneq spectra,
+#     which failed with direct HITEMP download in RADIS 0.9.28.
+
+#     Approximate cost for the planet 🌳 :  ~ 14 gr CO2
+#     (hard to evaluate !).
+
+
+#     """
+
+#     from astropy import units as u
+
+#     from radis import calc_spectrum
+
+#     calc_spectrum(
+#         wavenum_min=2000 / u.cm,
+#         wavenum_max=2300 / u.cm,
+#         molecule="CO",
+#         isotope="1,2",
+#         Tvib=1500,
+#         Trot=300,
+#         databank="hitemp",  # test by fetching directly
+#     )
+
+#     # Recompute with (now) locally downloaded database [note : this failed on 0.9.28]
+#     calc_spectrum(
+#         wavenum_min=2000 / u.cm,
+#         wavenum_max=2300 / u.cm,
+#         molecule="CO",
+#         isotope="1,2",
+#         Tvib=1500,
+#         Trot=300,
+#         databank="HITEMP-CO",  # registered in ~/radis.json
+#     )
 
 
 @pytest.mark.needs_connection
@@ -474,17 +468,28 @@ def test_parse_hitemp_missing_labels_issue280(*args, **kwargs):
 
 
 if __name__ == "__main__":
-    test_no_redownload()
+    # Removed due to issue 717 - https://github.com/radis/radis/issues/717
+    # from radis.api.hitempapi import (
+    #     HITEMP_MOLECULES,
+    #     HITEMPDatabaseManager,
+    #     )
+    # from radis.misc.config import getDatabankList
+    # test_partial_loading()
+    # test_partial_loading_vaex()
+
+    # test_fetch_hitemp_OH_pytables()
+    # test_fetch_hitemp_OH_vaex()
+
+    # test_fetch_hitemp_all_molecules("OH")
+    # test_fetch_hitemp_all_molecules("CO")
+    # test_fetch_hitemp_all_molecules("CO2", verbose=3)
+    # test_fetch_hitemp_all_molecules("N2O", verbose=3)
+    # test_fetch_hitemp_all_molecules("NO", verbose=3)
+
+    # test_fetch_hitemp_partial_download_CO2()
+
+    # test_no_redownload()
+    # test_calc_hitemp_CO_noneq()
+    # test_calc_hitemp_spectrum()
+
     test_relevant_files_filter()
-    test_fetch_hitemp_OH_pytables()
-    test_fetch_hitemp_OH_vaex()
-    test_partial_loading()
-    test_partial_loading_vaex()
-    test_calc_hitemp_CO_noneq()
-    test_fetch_hitemp_partial_download_CO2()
-    test_calc_hitemp_spectrum()
-    test_fetch_hitemp_all_molecules("OH")
-    test_fetch_hitemp_all_molecules("CO")
-    test_fetch_hitemp_all_molecules("CO2", verbose=3)
-    test_fetch_hitemp_all_molecules("N2O", verbose=3)
-    test_fetch_hitemp_all_molecules("NO", verbose=3)

--- a/radis/test/lbl/test_broadening.py
+++ b/radis/test/lbl/test_broadening.py
@@ -967,7 +967,7 @@ def test_broadening_chunksize_eq(verbose=True, plot=False, *args, **kwargs):
         wstep=0.001,
         verbose=True,
     )
-    sf.fetch_databank("hitemp")
+    sf.fetch_databank("hitran")
     # sf.params.broadening_method = "convolve"
     Tgas = 2000
 

--- a/radis/test/tools/test_database.py
+++ b/radis/test/tools/test_database.py
@@ -190,7 +190,7 @@ def test_lazy_loading(verbose=True, *args, **kwargs):
                 wavenum_max=4500,
                 molecule="CO",
                 Tgas=T,
-                databank="hitemp",  # test by fetching directly
+                databank="hitran",  # test by fetching directly
                 verbose=False,
             )
             .apply_slit(2, "nm")
@@ -204,7 +204,7 @@ def test_lazy_loading(verbose=True, *args, **kwargs):
                 wavenum_max=4500,
                 molecule="OH",
                 Tgas=T,
-                databank="hitemp",  # test by fetching directly
+                databank="hitran",  # test by fetching directly
                 verbose=False,
             )
             .apply_slit(2, "nm")


### PR DESCRIPTION
# Description
Thanks to recent development of the ExoMol database, self broadening is now more and more available. This PR add the `selbrd` column in df when fetching the database

# Comparison of spectra
### Before:
![image](https://github.com/user-attachments/assets/85843319-6e53-42fc-991b-2bee7158ea08)
`Ratio area absorbances:0.99`
### After:
![image](https://github.com/user-attachments/assets/3da221ab-df8e-4a82-aeae-2a52f9cf7f07)
`Ratio area absorbances:0.99`
### Code
```python
from radis import SpectrumFactory, plot_diff

sf = SpectrumFactory(
    2406,
    2408,  # cm-1
    molecule="CO2",
    isotope="1",
    wstep=0.001,
    verbose=5,
    mole_fraction=0.5,
    path_length=1,
    pressure=0.5,
)

T = 296  # K

sf.fetch_databank("exomol")
s_exo = sf.eq_spectrum(
    name="exomol",
    Tgas=T,
)
area_exomol = s_exo.get_integral('absorbance')

sf.fetch_databank("hitran")
s_hitran = sf.eq_spectrum(
    name="hitran",
    Tgas=T,
)
area_hitran = s_hitran.get_integral('absorbance')

plot_diff(s_hitran, s_exo, 'absorbance')
print(f"Ratio area absorbances:{area_exomol/area_hitran:.2f}")
```