### PR TITLE
docs:  Added HDF5 save/load gallery example for 'to_hdf5' serialization function and improve to_hdf5 documentation

### DIFF
--- a/examples/1_Spectra_handling/plot_hdf5_handling.py
+++ b/examples/1_Spectra_handling/plot_hdf5_handling.py
@@ -16,8 +16,6 @@ It shows:
 
 from radis.test.utils import getTestFile
 from radis.tools.database import load_spec
-from radis.spectrum.compare import plot_diff
-import matplotlib.pyplot as plt
 
 # Load an example spectrum
 my_file = getTestFile("synth-NH3-1-500-2000cm-P10-mf0.01-p1.spec")
@@ -31,20 +29,15 @@ s1.to_hdf5("spectrum_data.h5")
 
 #%% Load and plot retrieved spectrum
 s2 = s1.from_hdf5("spectrum_data.h5")
-s2.plot('radiance', nfig="same", label='Retrieved')
+s2.plot("radiance", nfig="same", label="Retrieved")
 
 #%% Load and plot partial spectrum (specific wavenumber range) from retrieved spectrum
-s_partial = s1.from_hdf5("spectrum_data.h5", 
-                       wmin=1020,  
-                       wmax=1040   
-                       )
-s_partial.plot('radiance', nfig="same",label='Partial (1020-1040 cm-1)')
+s_partial = s1.from_hdf5("spectrum_data.h5", wmin=1020, wmax=1040)
+s_partial.plot("radiance", nfig="same", label="Partial (1020-1040 cm-1)")
 
 #%% Load specific quantities and compare
-s_specific = s1.from_hdf5("spectrum_data.h5",
-                        columns=['radiance']
-                        )
-s_specific.plot('radiance', nfig="same", label='Specific (radiance)')
+s_specific = s1.from_hdf5("spectrum_data.h5", columns=["radiance"])
+s_specific.plot("radiance", nfig="same", label="Specific (radiance)")
 
 # Print metadata to verify it's preserved
 print("\nOriginal Spectrum conditions:")

--- a/examples/1_Spectra_handling/plot_hdf5_handling.py
+++ b/examples/1_Spectra_handling/plot_hdf5_handling.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""
+======================
+HDF5 Spectrum Handling
+======================
+
+This example demonstrates how to save and load spectrum data using HDF5 format.
+
+It shows:
+- Saving a spectrum to HDF5
+- Loading complete spectrum
+- Loading partial spectrum (specific wavenumber range)
+- Loading specific quantities
+- Comparing original vs loaded spectra
+"""
+
+from radis.test.utils import getTestFile
+from radis.tools.database import load_spec
+from radis.spectrum.compare import plot_diff
+import matplotlib.pyplot as plt
+
+# Load an example spectrum
+my_file = getTestFile("synth-NH3-1-500-2000cm-P10-mf0.01-p1.spec")
+s1 = load_spec(my_file)
+
+# Plot original spectrum
+s1.plot(nfig="same", label="Original")
+
+# Save to HDF5 format
+s1.to_hdf5("spectrum_data.h5")
+
+#%% Load and plot retrieved spectrum
+s2 = s1.from_hdf5("spectrum_data.h5")
+s2.plot('radiance', nfig="same", label='Retrieved')
+
+#%% Load and plot partial spectrum (specific wavenumber range) from retrieved spectrum
+s_partial = s1.from_hdf5("spectrum_data.h5", 
+                       wmin=1020,  
+                       wmax=1040   
+                       )
+s_partial.plot('radiance', nfig="same",label='Partial (1020-1040 cm-1)')
+
+#%% Load specific quantities and compare
+s_specific = s1.from_hdf5("spectrum_data.h5",
+                        columns=['radiance']
+                        )
+s_specific.plot('radiance', nfig="same", label='Specific (radiance)')
+
+# Print metadata to verify it's preserved
+print("\nOriginal Spectrum conditions:")
+print(s1.conditions)
+
+print("\nLoaded HDF5 Spectrum conditions:")
+print(s2.conditions)
+
+# Print available quantities in original and retrieved spectrum
+print("\nAvailable quantities in original spectrum:")
+print(s1.get_vars())
+
+print("\nAvailable quantities in retrieved spectrum:")
+print(s2.get_vars())

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -888,6 +888,8 @@ class Spectrum(object):
 
             Spectrum.from_hdf5("rad_hdf.h5", wmin=2100, wmax=2200, columns=['abscoeff', 'emisscoeff'])
 
+        .. minigallery:: radis.Spectrum.from_hdf5
+
         See Also
         --------
         :py:func:`~radis.spectrum.spectrum.Spectrum.to_hdf5`
@@ -3986,17 +3988,50 @@ class Spectrum(object):
         return self.store(compress=False, *args, **kwargs)
 
     def to_hdf5(self, file, engine="pytables"):
-        r"""Stores the Spectrum under HDF5 format. Uses :py:func:`~radis.io.spec_hdf.spec2hdf`
+        r"""Convert a ``radis`` :py:class:`~radis.spectrum.spectrum.Spectrum` object
+        to HDF5 format. Uses :py:func:`~radis.io.spec_hdf.spec2hdf`
+
+        Parameters
+        ----------
+        file: str
+            path to save the HDF5 file
+        engine: {'pytables'}, optional
+            HDF5 library to use for writing the file. Default is 'pytables'.
+
+        Returns
+        -------
+        None
+            The spectrum is saved to disk in HDF5 format
+
+        Notes
+        -----
+        The HDF5 file will contain:
+        - All spectral arrays in a 'arrays' group with their units as metadata
+        - Lines database in a 'lines' group if present
+        - Populations in metadata if present
+        - Conditions and references in metadata
+        - Slit function data if present
+
+        Use :py:meth:`~radis.spectrum.spectrum.Spectrum.from_hdf5` to load the spectrum back.
 
         Examples
         --------
         ::
 
-            s.to_hdf5('spec01.h5')
+            s.to_hdf5('spectrum.h5')
+
+        Load back with::
+
+            from radis import Spectrum
+            s2 = Spectrum.from_hdf5('spectrum.h5')
+
+        .. minigallery:: radis.Spectrum.to_hdf5
 
         See Also
         --------
-        :py:func:`~radis.spectrum.spectrum.Spectrum.from_hdf5`
+        :py:meth:`~radis.spectrum.spectrum.Spectrum.from_hdf5`
+        :py:func:`~radis.io.spec_hdf.spec2hdf`
+        :py:meth:`~radis.spectrum.spectrum.Spectrum.store`
         """
         from radis.io.spec_hdf import spec2hdf
 


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address Issue #708 

### Changes:
1. Added new example `examples/1_Spectra_handling/plot_hdf5_handling.py` that demonstrates:
   - Saving a spectrum to HDF5 using `to_hdf5()`
   - Loading complete spectrum using `from_hdf5()`
   - Loading partial spectrum by wavenumber range (1020-1040 cm-1) 
   - Loading specific quantities (radiance only)
   - Preserving and verifying metadata (conditions, units)
   - Comparing original vs loaded spectra on same plot

2. Added docstring for `to_hdf5()` method including:
   - Complete parameter descriptions

I'm not sure why am i getting this error even after the hdf5 data is retrieved
`Error reading metadata from spectrum_data.h5`

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #708 
@erwanp 
