### PR TITLE
Improve Plotly and Matplotlib Plotting: Utilize kwargs for Customization

### DIFF
--- a/examples/6_Misc/plot_styles.py
+++ b/examples/6_Misc/plot_styles.py
@@ -48,3 +48,20 @@ for plotlib, context, style in [
     s.plot()
     plt.title(", ".join(f"{v}" for v in radis.config["plot"].values()))
     plt.tight_layout()
+
+#%%
+# You can also choose to not show the figure immediately, and instead return
+# the Matplotlib or Plotly object. This allows for **advanced customization**
+# (e.g., modifying the matplotlib figure).
+
+fig, ax = s.plot("radiance", plotting_library="matplotlib", show=False)
+
+ax.set_xlabel("Updated X-axis Label")
+ax.set_ylabel("Updated Y-axis Label")
+ax.grid(True, linestyle=":", linewidth=1)
+ax.set_facecolor("beige")
+
+fig.gcf().set_size_inches(8.6, 5)  # Resize
+fig.gcf().set_dpi(150)  # Change DPI
+# Then Show
+fig.show()

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -2238,7 +2238,7 @@ class Spectrum(object):
                 still experimental ! Try it, feedback welcome !
         **kwargs: **dict
             kwargs forwarded as argument to plot (e.g: lineshape
-            attributes: `lw=3, color='r', width=800, height=600`)
+            attributes: `lw=3, color='r'`)
 
         Returns
         -------
@@ -2275,14 +2275,9 @@ class Spectrum(object):
 
         set_style()
 
-        # set figure size (width, height)
-        dpi = 100  # dots per inch
-        width = kwargs.pop("width", 800)
-        height = kwargs.pop("height", 600)
-
         if nfig == "same":
             nfig = plt.gcf().number
-        fig = plt.figure(nfig, figsize=(width / dpi, height / dpi))
+        fig = plt.figure(nfig)
 
         # If figure exist, ensures xlabel and ylabel are the same (prevents some
         # users errors if plotting difference units!)... Note that since
@@ -2385,8 +2380,8 @@ class Spectrum(object):
 
         if show:
             plt.show()
-
-        return line
+        else:
+            return plt
 
     def _plot_plotly(
         self,
@@ -2468,7 +2463,7 @@ class Spectrum(object):
             The Plotly template to use for the plot. Default is 'plotly_dark'.
         **kwargs: **dict
             kwargs forwarded as argument to plot (e.g: lineshape
-            attributes: `lw=3, color='r', width=800, height=600`)
+            attributes: `lw=3, color='r'`)
 
         Returns
         -------
@@ -2495,19 +2490,18 @@ class Spectrum(object):
             kwargs["line_width"] = kwargs.pop("lw")
         if "color" in kwargs:
             kwargs["line_color"] = kwargs.pop("color")
-        width = kwargs.pop("width", None)
-        height = kwargs.pop("height", None)
 
-        fig = px.line(df, x="Wavenumber", y="Radiance_noslit", template=template)
+        fig = px.line(df, x=x, y=y, template=template)
         fig.update_traces(**kwargs)
         fig.update_layout(
             xaxis_title=xlabel,
             yaxis_title=ylabel,
             yaxis=dict(tickmode="linear", dtick=0.01),
-            width=width,
-            height=height,
         )
-        fig.show()
+        if show is True:
+            fig.show()
+        else:
+            return fig
 
     def plot(
         self,
@@ -2577,8 +2571,9 @@ class Spectrum(object):
             plotting on an existing figure is forbidden if labels are not the
             same. Use ``force=True`` to ignore that.
         show: bool
-            show figure. Default ``False``. Will still show the figure in
+            show figure. Default ``True``. Will still show the figure in
             interactive mode, e.g, `%matplotlib inline` in a Notebook.
+            If ``show=False``, the function returns the Matplotlib or Plotly object for customization.
         show_ruler: bool
             if `True`, add a ruler tool to the Matplotlib toolbar. Convenient
             to measure distances between peaks, etc.
@@ -2596,8 +2591,8 @@ class Spectrum(object):
                 - "matplotlib": Forces the use of Matplotlib for static plots.
         **kwargs: **dict
             kwargs forwarded as argument to plot (e.g: lineshape
-            attributes: `lw=3, color='r', width=800, height=600`)
-
+            attributes: `lw=3, color='r'`)
+            Note: for more customizations set ``show=False`` to return the Matplotlib or Plotly object.
         Returns
         -------
         line:

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -2381,7 +2381,7 @@ class Spectrum(object):
         if show:
             plt.show()
         else:
