### PR TITLE
Add encryption for hitran credentials

### DIFF
--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -10,6 +10,7 @@ https://stupidpythonideas.blogspot.com/2014/07/three-ways-to-read-files.html
 
 """
 
+import json
 import os
 import re
 import urllib.request
@@ -20,9 +21,10 @@ import numpy as np
 import requests
 from bs4 import BeautifulSoup
 from cryptography.fernet import Fernet
-from dotenv import load_dotenv
 from getpass4 import getpass
 from tqdm import tqdm
+
+from radis.misc.config import CONFIG_PATH_JSON
 
 try:
     from .dbmanager import DatabaseManager
@@ -130,22 +132,34 @@ def setup_credentials():
 
 def get_encryption_key():
     """Get or create encryption key for HITRAN credentials"""
-    from radis.misc.utils import getProjectRoot
+    # Read existing radis.json
+    if os.path.exists(CONFIG_PATH_JSON):
+        with open(CONFIG_PATH_JSON, "r") as f:
+            config = json.load(f)
+    else:
+        config = {}
 
-    key_path = os.path.join(getProjectRoot(), "db", ".radis.key")
-    if os.path.exists(key_path):
-        with open(key_path, "rb") as f:
-            return f.read()
+    # Check if encryption key exists
+    if "credentials" in config and "ENCRYPTION_KEY" in config["credentials"]:
+        return config["credentials"]["ENCRYPTION_KEY"].encode()
     else:
         # Generate a new key
         key = Fernet.generate_key()
-        # Ensure directory exists
-        os.makedirs(os.path.dirname(key_path), exist_ok=True)
-        # Save the key
-        with open(key_path, "wb") as f:
-            f.write(key)
-        # Set restrictive permissions on key file
-        os.chmod(key_path, 0o600)
+
+        # Add credentials section if it doesn't exist
+        if "credentials" not in config:
+            config["credentials"] = {}
+
+        # Store the key
+        config["credentials"]["ENCRYPTION_KEY"] = key.decode()
+
+        # Write back to radis.json
+        with open(CONFIG_PATH_JSON, "w") as f:
+            json.dump(config, f, indent=4)
+
+        # Set restrictive permissions
+        os.chmod(CONFIG_PATH_JSON, 0o600)
+
         return key
 
 
@@ -164,31 +178,40 @@ def decrypt_password(encrypted_password):
 
 
 def store_credentials(username, password):
-    """Store HITRAN credentials in radis.env file in db folder with encrypted username and password"""
-    from radis.misc.utils import getProjectRoot
-
-    env_path = os.path.join(getProjectRoot(), "db", "radis.env")
-
-    # Create db directory if it doesn't exist
-    os.makedirs(os.path.dirname(env_path), exist_ok=True)
-
+    """Store HITRAN credentials in radis.json file with encrypted username and password"""
     # Encrypt both username and password before storing
     encrypted_username = encrypt_password(username)  # reuse same encryption function
     encrypted_password = encrypt_password(password)
 
-    print(
-        f"Your HITRAN credentials will be saved securely in {env_path}. You can delete this file if you wish but you will have to prompt your credentials at next download."
-    )
-    with open(env_path, "w") as f:
-        f.write(f"HITRAN_USERNAME={encrypted_username}\n")
-        f.write(f"HITRAN_PASSWORD={encrypted_password}\n")
+    # Read existing radis.json
+    if os.path.exists(CONFIG_PATH_JSON):
+        with open(CONFIG_PATH_JSON, "r") as f:
+            config = json.load(f)
+    else:
+        config = {}
 
-    # Set restrictive permissions on env file
-    os.chmod(env_path, 0o600)
+    # Add credentials section if it doesn't exist
+    if "credentials" not in config:
+        config["credentials"] = {}
+
+    # Store encrypted credentials
+    config["credentials"]["HITRAN_USERNAME"] = encrypted_username
+    config["credentials"]["HITRAN_PASSWORD"] = encrypted_password
+
+    print(
+        f"Your HITRAN credentials will be saved securely in {CONFIG_PATH_JSON}. You can delete the credentials section if you wish but you will have to prompt your credentials at next download."
+    )
+
+    # Write back to radis.json
+    with open(CONFIG_PATH_JSON, "w") as f:
+        json.dump(config, f, indent=4)
+
+    # Set restrictive permissions
+    os.chmod(CONFIG_PATH_JSON, 0o600)
 
 
 def login_to_hitran(verbose=False):
-    """Login to HITRAN using stored credentials or prompt if not available"""
+    """Login to HITRAN using stored credentials from radis.json or prompt if not available"""
     login_url = "https://hitran.org/login/"
     session = requests.Session()
 
@@ -221,36 +244,38 @@ def login_to_hitran(verbose=False):
         """Check if login was successful by looking for specific elements"""
         return response.status_code == 302 or "Logout" in response.text
 
-    # Check if radis.env exists in db folder
-    from radis.misc.utils import getProjectRoot
+    # Check if credentials exist in radis.json
+    if os.path.exists(CONFIG_PATH_JSON):
+        with open(CONFIG_PATH_JSON, "r") as f:
+            config = json.load(f)
 
-    env_path = os.path.join(getProjectRoot(), "db", "radis.env")
+        if "credentials" in config:
+            encrypted_username = config["credentials"].get("HITRAN_USERNAME")
+            encrypted_password = config["credentials"].get("HITRAN_PASSWORD")
 
-    if os.path.exists(env_path):
-        load_dotenv(env_path)
-        encrypted_username = os.getenv("HITRAN_USERNAME")
-        encrypted_password = os.getenv("HITRAN_PASSWORD")
+            if encrypted_username and encrypted_password:
+                try:
+                    # Decrypt both username and password
+                    username = decrypt_password(encrypted_username)
+                    password = decrypt_password(encrypted_password)
 
-        if encrypted_username and encrypted_password:
-            try:
-                # Decrypt both username and password
-                username = decrypt_password(encrypted_username)
-                password = decrypt_password(encrypted_password)
-                login_response, session = attempt_login(username, password)
-                if is_login_successful(login_response):
+                    login_response, session = attempt_login(username, password)
+                    if is_login_successful(login_response):
+                        if verbose:
+                            print("Login successful.")
+                        return session
+                except Exception as e:
                     if verbose:
-                        print("Login successful.")
-                    return session
-            except Exception as e:
-                if verbose:
-                    print(f"Error decrypting credentials: {str(e)}")
-                # Delete invalid credentials from radis.env
-                if os.path.exists(env_path):
-                    os.remove(env_path)
-                print(
-                    "Invalid stored credentials. Please enter your HITRAN credentials again."
-                )
-                # Continue to new user flow
+                        print(f"Error decrypting credentials: {str(e)}")
+                    # Remove invalid credentials from radis.json
+                    if "credentials" in config:
+                        del config["credentials"]
+                        with open(CONFIG_PATH_JSON, "w") as f:
+                            json.dump(config, f, indent=4)
+                    print(
+                        "Invalid stored credentials. Please enter your HITRAN credentials again."
+                    )
+                    # Continue to new user flow
 
     # First time use or no stored credentials
     username, password = setup_credentials()

--- a/setup.py
+++ b/setup.py
@@ -254,9 +254,11 @@ def run_setup():
             ### From environment.yml
             "astropy>=4.3.1",  # Unit aware calculations
             "astroquery>=0.4.6",  # to fetch HITRAN databases
-            "beautifulsoup4>=4.10.0",  # parse ExoMol website
+            "beautifulsoup4>=4.10.0",  # parse ExoMol website and HITRAN responses
             "cantera>=2.5.1",  # for chemical equilibrium computations
             "configparser",
+            "cryptography",  # for encryption and security features
+            "getpass4",  # for handling password input securely
             "habanero>=1.2.0",  # CrossRef API to retrieve data from doi
             "h5py>=3.2.1",  # load HDF5
             "joblib",  # for parallel loading of SpecDatabase
@@ -267,10 +269,13 @@ def run_setup():
             "pandas",
             "plotly>=2.5.1",  # for line survey HTML output
             "psutil",  # to get user RAM
+            "python-dotenv",  # for managing environment variables
+            "requests",  # for making HTTP requests to HITRAN database
             "tables",  # for pandas to HDF5 export - WARNING named "pytables" in conda
             "scipy>=1.4.0",
             "seaborn",  # other matplotlib themes
             "termcolor",  # terminal colors
+            "tqdm",  # for progress bars
             "specutils",
             ### From requirements.txt
             "lxml",  # parser used for ExoMol website


### PR DESCRIPTION
Both the username and password are now:
- Encrypted before storage
- Stored in encrypted form in the radis.env file
- Only decrypted when needed for login
- Protected by the same Fernet symmetric encryption key
- Both credentials and key are stored with restrictive file permissions (0o600) which can only be accessed by the owner

<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address #735 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #735 
@minouHub 
