### PR TITLE
Add support for HITEMP 2010 database

### DIFF
--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -127,7 +127,7 @@ def get_recent_hitemp_database_year(molecule):
     Get the latest database year for CO2 from HITEMP :
     ::
 
-        year = get_hitemp_database_list("CO2")
+        year = get_recent_hitemp_database_year("CO2")
         >>> "2024"
     """
 

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -27,6 +27,7 @@ def fetch_hitemp(
     engine="default",
     output="pandas",
     parallel=True,
+    database=None,
 ):
     """Stream HITEMP file from HITRAN website. Unzip and build a HDF5 file directly.
 
@@ -120,6 +121,7 @@ def fetch_hitemp(
 
     if r"{molecule}" in databank_name:
         databank_name = databank_name.format(**{"molecule": molecule})
+        databank_name += "-2010" if database == "2010" else ""
 
     if local_databases is None:
         import radis
@@ -135,6 +137,7 @@ def fetch_hitemp(
         chunksize=chunksize,
         parallel=parallel,
         engine=engine,
+        database=database,
     )
 
     # Get list of all expected local files for this database:
@@ -190,7 +193,8 @@ def fetch_hitemp(
             nrows = ldb.get_nrows(local_files[0])
             # assert nrows == Nlines
             _, Ntotal_lines_expected, _, _ = ldb.fetch_url_Nlines_wmin_wmax()
-            if nrows != Ntotal_lines_expected:
+            # Do not raise an exception for the 2010 version since it is not available on the HITEMP website.
+            if nrows != Ntotal_lines_expected and Ntotal_lines_expected != 0:
                 raise AssertionError(
                     f"Number of lines in local database ({nrows:,}) "
                     + "differ from the expected number of lines for "

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -27,7 +27,7 @@ def fetch_hitemp(
     engine="default",
     output="pandas",
     parallel=True,
-    database=None,
+    database="full",
 ):
     """Stream HITEMP file from HITRAN website. Unzip and build a HDF5 file directly.
 
@@ -77,7 +77,10 @@ def fetch_hitemp(
 
     parallel: bool
         if ``True``, uses joblib.parallel to load database with multiple processes
-
+    database: ``str``
+        The name of the database, e.g., ``full`` or ``2010`` for CO.
+        The full option retrieves the most recent available version, while ``2010``
+        specifically selects the 2010 version. If not provided, it defaults to ``full``
     Returns
     -------
     df: pd.DataFrame

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -8,7 +8,7 @@ Created on Sun May 22 17:35:05 2022
 from os.path import abspath, exists, expanduser, join
 
 from radis.api.hdf5 import update_pytables_to_vaex
-from radis.api.hitempapi import HITEMPDatabaseManager
+from radis.api.hitempapi import HITEMPDatabaseManager, get_recent_hitemp_database_year
 
 
 def fetch_hitemp(
@@ -27,7 +27,7 @@ def fetch_hitemp(
     engine="default",
     output="pandas",
     parallel=True,
-    database="full",
+    database="most_recent",
 ):
     """Stream HITEMP file from HITRAN website. Unzip and build a HDF5 file directly.
 
@@ -78,9 +78,11 @@ def fetch_hitemp(
     parallel: bool
         if ``True``, uses joblib.parallel to load database with multiple processes
     database: ``str``
-        The name of the database, e.g., ``full`` or ``2010`` for CO.
-        The full option retrieves the most recent available version, while ``2010``
-        specifically selects the 2010 version. If not provided, it defaults to ``full``
+        The database version to retrieve. Options include:
+        - `"most_recent"`: Fetches the latest available database version.
+        - A four-digit year (e.g., `"2010"`): Selects a specific version, such as the 2010 database for CO.
+
+        If not provided, the default is `"most_recent"`.
     Returns
     -------
     df: pd.DataFrame
@@ -121,6 +123,15 @@ def fetch_hitemp(
     :py:meth:`~radis.lbl.loader.DatabankLoader.fetch_databank`
 
     """
+
+    recent_database = get_recent_hitemp_database_year(molecule)
+    if database == "most_recent":
+        database = recent_database
+    available_years = {"2010", str(recent_database)}
+    if database not in available_years:
+        raise KeyError(
+            f"The database '{database}' is not recognized as an available HITEMP database for '{molecule}'. Please choose from the following available years: {available_years}."
+        )
 
     if r"{molecule}" in databank_name:
         databank_name = databank_name.format(**{"molecule": molecule})

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -80,7 +80,7 @@ def fetch_hitemp(
     database: ``str``
         The database version to retrieve. Options include:
         - `"most_recent"`: Fetches the latest available database version.
-        - A four-digit year (e.g., `"2010"`): Selects a specific version, such as the 2010 database for CO.
+        - A four-digit year (e.g., `"2010"`): Selects a specific version, such as the 2010 or 2019 database for CO.
 
         If not provided, the default is `"most_recent"`.
     Returns

--- a/radis/lbl/calc.py
+++ b/radis/lbl/calc.py
@@ -784,6 +784,7 @@ def _calc_spectrum_one_molecule(
         )
         or compare(databank, "exomol")
         or compare(databank, "hitran")
+        or compare(databank, "hitemp")
     ):  # mode to get databank without relying on  Line databases
         # Line database :
         if compare(databank, ["fetch", "hitran"]):
@@ -824,6 +825,12 @@ def _calc_spectrum_one_molecule(
                 "source": "exomol",
                 "database": databank[1],
                 "parfuncfmt": "exomol",  # download & use Exo partition functions for equilibrium}
+            }
+        elif compare(databank, "hitemp"):
+            conditions = {
+                "source": "hitemp",
+                "database": databank[1],
+                "parfuncfmt": "hapi",
             }
         # Partition functions :
         conditions.update(

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -1305,10 +1305,9 @@ class DatabankLoader(object):
 
             if memory_mapping_engine == "auto":
                 memory_mapping_engine = get_auto_MEMORY_MAPPING_ENGINE()
-
-            if database != "full":
+            if database not in ["full", "2010"]:
                 raise ValueError(
-                    f"Got `database={database}`. When fetching HITEMP, only the `database='full'` option is available."
+                    f"Got `database={database}`. When fetching HITEMP, only `database='full'` or `database='2010'` options are available."
                 )
 
             # Download, setup local databases, and fetch (use existing if possible)
@@ -1331,6 +1330,7 @@ class DatabankLoader(object):
                 engine=memory_mapping_engine,
                 output=output,
                 parallel=parallel,
+                database=database,
             )
             self.params.dbpath = ",".join(local_paths)
 

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -1115,7 +1115,7 @@ class DatabankLoader(object):
                 "hitemp-radisdb"  # downloaded in RADIS local databases ~/.radisdb
             )
             if database == "default":
-                database = "full"
+                database = "most_recent"
 
         elif compare_source == "kurucz":
             dbformat = "kurucz"

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -1305,9 +1305,11 @@ class DatabankLoader(object):
 
             if memory_mapping_engine == "auto":
                 memory_mapping_engine = get_auto_MEMORY_MAPPING_ENGINE()
-            if database not in ["full", "2010"]:
+            if database not in ["most_recent"] and not (
+                database.isdigit() and len(database) == 4
+            ):
                 raise ValueError(
-                    f"Got `database={database}`. When fetching HITEMP, only `database='full'` or `database='2010'` options are available."
+                    f"Invalid database selection: '{database}'. When fetching HITEMP, you must choose either 'most_recent' or a valid four-digit year."
                 )
 
             # Download, setup local databases, and fetch (use existing if possible)

--- a/radis/test/io/test_hitemp.py
+++ b/radis/test/io/test_hitemp.py
@@ -477,8 +477,6 @@ def test_calc_hitemp_spectrum_2010_version(*args, **kwargs):
         verbose=False,
     )
 
-    return
-
 
 @pytest.mark.needs_connection
 def test_calc_hitemp_CO_noneq(verbose=True, *args, **kwargs):

--- a/radis/test/io/test_hitemp.py
+++ b/radis/test/io/test_hitemp.py
@@ -446,6 +446,40 @@ def test_calc_hitemp_spectrum(*args, **kwargs):
     return
 
 
+@pytest.mark.fast
+@pytest.mark.needs_connection
+def test_calc_hitemp_spectrum_2010_version(*args, **kwargs):
+    """
+    Test direct loading of HDF5 files 2010 version
+    """
+
+    from astropy import units as u
+
+    from radis import calc_spectrum
+
+    calc_spectrum(
+        wavenum_min=1900 / u.cm,
+        wavenum_max=2500 / u.cm,
+        wstep="auto",
+        molecule="CO",
+        Tgas=300,
+        databank=("hitemp", "2010"),  # test by fetching directly
+        verbose=False,
+    )
+
+    calc_spectrum(
+        wavenum_min=1900 / u.cm,
+        wavenum_max=2500 / u.cm,
+        wstep="auto",
+        molecule="CO",
+        Tgas=300,
+        databank="HITEMP-CO-2010",  # test by loading the downloaded database
+        verbose=False,
+    )
+
+    return
+
+
 @pytest.mark.needs_connection
 def test_calc_hitemp_CO_noneq(verbose=True, *args, **kwargs):
     """Test proper download of HITEMP CO database.

--- a/radis/test/io/test_hitemp.py
+++ b/radis/test/io/test_hitemp.py
@@ -281,6 +281,34 @@ def test_fetch_hitemp_all_molecules(molecule, verbose=True, *args, **kwargs):
     assert len(df) == Nlines
 
 
+@pytest.mark.needs_connection
+@pytest.mark.download_large_databases
+@pytest.mark.parametrize("molecule", [mol for mol in HITEMP_MOLECULES])
+def test_fetch_hitemp_all_molecules_2010_version(
+    molecule, verbose=True, *args, **kwargs
+):
+    """Test fetch HITEMP for all molecules whose download URL is available for the 2010 version.
+
+    If it fails, check the databases downloaded in ~/.radisdb
+
+    Notes
+    -----
+
+    Currently, this works for all molecules except CO2 and H2O
+    """
+
+    df, local_files = fetch_hitemp(
+        molecule,
+        columns=["int", "wav"],
+        verbose=verbose,
+        return_local_path=True,
+        engine="default",
+        database="2010",
+    )
+
+    assert f"HITEMP-{molecule}-2010" in getDatabankList()
+
+
 @pytest.mark.fast
 @pytest.mark.needs_connection
 def test_partial_loading(*args, **kwargs):


### PR DESCRIPTION
### Description
This draft PR introduces support for the HITEMP 2010 database. 

To prevent conflicts with newer versions, entries in radis.json now append -2010 to the database name like this.

```json
   "database": {
      "HITEMP-CO-2010": {
         "info": "HITEMP CO lines (3.5-5351.7 cm-1) with TIPS-2017 (through HAPI) for partition functions and RADIS spectroscopic constants for rovibrational energies (nonequilibrium)",
         "path": "/home/mohy/.radisdb/hitemp/CO-05_HITEMP2010.h5",
         "format": "hitemp-radisdb",
         "parfuncfmt": "hapi",
         "levelsfmt": "radis",
         "download_url": [
            "05_HITEMP2010.zip"
         ],
         "download_date": "2025-03-31",
         "wavenumber_min": 3.462498,
         "wavenumber_max": 5351.731
      },
      "HITEMP-CO": {
         "info": "HITEMP CO lines (2.0-22149.0 cm-1) with TIPS-2017 (through HAPI) for partition functions and RADIS spectroscopic constants for rovibrational energies (nonequilibrium)",
         "path": "/home/mohy/.radisdb/hitemp/CO-05_HITEMP2019.h5",
         "format": "hitemp-radisdb",
         "parfuncfmt": "hapi",
         "levelsfmt": "radis",
         "download_url": [
            "05_HITEMP2019.par.bz2"
         ],
         "download_date": "2025-03-30",
         "wavenumber_min": 2,
         "wavenumber_max": 22149
      }
   },
```
Currently, this implementation works for all molecules except CO₂ and H₂O, as they are split across multiple files while ``download_hitemp_file`` currently handles only one file at a time. I will work on a solution for that.


### Usage examples
```python
s = calc_spectrum(
    1900,
    2500,
    species="CO",
    isotope="1",
    pressure=1.01325,  # bar
    Tgas=300,  # K
    mole_fraction=0.1,
    path_length=1,  # cm
    databank=("hitemp", "2010"),  
    # Use "2010" for the 2010 version or "full" for the latest available database  
    # Alternatively, specifying databank="hitemp" defaults to "full"
    use_cached=True,
    wstep="auto",
    export_lines=False,
)
```

```python
df, local_files = fetch_hitemp(
    "CO",
    columns=["int", "wav"],
    return_local_path=True,
    engine="default",
    database="2010",
)
print(local_files)

# output
# ['/home/mohy/.radisdb/hitemp/CO-05_HITEMP2010.h5']


df, local_files = fetch_hitemp(
    "CO",
    columns=["int", "wav"],
    return_local_path=True,
    engine="default",
    database="full", # or not provided
)
print(local_files)

# output
# ['/home/mohy/.radisdb/hitemp/CO-05_HITEMP2019.h5']

```
Fixes #784 
