### PR TITLE
update deprecated plotly attributes with new syntax

### DIFF
--- a/radis/tools/line_survey.py
+++ b/radis/tools/line_survey.py
@@ -659,11 +659,10 @@ def LineSurvey(
             range=(x_range.min(), x_range.max()),
         ),
         yaxis=dict(
-            title=ylabel,
+            title={"text": ylabel, "font": {"color": "#1f77b4"}},
             # note: LaTeX doesnt seem to work in Offline mode yet.
             type=yscale,
             range=plot_range,
-            titlefont=dict(color="#1f77b4"),
             tickfont=dict(color="#1f77b4"),
         ),
         showlegend=False,
@@ -689,14 +688,15 @@ def LineSurvey(
         )
 
         layout["yaxis2"] = dict(
-            title="{0} ({1})".format(
-                over_name.capitalize(), over_units
-            ),  # note: LaTeX doesnt seem to
+            title={
+                "text": "{0} ({1})".format(over_name.capitalize(), over_units),
+                "font": {"color": "#ff7f0e"},
+            },
+            # note: LaTeX doesnt seem to
             # work in Offline mode yet.
             overlaying="y",
             type="log",
             side="right",
-            titlefont=dict(color="#ff7f0e"),
             tickfont=dict(color="#ff7f0e"),
         )
 

--- a/radis/tools/line_survey.py
+++ b/radis/tools/line_survey.py
@@ -659,7 +659,10 @@ def LineSurvey(
             range=(x_range.min(), x_range.max()),
         ),
         yaxis=dict(
-            title={"text": ylabel, "font": {"color": "#1f77b4"}},
+            title={
+                "text": ylabel, 
+                "font": {"color": "#1f77b4"}
+            },
             # note: LaTeX doesnt seem to work in Offline mode yet.
             type=yscale,
             range=plot_range,

--- a/radis/tools/line_survey.py
+++ b/radis/tools/line_survey.py
@@ -659,10 +659,7 @@ def LineSurvey(
             range=(x_range.min(), x_range.max()),
         ),
         yaxis=dict(
-            title={
-                "text": ylabel, 
-                "font": {"color": "#1f77b4"}
-            },
+            title={"text": ylabel, "font": {"color": "#1f77b4"}},
             # note: LaTeX doesnt seem to work in Offline mode yet.
             type=yscale,
             range=plot_range,


### PR DESCRIPTION
updated `titlefont ` to `title.font`
i only found titlefont attribute in radis which is causing the tests to fail

<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #732 