### PR TITLE
Login HITRAN to retrieve HITEMP files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ $RECYCLE.BIN/
 radis/test/files/hitran/CO.hdf5
 radis/test/files/hitran_co2_626_bandhead_4165_4200nm.hdf5
 radis/test/files/hitran_co_3iso_2000_2300cm.hdf5
+
+# HITRAN credentials
+**/radis.env

--- a/examples/3_Fitting/plot3_fit_Trot-Tvib-molfrac.py
+++ b/examples/3_Fitting/plot3_fit_Trot-Tvib-molfrac.py
@@ -154,3 +154,6 @@ except OSError as err:
     print("HITEMP files must be downloaded manually. See error message.")
     print(err)
     s_experimental.plot()
+except EOFError:
+    print("Error: Unable to read input for HITRAN credentials. Please ensure you have the necessary credentials.")
+    s_experimental.plot()

--- a/examples/3_Fitting/plot3_fit_Trot-Tvib-molfrac.py
+++ b/examples/3_Fitting/plot3_fit_Trot-Tvib-molfrac.py
@@ -155,5 +155,7 @@ except OSError as err:
     print(err)
     s_experimental.plot()
 except EOFError:
-    print("Error: Unable to read input for HITRAN credentials. Please ensure you have the necessary credentials.")
+    print(
+        "Error: Unable to read input for HITRAN credentials. Please ensure you have the necessary credentials."
+    )
     s_experimental.plot()

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -192,6 +192,7 @@ def download_hitemp_file(session, file_url, output_filename, verbose=False):
         )
         print(f"{file_url} ==> {temp_folder} \n")
 
