### PR TITLE
Fixes `fetch_hitemp` bug

### DIFF
--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -177,7 +177,7 @@ def fetch_hitemp(
     # Download files
     if len(download_files) > 0:
 
-        if urlnames is None:
+        if urlnames is None or len(urlnames) == 0:
             urlnames = ldb.fetch_urlnames()
         filesmap = dict(zip(local_files, urlnames))
         download_urls = [filesmap[k] for k in download_files]

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -177,7 +177,7 @@ def fetch_hitemp(
     # Download files
     if len(download_files) > 0:
 
-        if urlnames is None or len(urlnames) == 0:
+        if len(urlnames) == 0:
             urlnames = ldb.fetch_urlnames()
         filesmap = dict(zip(local_files, urlnames))
         download_urls = [filesmap[k] for k in download_files]


### PR DESCRIPTION
### Description
<!-- Provide a general description of what your pull request does. -->

In #689 `urlnames = None` is changed to `urlnames = []` in `DatabaseManager` but in `fetch_hitemp` function from `hitemp.py` the check for fecting the URL was
```python
if urlnames is None:
    urlnames = ldb.fetch_urlnames()
```
Which is incorrect  as it is a dict now so I changed  to check if the length is zero. 

I tried using `fetch_hitemp` and it worked. All tests are Passing!!

Fixes #771