-            return plt
+            return plt, ax
 
     def _plot_plotly(
         self,

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -2238,7 +2238,7 @@ class Spectrum(object):
                 still experimental ! Try it, feedback welcome !
         **kwargs: **dict
             kwargs forwarded as argument to plot (e.g: lineshape
-            attributes: `lw=3, color='r'`)
+            attributes: `lw=3, color='r', width=800, height=600`)
 
         Returns
         -------
@@ -2275,9 +2275,14 @@ class Spectrum(object):
 
         set_style()
 
+        # set figure size (width, height)
+        dpi = 100  # dots per inch
+        width = kwargs.pop("width", 800)
+        height = kwargs.pop("height", 600)
+
         if nfig == "same":
             nfig = plt.gcf().number
-        fig = plt.figure(nfig)
+        fig = plt.figure(nfig, figsize=(width / dpi, height / dpi))
 
         # If figure exist, ensures xlabel and ylabel are the same (prevents some
         # users errors if plotting difference units!)... Note that since
@@ -2463,7 +2468,7 @@ class Spectrum(object):
             The Plotly template to use for the plot. Default is 'plotly_dark'.
         **kwargs: **dict
             kwargs forwarded as argument to plot (e.g: lineshape
-            attributes: `lw=3, color='r'`)
+            attributes: `lw=3, color='r', width=800, height=600`)
 
         Returns
         -------
@@ -2480,11 +2485,27 @@ class Spectrum(object):
         xlabel = format_xlabel(wunit, show_medium)
         ylabel = "{0} ({1})".format(make_up(var), make_up_unit(Iunit, var))
 
-        fig = px.line(x=x, y=y, template=template)
+        radiance_data = self.get("radiance_noslit")
+        df = pd.DataFrame(
+            {"Wavenumber": radiance_data[0], "Radiance_noslit": radiance_data[1]}
+        )
+
+        # Add extra plotting parameters
+        if "lw" in kwargs:
+            kwargs["line_width"] = kwargs.pop("lw")
+        if "color" in kwargs:
+            kwargs["line_color"] = kwargs.pop("color")
+        width = kwargs.pop("width", None)
+        height = kwargs.pop("height", None)
+
+        fig = px.line(df, x="Wavenumber", y="Radiance_noslit", template=template)
+        fig.update_traces(**kwargs)
         fig.update_layout(
             xaxis_title=xlabel,
             yaxis_title=ylabel,
             yaxis=dict(tickmode="linear", dtick=0.01),
+            width=width,
+            height=height,
         )
         fig.show()
 
@@ -2575,7 +2596,7 @@ class Spectrum(object):
                 - "matplotlib": Forces the use of Matplotlib for static plots.
         **kwargs: **dict
             kwargs forwarded as argument to plot (e.g: lineshape
-            attributes: `lw=3, color='r'`)
+            attributes: `lw=3, color='r', width=800, height=600`)
 
         Returns
         -------


### PR DESCRIPTION
### Description
This pull request is to enhance the plot function by ensuring that kwargs such as width, height, color, and lw (line width) are properly utilized when using the Plotly library. Additionally, support for width and height has been added when plotting with Matplotlib.

Fixes #760 

New Usage Examples:
```bash
from radis import calc_spectrum
s = calc_spectrum(1900, 2300,         # cm-1
                molecule='CO',
                isotope='1,3,10,1000',
                pressure=1.01325,   # bar
                Tgas=700,           # K
                mole_fraction=0.1,
                path_length=1,      # cm
                databank='hitran',  # or 'hitemp', 'geisa', 'exomol'
                )
s.apply_slit(0.5, 'nm')       # simulate an experimental slit
```
## Using plotly
### Default
![Screenshot from 2025-03-10 16-14-34](https://github.com/user-attachments/assets/74d1cfc3-7ecb-4a9c-bc13-0a9dadd44280)

```bash
s.plot('radiance', plotting_library='plotly')  
```
### With Customization
![Screenshot from 2025-03-10 16-14-21](https://github.com/user-attachments/assets/371823d8-a157-4e57-9c08-879e9fb4c918)

```bash
s.plot('radiance', plotting_library='plotly',lw=4, color='grey', width=1200, height=600)    
```
# Using matplotlib
### Default
![Screenshot from 2025-03-10 16-05-43](https://github.com/user-attachments/assets/8647bf57-aeeb-4dff-828e-5d569bed7138)
```bash
s.plot('radiance', plotting_library='matplotlib')  
```
### With Customization
![Screenshot from 2025-03-10 16-05-53](https://github.com/user-attachments/assets/743f623c-fbba-4b62-b74e-40ddd7992fc2)
```bash
s.plot('radiance', plotting_library='matplotlib',lw=4, color='grey', width=1200, height=600)    
```