+
 class HITEMPDatabaseManager(DatabaseManager):
     def __init__(
         self,

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -10,14 +10,13 @@ https://stupidpythonideas.blogspot.com/2014/07/three-ways-to-read-files.html
 
 """
 
+import os
 import re
 import urllib.request
 from os.path import basename, commonpath, join
 from typing import Union
 
 import numpy as np
-
-import os
 import requests
 from bs4 import BeautifulSoup
 
@@ -118,29 +117,31 @@ def get_last(b):
 
 
 def login_to_hitran():
-    login_url = 'https://hitran.org/login/'
-    username = os.getenv('HITRAN_USERNAME') or input("Enter HITRAN username: ")
-    password = os.getenv('HITRAN_PASSWORD') or input("Enter HITRAN password: ")
-    
+    login_url = "https://hitran.org/login/"
+    username = os.getenv("HITRAN_USERNAME") or input("Enter HITRAN username: ")
+    password = os.getenv("HITRAN_PASSWORD") or input("Enter HITRAN password: ")
+
     session = requests.Session()
     response = session.get(login_url)
-    soup = BeautifulSoup(response.text, 'html.parser')
-    csrf = soup.find('input', {'name': 'csrfmiddlewaretoken'})['value']
-    
+    soup = BeautifulSoup(response.text, "html.parser")
+    csrf = soup.find("input", {"name": "csrfmiddlewaretoken"})["value"]
+
     login_data = {
-        'csrfmiddlewaretoken': csrf,
-        'email': username,
-        'password': password,
+        "csrfmiddlewaretoken": csrf,
+        "email": username,
+        "password": password,
     }
-    
+
     headers = {
-        'Referer': login_url,
-        'Origin': 'https://hitran.org',
-        'Cookie': f'csrftoken={csrf}'
+        "Referer": login_url,
+        "Origin": "https://hitran.org",
+        "Cookie": f"csrftoken={csrf}",
     }
-    
-    login_response = session.post(login_url, data=login_data, headers=headers, allow_redirects=False)
-    
+
+    login_response = session.post(
+        login_url, data=login_data, headers=headers, allow_redirects=False
+    )
+
     if login_response.status_code == 302:
         print("Login successful.")
         return session
@@ -149,19 +150,23 @@ def login_to_hitran():
         print("Response:", login_response.text[:500])
         return None
 
+
 def download_hitemp_file(session, file_url, output_filename):
     file_response = session.get(file_url, stream=True)
-    
+
     if file_response.status_code == 200:
-        total_size = int(file_response.headers.get('content-length', 0))
-        with open(output_filename, 'wb') as f:
+        total_size = int(file_response.headers.get("content-length", 0))
+        with open(output_filename, "wb") as f:
             downloaded = 0
             for chunk in file_response.iter_content(chunk_size=8192):
                 if chunk:
                     f.write(chunk)
                     downloaded += len(chunk)
                     done = int(50 * downloaded / total_size)
-                    print(f'\rProgress: [{"=" * done}{" " * (50-done)}] {downloaded}/{total_size} bytes', end='')
+                    print(
+                        f'\rProgress: [{"=" * done}{" " * (50-done)}] {downloaded}/{total_size} bytes',
+                        end="",
+                    )
         print("\nDownload complete!")
     else:
         print(f"Download failed: {file_response.status_code}")
@@ -408,8 +413,12 @@ class HITEMPDatabaseManager(DatabaseManager):
         if molecule == "CO2":
             session = login_to_hitran()
             if session:
-                download_hitemp_file(session, 'https://hitran.org/files/HITEMP/bzip2format/02_HITEMP2024.par.bz2', '02_HITEMP2024.par.bz2')
-                urlname = '02_HITEMP2024.par.bz2'
+                download_hitemp_file(
+                    session,
+                    "https://hitran.org/files/HITEMP/bzip2format/02_HITEMP2024.par.bz2",
+                    "02_HITEMP2024.par.bz2",
+                )
+                urlname = "02_HITEMP2024.par.bz2"
             else:
                 return 0  # Exit if login failed
 

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -182,6 +182,7 @@ def download_hitemp_file(session, file_url, output_filename, verbose=False):
             f"Failed to download {file_url}. Please download manually and place it in the appropriate directory."
         )
 
+
 class HITEMPDatabaseManager(DatabaseManager):
     def __init__(
         self,

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -188,7 +188,7 @@ def download_hitemp_file(session, file_url, output_filename, verbose=False):
             "files",
             "HITEMP",
             "HITEMP-2024",
-            f"{self.molecule}_line_list",
+            f"{molecule}_line_list",
         )
         print(f"{file_url} ==> {temp_folder} \n")
 

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -179,9 +179,18 @@ def download_hitemp_file(session, file_url, output_filename, verbose=False):
             print(f"Download failed: {file_response.status_code}")
             print("Response:", file_response.text[:500])
         raise Warning(
-            f"Failed to download {file_url}. Please download manually and place it in the appropriate directory."
+            f"Failed to download {file_url}. Please download manually and place it in the following location:"
         )
-
+        temp_folder = os.path.join(
+            os.path.dirname(output_filename),
+            "downloads__can_be_deleted",
+            "hitran.org",
+            "files",
+            "HITEMP",
+            "HITEMP-2024",
+            f"{self.molecule}_line_list",
+        )
+        print(f"{file_url} ==> {temp_folder} \n")
 
 class HITEMPDatabaseManager(DatabaseManager):
     def __init__(

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -55,17 +55,6 @@ from radis.misc.progress_bar import ProgressBar
 HITEMP_MOLECULES = ["H2O", "CO2", "N2O", "CO", "CH4", "NO", "NO2", "OH"]
 
 
-def running_in_spyder():
-    """Check if the console is running within Spyder."""
-    return "SPYDER_ARGS" in os.environ
-
-
-if running_in_spyder():
-    raise EnvironmentError(
-        "This script cannot be run within Spyder due to getpass4/maskpass limitations."
-    )
-
-
 def keep_only_relevant(
     inputfiles, wavenum_min=None, wavenum_max=None, verbose=True
 ) -> Union[list, float, float]:

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -188,7 +188,7 @@ def download_hitemp_file(session, file_url, output_filename, verbose=False):
             "files",
             "HITEMP",
             "HITEMP-2024",
-            f"{molecule}_line_list",
+            "CO2_line_list",
         )
         print(f"{file_url} ==> {temp_folder} \n")
 

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -10,13 +10,14 @@ https://stupidpythonideas.blogspot.com/2014/07/three-ways-to-read-files.html
 
 """
 
-import os
 import re
 import urllib.request
 from os.path import basename, commonpath, join
 from typing import Union
 
 import numpy as np
+
+import os
 import requests
 from bs4 import BeautifulSoup
 
@@ -117,31 +118,29 @@ def get_last(b):
 
 
 def login_to_hitran():
-    login_url = "https://hitran.org/login/"
-    username = os.getenv("HITRAN_USERNAME") or input("Enter HITRAN username: ")
-    password = os.getenv("HITRAN_PASSWORD") or input("Enter HITRAN password: ")
-
+    login_url = 'https://hitran.org/login/'
+    username = os.getenv('HITRAN_USERNAME') or input("Enter HITRAN username: ")
+    password = os.getenv('HITRAN_PASSWORD') or input("Enter HITRAN password: ")
+    
     session = requests.Session()
     response = session.get(login_url)
-    soup = BeautifulSoup(response.text, "html.parser")
-    csrf = soup.find("input", {"name": "csrfmiddlewaretoken"})["value"]
-
+    soup = BeautifulSoup(response.text, 'html.parser')
+    csrf = soup.find('input', {'name': 'csrfmiddlewaretoken'})['value']
+    
     login_data = {
-        "csrfmiddlewaretoken": csrf,
-        "email": username,
-        "password": password,
+        'csrfmiddlewaretoken': csrf,
+        'email': username,
+        'password': password,
     }
-
+    
     headers = {
-        "Referer": login_url,
-        "Origin": "https://hitran.org",
-        "Cookie": f"csrftoken={csrf}",
+        'Referer': login_url,
+        'Origin': 'https://hitran.org',
+        'Cookie': f'csrftoken={csrf}'
     }
-
-    login_response = session.post(
-        login_url, data=login_data, headers=headers, allow_redirects=False
-    )
-
+    
+    login_response = session.post(login_url, data=login_data, headers=headers, allow_redirects=False)
+    
     if login_response.status_code == 302:
         print("Login successful.")
         return session
@@ -150,23 +149,19 @@ def login_to_hitran():
         print("Response:", login_response.text[:500])
         return None
 
-
 def download_hitemp_file(session, file_url, output_filename):
     file_response = session.get(file_url, stream=True)
-
+    
     if file_response.status_code == 200:
-        total_size = int(file_response.headers.get("content-length", 0))
-        with open(output_filename, "wb") as f:
+        total_size = int(file_response.headers.get('content-length', 0))
+        with open(output_filename, 'wb') as f:
             downloaded = 0
             for chunk in file_response.iter_content(chunk_size=8192):
                 if chunk:
                     f.write(chunk)
                     downloaded += len(chunk)
                     done = int(50 * downloaded / total_size)
-                    print(
-                        f'\rProgress: [{"=" * done}{" " * (50-done)}] {downloaded}/{total_size} bytes',
-                        end="",
-                    )
+                    print(f'\rProgress: [{"=" * done}{" " * (50-done)}] {downloaded}/{total_size} bytes', end='')
         print("\nDownload complete!")
     else:
         print(f"Download failed: {file_response.status_code}")
@@ -413,12 +408,8 @@ class HITEMPDatabaseManager(DatabaseManager):
         if molecule == "CO2":
             session = login_to_hitran()
             if session:
-                download_hitemp_file(
-                    session,
-                    "https://hitran.org/files/HITEMP/bzip2format/02_HITEMP2024.par.bz2",
-                    "02_HITEMP2024.par.bz2",
-                )
-                urlname = "02_HITEMP2024.par.bz2"
+                download_hitemp_file(session, 'https://hitran.org/files/HITEMP/bzip2format/02_HITEMP2024.par.bz2', '02_HITEMP2024.par.bz2')
+                urlname = '02_HITEMP2024.par.bz2'
             else:
                 return 0  # Exit if login failed
 

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -134,11 +134,14 @@ def store_credentials(username, password):
 
     from radis.misc.utils import getProjectRoot
 
-    env_path = os.path.join(getProjectRoot(), "misc", "radis.env")
+    env_path = os.path.join(getProjectRoot(), "db", "radis.env")
 
     # Create misc directory if it doesn't exist
     os.makedirs(os.path.dirname(env_path), exist_ok=True)
 
+    print(
+        "Your HITRAN credentials will be saved in {env_path}. You can delete this file if you wish but you will have to prompt your password at next download."
+    )
     with open(env_path, "w") as f:
         f.write(f"HITRAN_USERNAME={username}\n")
         f.write(f"HITRAN_PASSWORD={password}\n")

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -5,10 +5,16 @@ Created on Sun May 22 17:35:05 2022
 @author: erwan
 """
 
+import os
 from os.path import abspath, exists, expanduser, join
 
 from radis.api.hdf5 import update_pytables_to_vaex
 from radis.api.hitempapi import HITEMPDatabaseManager
+
+
+def running_in_spyder():
+    """Check if the console is running within Spyder."""
+    return "SPYDER_ARGS" in os.environ
 
 
 def fetch_hitemp(
@@ -176,6 +182,12 @@ def fetch_hitemp(
 
     # Download files
     if len(download_files) > 0:
+
+        if running_in_spyder():
+            raise EnvironmentError(
+                "This script cannot be run within Spyder because the modules getpass4/maskpass are required to input the HITRAN credentials - see also comment of Carlos Cordoba here: https://stackoverflow.com/questions/45814910/data-hiding-for-python-qtconsole \n\nPotential solution: If you attempted to download a database, you can run your code once in a console or an alternative to Spyder. Once the database is downloaded, you should be able to run in Spyder again."
+            )
+
         if urlnames is None:
             urlnames = ldb.fetch_urlnames()
         filesmap = dict(zip(local_files, urlnames))

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,8 @@ json-tricks>=3.15.0  # to deal with non jsonable formats
 mpldatacursor
 nvidia-cufft-cu11; sys_platform != "darwin"
 periodictable
+requests
+beautifulsoup4
 # tuna            # to generate visual/interactive performance profiles
 vaex-core ; python_version < '3.11'
 vaex-hdf5 ; python_version < '3.11'

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ requests        # for making HTTP requests to HITRAN database
 beautifulsoup4  # for parsing HTML responses from HITRAN website
 getpass4       # for handling password input securely
 tqdm          # for progress bars
+python-dotenv  # for managing environment variables
 # tuna            # to generate visual/interactive performance profiles
 vaex-core ; python_version < '3.11'
 vaex-hdf5 ; python_version < '3.11'

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,10 @@ json-tricks>=3.15.0  # to deal with non jsonable formats
 mpldatacursor
 nvidia-cufft-cu11; sys_platform != "darwin"
 periodictable
-requests
-beautifulsoup4
+requests        # for making HTTP requests to HITRAN database
+beautifulsoup4  # for parsing HTML responses from HITRAN website
+getpass4       # for handling password input securely
+tqdm          # for progress bars
 # tuna            # to generate visual/interactive performance profiles
 vaex-core ; python_version < '3.11'
 vaex-hdf5 ; python_version < '3.11'


### PR DESCRIPTION

<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address [Issue #717 ](https://github.com/radis/radis/issues/717)


**Changes:**

1. Added New Authentication Function:
-`login_to_hitran()`: Handles user authentication to HITRAN's website
-Takes username/password from environment variables or prompts user

2. Added Download Function:
-`download_hitemp_file` : Downloads CO2 files 
-Downloads file in chunks with progress bar

Tested on [GPU Accelerated Spectra](https://radis.readthedocs.io/en/latest/auto_examples/4_GPU/plot_gpu.html#sphx-glr-auto-examples-4-gpu-plot-gpu-py)(CO2)
used `source = 'hitemp'`

<img src="https://github.com/user-attachments/assets/67631471-8c3c-4264-95b2-c2de82bc5926" alt="before" width="600">

@minouHub 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #717
