### PR TITLE
Ensure HITRAN Login is Compatible with Spyder with `PyQt` Support

### DIFF
--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -155,7 +155,7 @@ def _prompt_password(user):
             if ok and text:
                 return text
             raise ValueError(
-                "The dialog window was probably closed and the password could not be retrieved left empty. A valid password is required."
+                "The dialog window was probably closed or left empty. Please enter a valid password."
             )
         except ModuleNotFoundError:
             raise ImportError(

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -121,8 +121,15 @@ def get_last(b):
     return b[non_zero]
 
 
+def running_in_spyder():
+    """Check if the console is running within Spyder."""
+    return "SPYDER_ARGS" in os.environ
+
+
 def _prompt_password(user):
     """
+    Prompts the user for a password securely and handels input if spyder is used.
+    
     Parameters
     ----------
     user : str
@@ -133,24 +140,26 @@ def _prompt_password(user):
     text : str
         User input password.
     """
-    try:
-        from PyQt5.QtCore import QCoreApplication
-        from PyQt5.QtWidgets import QApplication, QInputDialog, QLineEdit
+    if running_in_spyder():
+        try:
+            from PyQt5.QtCore import QCoreApplication
+            from PyQt5.QtWidgets import QApplication, QInputDialog, QLineEdit
 
-        app = QCoreApplication.instance()
-        if app is None:
-            app = QApplication([])
+            app = QCoreApplication.instance()
+            if app is None:
+                app = QApplication([])
 
-        text, ok = QInputDialog.getText(
-            None, "Credential", f"User {user}:", QLineEdit.Password
-        )
-        if ok and text:
-            return text
-        raise ValueError("Must specify a valid password")
-    except ModuleNotFoundError:
-        # If PyQt5 is not available, use getpass
+            text, ok = QInputDialog.getText(
+                None, "Credential", f"User {user}:", QLineEdit.Password
+            )
+            if ok and text:
+                return text
+            raise ValueError("Password entry was canceled by the user or left empty. A valid password is required.")
+        except ModuleNotFoundError:
+            raise ImportError("You are using Spyder; please install PyQt5 to use the password prompt.")
+    else:
+        # If not using spyder use getpass
         from getpass4 import getpass
-
         return getpass(f"Enter password for {user}: ")
 
 

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -21,7 +21,6 @@ import numpy as np
 import requests
 from bs4 import BeautifulSoup
 from cryptography.fernet import Fernet
-from getpass4 import getpass
 from tqdm import tqdm
 
 from radis.misc.config import CONFIG_PATH_JSON
@@ -122,11 +121,43 @@ def get_last(b):
     return b[non_zero]
 
 
+def _prompt_password(user):
+    """
+    Parameters
+    ----------
+    user : str
+        Username.
+
+    Returns
+    -------
+    text : str
+        User input password.
+    """
+    try:
+        from PyQt5.QtCore import QCoreApplication
+        from PyQt5.QtWidgets import QApplication, QInputDialog, QLineEdit
+
+        app = QCoreApplication.instance()
+        if app is None:
+            app = QApplication([])
+
+        text, ok = QInputDialog.getText(
+            None, "Credential", f"User {user}:", QLineEdit.Password
+        )
+        if ok and text:
+            return text
+        raise ValueError("Must specify a valid password")
+    except ModuleNotFoundError:
+        # If PyQt5 is not available, use getpass
+        from getpass import getpass
+
+        return getpass(f"Enter password for {user}: ")
+
+
 def setup_credentials():
-    """Set up HITRAN credentials and store them in .env file"""
-    # Get credentials from user
+    """Set up HITRAN credentials and store them in .env file."""
     username = input("Enter HITRAN username: ")
-    password = getpass("Enter HITRAN password: ")
+    password = _prompt_password(username)
     return username, password
 
 

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -129,7 +129,7 @@ def running_in_spyder():
 def _prompt_password(user):
     """
     Prompts the user for a password securely and handels input if spyder is used.
-    
+
     Parameters
     ----------
     user : str
@@ -154,12 +154,17 @@ def _prompt_password(user):
             )
             if ok and text:
                 return text
-            raise ValueError("Password entry was canceled by the user or left empty. A valid password is required.")
+            raise ValueError(
+                "Password entry was canceled by the user or left empty. A valid password is required."
+            )
         except ModuleNotFoundError:
-            raise ImportError("You are using Spyder; please install PyQt5 to use the password prompt.")
+            raise ImportError(
+                "You are using Spyder; please install PyQt5 with `pip install PyQt5` to use the password prompt."
+            )
     else:
         # If not using spyder use getpass
         from getpass4 import getpass
+
         return getpass(f"Enter password for {user}: ")
 
 

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -149,7 +149,7 @@ def _prompt_password(user):
         raise ValueError("Must specify a valid password")
     except ModuleNotFoundError:
         # If PyQt5 is not available, use getpass
-        from getpass import getpass
+        from getpass4 import getpass
 
         return getpass(f"Enter password for {user}: ")
 

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -155,7 +155,7 @@ def _prompt_password(user):
             if ok and text:
                 return text
             raise ValueError(
-                "Password entry was canceled by the user or left empty. A valid password is required."
+                "The dialog window was probably closed and the password could not be retrieved left empty. A valid password is required."
             )
         except ModuleNotFoundError:
             raise ImportError(

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -5,13 +5,10 @@ Created on Sun May 22 17:35:05 2022
 @author: erwan
 """
 
-import os
 from os.path import abspath, exists, expanduser, join
 
 from radis.api.hdf5 import update_pytables_to_vaex
 from radis.api.hitempapi import HITEMPDatabaseManager
-
-
 
 
 def fetch_hitemp(

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -12,9 +12,6 @@ from radis.api.hdf5 import update_pytables_to_vaex
 from radis.api.hitempapi import HITEMPDatabaseManager
 
 
-def running_in_spyder():
-    """Check if the console is running within Spyder."""
-    return "SPYDER_ARGS" in os.environ
 
 
 def fetch_hitemp(
@@ -182,11 +179,6 @@ def fetch_hitemp(
 
     # Download files
     if len(download_files) > 0:
-
-        if running_in_spyder():
-            raise EnvironmentError(
-                "This script cannot be run within Spyder because the modules getpass4/maskpass are required to input the HITRAN credentials - see also comment of Carlos Cordoba here: https://stackoverflow.com/questions/45814910/data-hiding-for-python-qtconsole \n\nPotential solution: If you attempted to download a database, you can run your code once in a console or an alternative to Spyder. Once the database is downloaded, you should be able to run in Spyder again."
-            )
 
         if urlnames is None:
             urlnames = ldb.fetch_urlnames()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ lxml           # parser used for ExoMol website
 hjson          # Json with comments (for default_radis.json)
 publib 		   # Plotting styles for Matplotlib. Version, update to 0.4.0 needed for matplotlib==3.8. However, only 0.3.2 is compatible with python==3.8 (see #647)
 hitran-api     # HAPI, used to access TIPS partition functions
+PyQt5
 peakutils
 ruamel.yaml
 json-tricks>=3.15.0  # to deal with non jsonable formats

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ lxml           # parser used for ExoMol website
 hjson          # Json with comments (for default_radis.json)
 publib 		   # Plotting styles for Matplotlib. Version, update to 0.4.0 needed for matplotlib==3.8. However, only 0.3.2 is compatible with python==3.8 (see #647)
 hitran-api     # HAPI, used to access TIPS partition functions
-PyQt5
 peakutils
 ruamel.yaml
 json-tricks>=3.15.0  # to deal with non jsonable formats


### PR DESCRIPTION
<!-- Please be sure to check out our contributing guidelines,
https://github.com/radis/radis/blob/develop/CONTRIBUTING.md . -->

### Description

Fixes: #736 : Password typing compatible with Spyder
As we are moving `requirements.txt` to `.toml` file for dep, we can put `PyQt5` in optional dep if it is unnecessary for core.