### PR TITLE
[WIP] Add Multigrid support 

### DIFF
--- a/radis/default_radis.json
+++ b/radis/default_radis.json
@@ -29,6 +29,9 @@
     "DATAFRAME_ENGINE" : "pandas"
     "MISSING_BROAD_COEF" : false            # accepted values: false and "air". If "air", missing boradening coefficients are replaced by those of air.
     #"USE_CYTHON": true                      # use Cython module if available (else default to Python)
+    "MULTI_SPARSE_GRID": false              # Compute with multiple coarser sparse wavenumber grids
+    "PRECOMPUTE_ALL_QUANTITIES": true       # if `true` Spectrum objects contain radiance, transmittance, etc. Else only abscoeff is computed.
+
     # molecular parameters
     # --------------------
     # Additional parameters are read from radis.db.molparams_extra.json

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -766,7 +766,9 @@ def olivero_1977(wg, wl):
     return wv
 
 
-def voigt_lineshape(w_centered, hwhm_lorentz, hwhm_voigt, jit=True):
+def voigt_lineshape(
+    w_centered, hwhm_lorentz, hwhm_voigt, jit=True, exact_normalize=True
+):
     """Calculates Voigt lineshape using the approximation of the Voigt profile
     of [NEQAIR-1996]_, [Whiting-1968]_ that maintains a good accuracy in the far wings.
     Exact for a pure Gaussian and pure Lorentzian.
@@ -786,6 +788,10 @@ def voigt_lineshape(w_centered, hwhm_lorentz, hwhm_voigt, jit=True):
     jit: boolean
         if ``True``, use just in time compiler. Usually faster when > 10k lines.
         Default ``True``.
+    exact_normalize: boolean
+        if ``True``, normalize the lineshape to 1. This ensures energy conservation
+        even if the grid resolution is not good enough. Else, use an analytical
+        expression to normalize. Default ``True``.
 
     Returns
     -------
@@ -1218,8 +1224,8 @@ class BroadenFactory(BaseFactory):
         self.profiler.stop("calc_hwhm", "Calculate broadening HWHM")
 
     def _calc_min_width(self, df):
-        """Calculates the minimum FWHM of the lines
-        and stores in self.min_width
+        """Calculates the minimum FWHW of the lines
+        and stores in self._min_width
         """
         if "hwhm_voigt" in df:
             min_width = 2 * df.hwhm_voigt.min()
@@ -1231,7 +1237,7 @@ class BroadenFactory(BaseFactory):
             # but it's quite expensive to compute
             min_width = max(min_lorentz_fwhm, min_gauss_fwhm)
 
-        self.min_width = min_width
+        self._min_width = min_width
 
         return
 
@@ -1268,7 +1274,7 @@ class BroadenFactory(BaseFactory):
         # TODO: thresholds depend whether we're computing Transmittance/optically thin emission,
         # for a homogeneous slab, or self-absorbed radiance combined with other slabs.
 
-        min_width = self.min_width
+        min_width = self._min_width
 
         gridpoints_per_linewidth_error_threshold = radis.config[
             "GRIDPOINTS_PER_LINEWIDTH_ERROR_THRESHOLD"
@@ -1590,7 +1596,7 @@ class BroadenFactory(BaseFactory):
 
         return lineshape
 
-    def _voigt_broadening(self, dg, wbroad_centered, jit=True):
+    def _voigt_broadening(self, dg, wbroad_centered, jit=True, exact_normalize=True):
         """Computes voigt broadening over all lines + normalize.
 
         Uses an approximation of the Voigt profile [1]_, [2]_ that maintains a
@@ -1652,13 +1658,19 @@ class BroadenFactory(BaseFactory):
 
         # Calculate broadening for all lines
         # ----------------------------------
-        lineshape = voigt_lineshape(wbroad_centered, hwhm_lorentz, hwhm_voigt, jit=jit)
+        lineshape = voigt_lineshape(
+            wbroad_centered,
+            hwhm_lorentz,
+            hwhm_voigt,
+            jit=jit,
+            exact_normalize=exact_normalize,
+        )
 
         return lineshape
 
     # %% Function to calculate lineshapes from HWHM
 
-    def _calc_lineshape(self, dg):
+    def _calc_lineshape(self, dg, wavenumber_group):
         """Sum over each line (trying to use vectorize operations to be faster)
 
         Parameters
@@ -1667,6 +1679,12 @@ class BroadenFactory(BaseFactory):
             list of lines  (keys includes HWHM half-width half max coefficient
             `gamma_lb` for broadening calculation)
 
+        Other Parameters
+        ----------------
+        wavenumber_group: (int, int) or None
+            used for multisparsegrids : if not None, use the lineshape grid
+            corresponding to the specific wavenumber grid (i.e. : only the
+            center for the most resolved grid, only the wings for the coarser grid)
 
         Returns
         -------
@@ -1712,7 +1730,11 @@ class BroadenFactory(BaseFactory):
 
         # Generate broadening array (so that it is as large as `truncation`
         # in cm-1, and keeps the same spacing as the final output wavelength vector)
-        wbroad_centered_oneline = self.wbroad_centered  # size (B,)
+        if wavenumber_group is None:
+            wbroad_centered_oneline = self.wbroad_centered  # size (B,)
+        else:
+            gridnb = wavenumber_group[0]
+            wbroad_centered_oneline = self.wbroad_centered[gridnb]  # size (<B,)
 
         shifted_wavenum = dg.shiftwav
 
@@ -1741,7 +1763,10 @@ class BroadenFactory(BaseFactory):
         if broadening_method == "voigt":
             jit = True
             self.profiler.start("voigt_broadening", 3)
-            line_profile = self._voigt_broadening(dg, wbroad_centered, jit=jit)
+            # we normalize numerically only if using a single grid (else, we use an analytical expression)
+            line_profile = self._voigt_broadening(
+                dg, wbroad_centered, jit=jit, exact_normalize=(wavenumber_group is None)
+            )
             self.profiler.stop(
                 "voigt_broadening", f"Calculated Voigt profile (jit={jit})"
             )
@@ -1781,7 +1806,7 @@ class BroadenFactory(BaseFactory):
 
         return line_profile
 
-    def _calc_lineshape_LDM(self, df):
+    def _calc_lineshape_LDM(self, df, wavenumber_group):
         """Generate the lineshape database using the steps defined by the
         parameters :py:attr:`~radis.lbl.loader.Parameters.dxL` and
         :py:attr:`~radis.lbl.loader.Parameters.dxG`.
@@ -1790,6 +1815,9 @@ class BroadenFactory(BaseFactory):
         ----------
         df: pandas DataFrame
             line database
+        wavenumber_group: (int, int), or ``None``
+            in sparse wavenumber mode; wavenumber grid & group to apply these lines on.
+            If ``None``, use full range.
 
         Returns
         -------
@@ -1856,7 +1884,11 @@ class BroadenFactory(BaseFactory):
         broadening_method = self.params.broadening_method
         if broadening_method == "voigt":
             jit = False  # not enough lines to make the just-in-time FORTRAN compilation useful
-            wbroad_centered = self.wbroad_centered
+            if wavenumber_group is None:
+                wbroad_centered = self.wbroad_centered
+            else:
+                gridnb = wavenumber_group[0]
+                wbroad_centered = self.wbroad_centered[gridnb]
 
             # Non vectorized loop. Probably slightly slower, but this is not the bottleneck anyway.
             # see commit 6474cb7e on 15/08/2019 for a vectorized version
@@ -1864,13 +1896,25 @@ class BroadenFactory(BaseFactory):
                 line_profile_LDM[l] = {}
                 for m in range(len(wL)):
                     wV_ij = olivero_1977(wG[l], wL[m])  # FWHM
+                    # we normalize numerically only if using a single grid (else, we use an analytical expression)
                     lineshape = voigt_lineshape(
-                        wbroad_centered, wL[m] / 2, wV_ij / 2, jit=jit
+                        wbroad_centered,
+                        wL[m] / 2,
+                        wV_ij / 2,
+                        jit=jit,
+                        exact_normalize=wavenumber_group is None,
                     )  # FWHM > HWHM
                     line_profile_LDM[l][m] = lineshape
 
         elif broadening_method == "convolve":
-            wbroad_centered = self.wbroad_centered
+            if wavenumber_group is None:
+                wbroad_centered = self.wbroad_centered
+            else:
+                gridnb = wavenumber_group[0]
+                wbroad_centered = self.wbroad_centered[gridnb]
+                raise NotImplementedError(
+                    "broadening_method == 'convolve'. Only broadening_method='voigt' is implemented with Multigrids"
+                )  # @dev in particular, exact normalization (/np.trapz() won't work if full lineshape is not given
 
             IG = [
                 gaussian_lineshape(wbroad_centered, wG[l] / 2) for l in range(len(wG))
@@ -1891,8 +1935,17 @@ class BroadenFactory(BaseFactory):
         elif broadening_method == "fft":
             # Unlike real space methods ('convolve', 'voigt'), here we calculate
             # the lineshape on the full spectral range.
-            w = self.wavenumber_calc
-            wstep = self.params.wstep
+            if wavenumber_group is not None:
+                w = self.wavenumber_calc[wavenumber_group]
+                wstep = self.params.wstep
+            else:
+                gridnb = wavenumber_group[0]
+                w = self.wavenumber_calc[gridnb]
+                wstep = self._wstep_multigrid[gridnb]
+                raise NotImplementedError(
+                    "broadening_method == 'fft'. Only broadening_method='voigt' is implemented with Multigrids"
+                )
+
             w_lineshape_ft = np.fft.rfftfreq(
                 2 * len(w), wstep
             )  # TO-DO: add  + self.misc.zero_padding
@@ -1969,29 +2022,53 @@ class BroadenFactory(BaseFactory):
         if Tgas is None:
             Tgas = self.input.Tgas
 
+        # Plot!
+        set_style()
+        plt.figure()
+
         # Get one line only:
         dg = self.df1.iloc[i]
-
         wbroad_centered = self.wbroad_centered
         wbroad = wbroad_centered + dg.shiftwav
         #        convolve_profile = self._calc_lineshape(dg)
         # Get Voigt from empirical approximation
-        if "hwhm_voigt" in dg:
-            voigt_profile = self._voigt_broadening(dg, wbroad_centered, jit=False)
-        # Get Voigt from convolution
-        pressure_profile = self._collisional_lineshape(dg, wbroad_centered)
-        gaussian_profile = self._gaussian_lineshape(dg, wbroad_centered)
-        line_profile = np.convolve(pressure_profile, gaussian_profile, "same")
-        line_profile /= trapz(line_profile.T, x=wbroad.T)  # normalize
+        if not self._multisparsegrid:
+            if "hwhm_voigt" in dg:
+                voigt_profile = self._voigt_broadening(dg, wbroad_centered, jit=False)
+            # Get Voigt from convolution
+            pressure_profile = self._collisional_lineshape(dg, wbroad_centered)
+            gaussian_profile = self._gaussian_lineshape(dg, wbroad_centered)
+            line_profile = np.convolve(pressure_profile, gaussian_profile, "same")
+            line_profile /= trapz(line_profile.T, x=wbroad.T)  # normalize
 
-        # Plot!
-        set_style()
-        plt.figure()
-        plt.plot(wbroad, pressure_profile, label="Pressure")
-        plt.plot(wbroad, gaussian_profile, label="Doppler")
-        plt.plot(wbroad, line_profile, label="Voigt (convolved)", lw=3)
-        if "hwhm_voigt" in dg:
-            plt.plot(wbroad, voigt_profile, label="Voigt (approximation)")
+            plt.plot(wbroad, pressure_profile, label="Pressure")
+            plt.plot(wbroad, gaussian_profile, label="Doppler")
+            plt.plot(wbroad, line_profile, label="Voigt (convolved)", lw=3)
+            if "hwhm_voigt" in dg:
+                plt.plot(wbroad, voigt_profile, label="Voigt (approximation)")
+        else:
+            for gridnb in len(range(self.wbroad_centered)):
+                if "hwhm_voigt" in dg:
+                    voigt_profile = self._voigt_broadening(
+                        dg, wbroad_centered[gridnb], jit=False
+                    )
+                # Get Voigt from convolution
+                pressure_profile = self._collisional_lineshape(
+                    dg, wbroad_centered[gridnb]
+                )
+                gaussian_profile = self._gaussian_lineshape(dg, wbroad_centered[gridnb])
+                line_profile = np.convolve(pressure_profile, gaussian_profile, "same")
+                line_profile /= trapz(line_profile.T, x=wbroad.T)  # normalize
+
+                plt.plot(wbroad[gridnb], pressure_profile, label="Pressure")
+                plt.plot(wbroad[gridnb], gaussian_profile, label="Doppler")
+                plt.plot(wbroad[gridnb], line_profile, label="Voigt (convolved)", lw=3)
+                if "hwhm_voigt" in dg:
+                    plt.plot(
+                        wbroad[gridnb], voigt_profile, label="Voigt (approximation)"
+                    )
+                # Must be unreadable, TODO update with fewer graphs
+
         plt.xlabel("Wavenumber (cm-1)")
         plt.ylabel("Broadening coefficient")
         plt.title("Line {0}, T={1:.1f}K, P={2:.2f}atm".format(i, Tgas, pressure_atm))
@@ -2028,16 +2105,18 @@ class BroadenFactory(BaseFactory):
 
         See Also
         --------
-        :py:meth:`~radis.lbl.broadening.BroadenFactory._calc_lineshape`
+        :py:meth:`~radis.lbl.broadening.BroadenFactory._calc_lineshape`,
+        :py:meth:`~radis.lbl.broadening.BroadenFactory._apply_lineshape_multigrid`
         """
 
         self.profiler.start("init_vectors_apply", 3)
 
-        #        # Get spectrum range
+        # Get spectrum range
         wavenumber = self.wavenumber  # final vector of wavenumbers (shape W)
         wavenumber_calc = (
             self.wavenumber_calc
-        )  # calculation vector of wavenumbers (shape W + space B on the sides)
+        )  # calculation vector (shape W + space B on sides)
+        woutrange = self.woutrange
 
         # Vectorize the chunk of lines
         if isinstance(broadened_param, np.ndarray):
@@ -2051,6 +2130,7 @@ class BroadenFactory(BaseFactory):
 
         # Get truncation array
         wbroad_centered = self.wbroad_centered  # size (B,)
+
         # index of truncation half width
         iwbroad_half = len(wbroad_centered) // 2
         ineighbour = arange_len(0, self.params.neighbour_lines, self.params.wstep)
@@ -2111,27 +2191,30 @@ class BroadenFactory(BaseFactory):
         #        # normal: ~ 36 ms  called 9 times
         #        # with @jit : ~ 200 ms called 9 times (worse!)
 
-        # summ all lines :
+        # sum all lines :
 
-        # I_low_in_left: lower wavenumber limit of the line, left grid point
-        # I_low_in_right: lower wavenumber limit of the line, right grid point
-        # I_high_in_left: higher wavenumber limit of the line, left grid point
-        # I_high_in_right: higher wavenumber limit of the line, right grid point
+        # Indices : (e.g. with examples for a line centered on 2325 cm-1, HWHM = 25cm-1)
+        # I_low_in_left: lower wavenumber limit of the line, left grid point (e.g 2300 cm-1)
+        # I_low_in_right: lower wavenumber limit of the line, right grid point (e.g 2300.01 cm-1)
+        # I_high_in_left: higher wavenumber limit of the line, left grid point (e.g. 2350 cm-1)
+        # I_high_in_right: higher wavenumber limit of the line, right grid point (e.g. 2350.01 cm-1)
         I_low_in_left = idcenter_left - iwbroad_half + ioffset
         I_low_in_right = idcenter_right - iwbroad_half + ioffset
         I_high_in_left = I_low_in_left + 2 * iwbroad_half
         I_high_in_right = I_low_in_right + 2 * iwbroad_half
-        for i, (fr_left, fr_right, profS) in enumerate(
-            zip(frac_left, frac_right, profile_S.T)
-        ):
-            sumoflines_calc[I_low_in_left[i] : I_high_in_left[i] + 1] += fr_left * profS
-            sumoflines_calc[I_low_in_right[i] : I_high_in_right[i] + 1] += (
-                fr_right * profS
-            )
 
-        # Nomenclature for lines above:
-        # - low/high: start/end of a lineshape
-        # - left/right: closest spectral grid point on the left/right
+        from radis.misc.arrays import aggregate_at_indices
+
+        sumoflines_calc = aggregate_at_indices(
+            sumoflines_calc,
+            I_low_in_left,
+            I_low_in_right,
+            I_high_in_left,
+            I_high_in_right,
+            profile_S.T,
+            frac_left,
+            frac_right,
+        )
 
         self.profiler.stop("aggregate__lines", "Aggregate lines")
 
@@ -2139,8 +2222,265 @@ class BroadenFactory(BaseFactory):
         sumoflines_calc = sumoflines_calc[ioffset:-ioffset]
         assert len(sumoflines_calc) == len(wavenumber_calc)
         # Get valid range (discard neighbour lines)
-        sumoflines = sumoflines_calc[self.woutrange[0] : self.woutrange[1]]
+        sumoflines = sumoflines_calc[woutrange[0] : woutrange[1]]
 
+        assert len(wavenumber) == len(sumoflines)
+        return wavenumber, sumoflines
+
+    def _apply_lineshape_multigrid(
+        self, broadened_param, line_profile, shifted_wavenum, wavenumber_group
+    ):
+        """Multiply `broadened_param` by `line_profile` and project it on the
+        correct wavelength given by `shifted_wavenum`
+
+        Parameters
+        ----------
+        broadened_param: pandas Series (or numpy array)   [size N = number of lines]
+            Series to apply lineshape to. Typically linestrength `S` for absorption,
+            or `nu * Aul / 4pi * DeltaE` for emission
+        line_profile:   (1/cm-1)        2D array of lines_profiles for all lines
+                (size B * N, B = width of lineshape)
+        shifted_wavenum: (cm-1)     pandas Series (size N = number of lines)
+            center wavelength (used to project broaded lineshapes )
+
+        Other Parameters
+        ----------------
+        wavenumber_group: (int, int), or ``None``
+            in sparse wavenumber mode; wavenumber grid & group to apply these lines on.
+            If ``None``, use full range.
+
+
+        Returns
+        -------
+        sumoflines: array (size W  = size of output wavenumbers)
+            sum of (broadened_param x line_profile)
+
+        Notes
+        -----
+        Units change during convolution::
+
+            [sumoflines] = [broadened_param] * cm
+
+        See Also
+        --------
+        :py:meth:`~radis.lbl.broadening.BroadenFactory._calc_lineshape`
+        """
+
+        self.profiler.start("init_vectors_apply_multigrid", 3)
+
+        # Get spectrum range
+        wavenumber = self.wavenumber  # final vector of wavenumbers (shape W)
+        wavenumber_calc = (
+            self.wavenumber_calc
+        )  # calculation vector (shape W + space B on sides)
+        woutrange = self.woutrange
+        if wavenumber_group is not None:  # multiple, discontinued grids
+            gridnb, groupnb = wavenumber_group
+            wavenumber = wavenumber[gridnb][groupnb]
+            wavenumber_calc = wavenumber_calc[gridnb][groupnb]
+            woutrange = woutrange[gridnb][groupnb]
+
+        # Vectorize the chunk of lines
+        S = broadened_param.reshape((1, -1))
+        shifted_wavenum = shifted_wavenum.reshape((1, -1))  # make it a row vector
+
+        # Get truncation array
+        gridnb = wavenumber_group[0]
+        wbroad_centered = self.wbroad_centered[gridnb]  # size (<B,)
+
+        # index of truncation half width
+        wstep = self._wstep_multigrid[gridnb]
+        truncation = self._truncation_multigrid[gridnb]
+        if wavenumber_group is not None:
+            nearest = (
+                0
+                if gridnb == 0
+                else self._truncation_multigrid[gridnb - 1]
+                - self._wstep_multigrid[gridnb - 1]
+            )  # should be consistent with definitions of hollow wavenumber ranges in radis.lbl.factory.SpectrumFactory._generate_broadening_range_multigrid
+        iwbroad_half = len(wbroad_centered) // 2
+        ineighbour = arange_len(
+            0, self.params.neighbour_lines, wstep
+        )  # TODO update; doesn't work with multigrid
+        if self.params.neighbour_lines > 0:
+            raise NotImplementedError("Neighbour lines with multigrid")
+        itruncation = arange_len(
+            0, truncation, wstep
+        )  # index of lineshape end in this grid
+        # ihollow_center = arange_len(0, nearest, wstep)           # index of the end of the lineshape hollow zone in this grid (starting from the center)
+        ihollow_center = int(
+            nearest // wstep
+        )  # index of the end of the lineshape hollow zone in this grid (starting from the center)
+
+        # Calculate matrix of broadened parameter (for all lines)
+        # ... Note @dev : this is the memory bottleneck !
+        profile_S = line_profile * S
+
+        # ---------------------------
+        # Apply line profile
+
+        self.profiler.stop("init_vectors_apply_multigrid", "Initialized vectors")
+        self.profiler.start("get_matching_line_multigrid", 3)
+        # ... First get closest matching line (on the left, and on the right)
+        # ... note @dev: wavenumber_calc must be sorted, which it is by construction.
+        idcenter_left = (
+            np.searchsorted(wavenumber_calc, shifted_wavenum.T, side="left").ravel() - 1
+        )
+        idcenter_right = np.minimum(idcenter_left + 1, len(wavenumber_calc) - 1)
+
+        # ... Get the fraction of each line distributed to the left and to the right.
+        frac_left = (
+            shifted_wavenum - wavenumber_calc[idcenter_left]
+        ).flatten()  # distance to left grid point
+        frac_right = (
+            wavenumber_calc[idcenter_right] - shifted_wavenum
+        ).flatten()  # distance to right grid point
+        dv = frac_left + frac_right
+        # fraction of intensity on each side:
+        frac_left, frac_right = frac_right / dv, frac_left / dv
+
+        # offset to account for out-of-bound truncation
+        ioffset = itruncation + 1
+
+        # ... Initialize array on which to distribute the lineshapes
+        sumoflines_calc = zeros(len(wavenumber_calc) + 2 * ioffset)
+
+        # Note on performance: it isn't straightforward to vectorize the summation
+        # of all lineshapes on the spectral range as some lines may be parly outside
+        # the spectral range.
+        # to avoid an If / Else condition in the loop, we do a vectorized
+        # comparison beforehand and run 3 different loops
+
+        # reminder: wavenumber_calc has size [neighbour_lines/wstep+vec_length+neighbour_lines/wstep]
+        vec_length = len(wavenumber)
+        assert (
+            len(wavenumber_calc) == vec_length + 2 * ineighbour
+        )  # self.params.neighbour_lines/self.params.wstep
+
+        self.profiler.stop(
+            "get_matching_line_multigrid", "Get closest matching line & fraction"
+        )
+        self.profiler.start("aggregate__lines_multigrid", 3)
+
+        #        # Performance for lines below
+        #        # ----------
+        #        #
+        #        # on test case: 6.5k lines x 18.6k grid length
+        #        # normal: ~ 36 ms  called 9 times
+        #        # with @jit : ~ 200 ms called 9 times (worse!)
+
+        # sum all lines :
+
+        # Indices : (e.g. with examples for a line centered on 2325 cm-1, HWHM = 25cm-1)
+        # I_low_in_left: lower wavenumber limit of the line, left grid point (e.g 2300 cm-1)
+        # I_low_in_right: lower wavenumber limit of the line, right grid point (e.g 2300.01 cm-1)
+        # I_high_in_left: higher wavenumber limit of the line, left grid point (e.g. 2350 cm-1)
+        # I_high_in_right: higher wavenumber limit of the line, right grid point (e.g. 2350.01 cm-1)
+        I_low_in_left = idcenter_left - iwbroad_half + ioffset
+        I_low_in_right = idcenter_right - iwbroad_half + ioffset
+        I_high_in_left = I_low_in_left + 2 * iwbroad_half
+        I_high_in_right = I_low_in_right + 2 * iwbroad_half
+        # Indices specific for multigrids with hollow-lineshapes (e.g. 10 cm-1 hollow zone centered around 25 cm-1):
+        # I_low_nearest_left: start on the hollow zone on the lower wavenumber limit of the line, left grid point (e.g 2315 cm-1)
+        # I_low_nearest_right: start on the hollow zone on the lower wavenumber limit of the line, right grid point (e.g 2315.01 cm-1)
+        # I_high_nearest_left : end of the hollow zone on the higher wavenumber limit of the line, left grid point (e.g 2335 cm-1)
+        # I_high_nearest_right : end of the hollow zone on the higher wavenumber limit of the line, right grid point (e.g 2335.01 cm-1)
+        I_low_nearest_left = idcenter_left - ihollow_center + ioffset
+        I_high_nearest_left = I_low_nearest_left + 2 * ihollow_center
+        I_low_nearest_right = idcenter_right - ihollow_center + ioffset
+        I_high_nearest_right = I_low_nearest_right + 2 * ihollow_center
+        if gridnb == 0:  # prevent center point from being counted twice :
+            I_low_nearest_left -= 1
+            I_low_nearest_right -= 1
+
+        from radis.misc.arrays import aggregate_at_indices_hollow
+
+        sumoflines_calc = aggregate_at_indices_hollow(
+            sumoflines_calc,
+            I_low_in_left,
+            I_low_in_right,
+            I_high_in_left,
+            I_high_in_right,
+            I_low_nearest_left,
+            I_high_nearest_left,
+            I_low_nearest_right,
+            I_high_nearest_right,
+            profile_S.T,
+            frac_left,
+            frac_right,
+        )
+
+        def fix_boundary_effects(
+            sumoflines_calc, profile_S_T, frac_left, frac_right, wstep_correction
+        ):
+            """
+            Fix boundary effects for hollow ranges :
+            Fix linear interpolation effect, and add all of the linestrength
+            to the boundary
+            Model used : rather than distribute linearly over W, W+wstep with fractions fr_left, fr_right,
+            we distribute over W, W+"wstep_narrower_grid" with fractions fr_left', fr_right'
+            ::
+
+                fr_left' = fr_left  * "wstep_narrower_grid"/wstep
+                fr_right' = fr_right * "wstep_narrower_grid"/wstep
+            """
+            for i in range(len(profile_S_T)):
+                center_index_i = len(profile_S_T[i]) // 2
+
+                # if radis.config["DEBUG_MODE"]:
+                #     assert np.isclose(
+                #         (sumoflines_calc - sumoflines_calc_0)[
+                #             I_low_nearest_left[i] + 1
+                #         ],
+                #         fr_right * profS[len(profS) // 2 - 1],
+                #     )  # used to check indices; debug mode
+                sumoflines_calc[I_low_nearest_left[i] + 1] -= (
+                    frac_right[i]
+                    * profile_S_T[i][center_index_i - 1]
+                    * wstep_correction
+                )
+                sumoflines_calc[I_low_nearest_left[i]] += (
+                    frac_right[i]
+                    * profile_S_T[i][center_index_i - 1]
+                    * wstep_correction
+                )
+                # if radis.config["DEBUG_MODE"]:
+                #     assert np.isclose(
+                #         (sumoflines_calc - sumoflines_calc_0)[
+                #             I_high_nearest_left[i] + 1
+                #         ],
+                #         fr_right * profS[len(profS) // 2]
+                #         + fr_left * profS[len(profS) // 2 + 1],
+                #     )  # used to check indices; debug mode
+                sumoflines_calc[I_high_nearest_left[i] + 1] -= (
+                    frac_right[i] * profile_S_T[i][center_index_i]
+                    + frac_left[i]
+                    * profile_S_T[i][center_index_i + 1]
+                    * wstep_correction
+                )
+                sumoflines_calc[I_high_nearest_left[i] + 2] += (
+                    frac_right[i] * profile_S_T[i][center_index_i]
+                    + frac_left[i]
+                    * profile_S_T[i][center_index_i + 1]
+                    * wstep_correction
+                )
+            return sumoflines_calc
+
+        if gridnb > 0:
+            wstep_correction = (wstep - self._wstep_multigrid[gridnb - 1]) / wstep
+            sumoflines_calc = fix_boundary_effects(
+                sumoflines_calc, profile_S.T, frac_left, frac_right, wstep_correction
+            )
+
+        self.profiler.stop("aggregate__lines_multigrid", "Aggregate lines")
+
+        # Get valid range (discard wings of line profiles)
+        sumoflines_calc = sumoflines_calc[ioffset:-ioffset]
+        assert len(sumoflines_calc) == len(wavenumber_calc)
+        # Get valid range (discard neighbour lines)
+        sumoflines = sumoflines_calc[woutrange[0] : woutrange[1]]
+
+        assert len(wavenumber) == len(sumoflines)
         return wavenumber, sumoflines
 
     def _get_indices(self, arr_i, axis):
@@ -2158,6 +2498,7 @@ class BroadenFactory(BaseFactory):
         wL_dat,
         wG_dat,
         optimization,
+        wavenumber_group=None,
     ):
         """Multiply `broadened_param` by `line_profile` and project it on the
         correct wavelength given by `shifted_wavenum`
@@ -2174,7 +2515,6 @@ class BroadenFactory(BaseFactory):
 
             If ``self.params.broadening_method == 'fft'``, templates are given
             in Fourier space.
-
         shifted_wavenum: (cm-1)     pandas Series (size N = number of lines)
             center wavelength (used to project broadened lineshapes )
         wL: array       (size DL)
@@ -2188,6 +2528,13 @@ class BroadenFactory(BaseFactory):
         optimization :
             if ``"min-RMS"`` weights optimized by analytical minimization of the RMS-error.
             Otherwise, weights equal to their relative position in the grid.
+
+        Other Parameters
+        ----------------
+        wavenumber_group: (int, int), or ``None``
+            in sparse wavenumber mode; wavenumber grid & group to apply these lines on.
+            If ``None``, use full range.
+
 
         Returns
         -------
@@ -2214,6 +2561,27 @@ class BroadenFactory(BaseFactory):
         # Get spectrum range
         wavenumber = self.wavenumber  # get vector of wavenumbers (shape W)
         wavenumber_calc = self.wavenumber_calc
+        woutrange = self.woutrange
+        wstep = self.params.wstep
+        truncation = self.params.truncation
+        if wavenumber_group is not None:
+            # select wavenumber grid and group
+            gridnb, groupnb = wavenumber_group
+            if groupnb == "all":  # deal with all discontinued groups together
+                wavenumber = np.hstack(wavenumber[gridnb])
+                wavenumber_calc = np.hstack(
+                    wavenumber_calc[gridnb]
+                )  # TODO : Check it's ok when using neighbour_lines
+                if self.params.neighbour_lines != 0:
+                    raise NotImplementedError
+                # woutrange = (woutrange[gridnb][0], sum(woutrange[gridnb]))  # TODO : Check it's ok when using neighbour_lines
+            else:
+                wavenumber = wavenumber[gridnb][groupnb]
+                wavenumber_calc = wavenumber_calc[gridnb][groupnb]
+                woutrange = woutrange[gridnb][groupnb]
+            wstep = self._wstep_multigrid[gridnb]
+            truncation = self._truncation_multigrid[gridnb]
+
         broadening_method = self.params.broadening_method
 
         # Get add-at method
@@ -2259,7 +2627,7 @@ class BroadenFactory(BaseFactory):
         # Next assign simple weights:
         if optimization == "min-RMS":
 
-            dv = self.params.wstep
+            dv = wstep
             dxvGi = dv / wG_dat
             dxG = self.params.dxG  # LDM user params
             dxL = self.params.dxL  # LDM user params
@@ -2387,7 +2755,7 @@ class BroadenFactory(BaseFactory):
                 LDM_ranges = {}
                 LDM_reduced = {}
                 for groupby_param, group in dgb:
-                    truncation_pts = int(self.params.truncation // self.params.wstep)
+                    truncation_pts = int(truncation // wstep)
                     # note: truncation can be unique for each point of the LDM basis
                     # (allow to have line-dependant truncation, at least as all
                     # lines with same truncation are grouped together in the LDM basis)
@@ -2443,7 +2811,7 @@ class BroadenFactory(BaseFactory):
             )
             LDM_ranges = {}
             LDM_reduced = {}
-            #  (note : could be combined faster by combining the ranges directly, rather than generating the boolean arrays?)
+            #  (note : could be made faster by combining the ranges directly, rather than generating the boolean arrays?)
             for param in all_keys:
                 b = np.zeros(len(w), dtype=bool)
                 I = np.zeros(len(w))
@@ -2520,18 +2888,24 @@ class BroadenFactory(BaseFactory):
                     Ildm_FT += np.fft.rfft(LDM[:, l, m]) * lineshape_FT
             # Back in real space:
             sumoflines_calc = np.fft.irfft(Ildm_FT)[: len(wavenumber_calc)]
-            sumoflines_calc /= self.params.wstep
+            sumoflines_calc /= wstep
 
         else:
             raise NotImplementedError(broadening_method)
 
         self.profiler.stop("LDM_convolve", "Convolve and sum on spectral range")
         # Get valid range (discard wings)
-        sumoflines = sumoflines_calc[self.woutrange[0] : self.woutrange[1]]
+        if wavenumber_group is not None and wavenumber_group[1] == "all":
+            if self.params.neighbour_lines != 0:
+                raise NotImplementedError
+            sumoflines = sumoflines_calc
+        else:
+            sumoflines = sumoflines_calc[woutrange[0] : woutrange[1]]
 
+        assert len(wavenumber) == len(sumoflines)
         return wavenumber, sumoflines
 
-    def _broaden_lines(self, df):
+    def _broaden_lines(self, df, wavenumber_group=None):
         """Divide over chunks not to process to many lines in memory at the
         same time (note that this is not where the parallelisation is done: all
         lines are processed on the same core. )
@@ -2543,51 +2917,54 @@ class BroadenFactory(BaseFactory):
             contains the ``self.params.optimization`` parameter
         df: DataFrame
             line dataframe
-
-        See _calc_lineshape for more information
+        wavenumber_group: (int, int), or ``None``
+            in sparse wavenumber mode; wavenumber grid & group to apply these lines on.
+            If ``None``, use full range.
 
         Examples
         ----------
-        s = calc_spectrum(
-            2135,
-            2170,
-            molecule="CO",
-            isotope="1",
-            pressure=3,
-            Tgas=2000,
-            mole_fraction=0.1,
-            path_length=1,
-            databank="hitemp",
-            name="Chunksize=1e7",
-            chunksize=1e7,
-            optimization = "min-RMS",
-        )
+        ::
+
+            s = calc_spectrum(
+                2135,
+                2170,
+                molecule="CO",
+                isotope="1",
+                pressure=3,
+                Tgas=2000,
+                mole_fraction=0.1,
+                path_length=1,
+                databank="hitemp",
+                name="Chunksize=1e7",
+                chunksize=1e7,
+                optimization = "min-RMS",
+            )
 
         Alternatively, you can also initialize a SpectrumFactory object and
-        include chunksize, as follows:
+        include chunksize, as follows::
 
-        sf = SpectrumFactory(
-            wavelength_min=4000,
-            wavelength_max=4500,
-            cutoff=1e-27,
-            pressure=1,
-            isotope="1,2",
-            truncation=5,
-            neighbour_lines=5,
-            path_length=0.1,
-            mole_fraction=1e-3,
-            medium="vacuum",
-            optimization=None,
-            chunksize=1e7,
-            wstep=0.001,
-            verbose=False,
-        )
-        sf.load_databank("HITEMP-CO")
+            sf = SpectrumFactory(
+                wavelength_min=4000,
+                wavelength_max=4500,
+                cutoff=1e-27,
+                pressure=1,
+                isotope="1,2",
+                truncation=5,
+                neighbour_lines=5,
+                path_length=0.1,
+                mole_fraction=1e-3,
+                medium="vacuum",
+                optimization=None,
+                chunksize=1e7,
+                wstep=0.001,
+                verbose=False,
+            )
+            sf.load_databank("HITEMP-CO")
 
-        To plot:
+        To plot::
 
-        s.plot("abscoeff")
-        plt.show()
+            s.plot("abscoeff")
+            plt.show()
 
         To iterate over the entire dataframe at once (not recommended for large molecules
         unless you have large RAM), just pass chunksize = None
@@ -2600,15 +2977,25 @@ class BroadenFactory(BaseFactory):
 
         # Init arrays
         wavenumber = self.wavenumber
+        wavenumber_calc = self.wavenumber_calc
+        if wavenumber_group is not None:
+            gridnb, groupnb = wavenumber_group
+            if groupnb == "all":  # deal with all discontinued groups together
+                wavenumber = np.hstack(wavenumber[gridnb])
+                wavenumber_calc = np.hstack(
+                    wavenumber_calc[gridnb]
+                )  # TODO : Check it's ok
+            else:
+                wavenumber = wavenumber[gridnb][groupnb]
+                wavenumber_calc = wavenumber_calc[gridnb][groupnb]
+
         # Get number of groups for memory splitting
         chunksize = self.misc.chunksize
         # Get which optimization method to use:
         optimization = self.params.optimization
 
-        if self.misc.zero_padding < 0 or self.misc.zero_padding > len(
-            self.wavenumber_calc
-        ):
-            self.misc.zero_padding = len(self.wavenumber_calc)
+        if self.misc.zero_padding < 0 or self.misc.zero_padding > len(wavenumber_calc):
+            self.misc.zero_padding = len(wavenumber_calc)
 
         try:
             if chunksize is None:
@@ -2616,7 +3003,9 @@ class BroadenFactory(BaseFactory):
                 if optimization is None:
 
                     # printing estimated time
-                    if self.verbose >= 2:
+                    if (
+                        self.verbose >= 2 and wavenumber_group is None
+                    ):  # does not work if using an adaptative grid with wavenumber groups
                         estimated_time = self.predict_time()
                         print(
                             "Estimated time for calculating broadening: {0:.2f}s on 1 CPU".format(
@@ -2624,10 +3013,21 @@ class BroadenFactory(BaseFactory):
                             )
                         )
 
-                    line_profile = self._calc_lineshape(df)  # usually the bottleneck
-                    (wavenumber, abscoeff) = self._apply_lineshape(
-                        df.S.values, line_profile, df.shiftwav.values
+                    line_profile = self._calc_lineshape(
+                        df, wavenumber_group=wavenumber_group
                     )
+                    # usually the bottleneck :
+                    if wavenumber_group is None:
+                        (wavenumber, abscoeff) = self._apply_lineshape(
+                            df.S.values, line_profile, df.shiftwav.values
+                        )
+                    else:
+                        (wavenumber, abscoeff) = self._apply_lineshape_multigrid(
+                            df.S.values,
+                            line_profile,
+                            df.shiftwav.values,
+                            wavenumber_group,
+                        )
                 elif optimization in ("simple", "min-RMS"):
                     self.reftracker.add(doi["DIT-2020"], "algorithm")
                     (
@@ -2636,7 +3036,7 @@ class BroadenFactory(BaseFactory):
                         wG,
                         wL_dat,
                         wG_dat,
-                    ) = self._calc_lineshape_LDM(df)
+                    ) = self._calc_lineshape_LDM(df, wavenumber_group=wavenumber_group)
 
                     # printing estimated time
                     if self.verbose >= 2:
@@ -2656,6 +3056,7 @@ class BroadenFactory(BaseFactory):
                         wL_dat,
                         wG_dat,
                         self.params.optimization,
+                        wavenumber_group,
                     )
                 else:
                     raise ValueError(
@@ -2684,7 +3085,7 @@ class BroadenFactory(BaseFactory):
                         "PerformanceWarning",
                     )
 
-                abscoeff = zeros_like(self.wavenumber)
+                abscoeff = zeros_like(wavenumber)
                 pb = ProgressBar(N, active=self.verbose)
 
                 if optimization is None:
@@ -2707,10 +3108,21 @@ class BroadenFactory(BaseFactory):
                         df = df.groupby(df.idx)
 
                     for i, (_, dg) in enumerate(df):
-                        line_profile = self._calc_lineshape(dg)
-                        (wavenumber, absorption) = self._apply_lineshape(
-                            dg.S.values, line_profile, dg.shiftwav.values
+                        line_profile = self._calc_lineshape(
+                            dg, wavenumber_group=wavenumber_group
                         )
+                        # usually the bottleneck :
+                        if wavenumber_group is None:
+                            (wavenumber, absorption) = self._apply_lineshape(
+                                dg.S.values, line_profile, dg.shiftwav.values
+                            )
+                        else:
+                            (wavenumber, absorption) = self._apply_lineshape_multigrid(
+                                dg.S.values,
+                                line_profile,
+                                dg.shiftwav.values,
+                                wavenumber_group,
+                            )
                         abscoeff += absorption
                         pb.update(i)
                     pb.done()
@@ -2736,7 +3148,9 @@ class BroadenFactory(BaseFactory):
                             wG_i,
                             wL_dat_i,
                             wG_dat_i,
-                        ) = self._calc_lineshape_LDM(dg)
+                        ) = self._calc_lineshape_LDM(
+                            dg, wavenumber_group=wavenumber_group
+                        )
                         (wavenumber, absorption) = self._apply_lineshape_LDM(
                             dg.S.values,
                             line_profile_LDM,
@@ -2746,6 +3160,7 @@ class BroadenFactory(BaseFactory):
                             wL_dat_i,
                             wG_dat_i,
                             self.params.optimization,
+                            wavenumber_group,
                         )
                         abscoeff += absorption
                         pb.update(i)
@@ -2773,12 +3188,25 @@ class BroadenFactory(BaseFactory):
                 )
             ) from err
 
+        assert len(wavenumber) == len(abscoeff)
         return wavenumber, abscoeff
 
-    def _broaden_lines_noneq(self, df):
+    def _broaden_lines_noneq(self, df, wavenumber_group=None):
         """Divide over chunks not to process to many lines in memory at the
         same time (note that this is not where the parallelisation is done: all
         lines are processed on the same core)
+
+        Parameters
+        ----------
+        df: DataFrame
+            line dataframe
+
+        Other Parameters
+        ----------------
+        wavenumber_group: (int, int), or ``None``
+            in sparse wavenumber mode; wavenumber grid & group to apply these lines on.
+            If ``None``, use full range.
+
 
         See _calc_lineshape for more information
         """
@@ -2790,6 +3218,12 @@ class BroadenFactory(BaseFactory):
 
         # Init arrays
         wavenumber = self.wavenumber
+        wavenumber_calc = self.wavenumber_calc
+        if wavenumber_group is not None:
+            gridnb, groupnb = wavenumber_group
+            wavenumber = wavenumber[gridnb][groupnb]
+            wavenumber_calc = wavenumber_calc[gridnb][groupnb]
+
         # Get number of groups for memory splitting
         chunksize = self.misc.chunksize
         # Get which optimization method to use:
@@ -2801,11 +3235,13 @@ class BroadenFactory(BaseFactory):
                 # Use LDM
 
                 if self.misc.zero_padding < 0 or self.misc.zero_padding > len(
-                    self.wavenumber_calc
+                    wavenumber_calc
                 ):
-                    self.misc.zero_padding = len(self.wavenumber_calc)
+                    self.misc.zero_padding = len(wavenumber_calc)
 
-                line_profile_LDM, wL, wG, wL_dat, wG_dat = self._calc_lineshape_LDM(df)
+                line_profile_LDM, wL, wG, wL_dat, wG_dat = self._calc_lineshape_LDM(
+                    df, wavenumber_group=wavenumber_group
+                )
                 # printing estimated time
                 if self.verbose >= 2:
                     estimated_time = self.predict_time()
@@ -2823,6 +3259,7 @@ class BroadenFactory(BaseFactory):
                     wL_dat,
                     wG_dat,
                     optimization,
+                    wavenumber_group,
                 )
                 (_, emisscoeff) = self._apply_lineshape_LDM(
                     df.Ei.values,
@@ -2833,6 +3270,7 @@ class BroadenFactory(BaseFactory):
                     wL_dat,
                     wG_dat,
                     optimization,
+                    wavenumber_group,
                 )
                 # Note @dev: typical results is:
                 # >>> abscoeff:
@@ -2863,13 +3301,30 @@ class BroadenFactory(BaseFactory):
                     )
                 if chunksize is None:
                     # Deal with all lines directly (usually faster)
-                    line_profile = self._calc_lineshape(df)  # usually the bottleneck
-                    (wavenumber, abscoeff) = self._apply_lineshape(
-                        df.S.values, line_profile, df.shiftwav.values
+                    line_profile = self._calc_lineshape(
+                        df, wavenumber_group=wavenumber_group
                     )
-                    (_, emisscoeff) = self._apply_lineshape(
-                        df.Ei.values, line_profile, df.shiftwav.values
-                    )
+                    # usually the bottleneck :
+                    if wavenumber_group is None:
+                        (wavenumber, abscoeff) = self._apply_lineshape(
+                            df.S.values, line_profile, df.shiftwav.values
+                        )
+                        (_, emisscoeff) = self._apply_lineshape(
+                            df.Ei.values, line_profile, df.shiftwav.values
+                        )
+                    else:
+                        (wavenumber, abscoeff) = self._apply_lineshape_multigrid(
+                            df.S.values,
+                            line_profile,
+                            df.shiftwav.values,
+                            wavenumber_group,
+                        )
+                        (_, emisscoeff) = self._apply_lineshape_multigrid(
+                            df.Ei.values,
+                            line_profile,
+                            df.shiftwav.values,
+                            wavenumber_group,
+                        )
 
                 elif is_float(chunksize):
                     # Cut lines in smaller bits for better memory handling
@@ -2879,18 +3334,32 @@ class BroadenFactory(BaseFactory):
                     # Too big may be faster but overload memory.
                     # See Performance for more information
 
-                    abscoeff = zeros_like(self.wavenumber)
-                    emisscoeff = zeros_like(self.wavenumber)
+                    abscoeff = zeros_like(wavenumber)
+                    emisscoeff = zeros_like(wavenumber)
 
                     pb = ProgressBar(N, active=self.verbose)
                     for i, (_, dg) in enumerate(df.groupby(arange(len(df)) % N)):
-                        line_profile = self._calc_lineshape(dg)
-                        (wavenumber, absorption) = self._apply_lineshape(
-                            dg.S.values, line_profile, dg.shiftwav.values
-                        )
-                        (_, emission) = self._apply_lineshape(
-                            dg.Ei.values, line_profile, dg.shiftwav.values
-                        )
+                        line_profile = self._calc_lineshape(dg, wavenumber_group)
+                        if wavenumber_group is None:
+                            (wavenumber, absorption) = self._apply_lineshape(
+                                dg.S.values, line_profile, dg.shiftwav.values
+                            )
+                            (_, emission) = self._apply_lineshape(
+                                dg.Ei.values, line_profile, dg.shiftwav.values
+                            )
+                        else:
+                            (wavenumber, absorption) = self._apply_lineshape_multigrid(
+                                dg.S.values,
+                                line_profile,
+                                dg.shiftwav.values,
+                                wavenumber_group,
+                            )
+                            (_, emission) = self._apply_lineshape_multigrid(
+                                dg.Ei.values,
+                                line_profile,
+                                dg.shiftwav.values,
+                                wavenumber_group,
+                            )
                         abscoeff += absorption  #
                         emisscoeff += emission
                         pb.update(i)
@@ -2922,6 +3391,323 @@ class BroadenFactory(BaseFactory):
         return wavenumber, abscoeff, emisscoeff
 
     # %% Generate absorption profile which includes linebroadening factors
+
+    def _interpolate_and_sum_multisparsegrid(
+        self, wavenumber, abscoeff, regular_output_grid=True
+    ):
+        """Interpolate abscoeff arrays to a common grid.
+
+        Parameters
+        ----------
+        wavenumber : list of list of arrays
+            List of wavenumber arrays for each group in each grid.
+        abscoeff : list of list of arrays
+            List of absorption coefficient arrays for each group in each grid.
+
+        Other Parameters
+        ----------------
+        regular_output_grid: bool
+            if ``True``, output grid is regularly spaced. Else, the output
+            wavenumber grid is adaptative : the narrowest grid is used for each
+            spectral range. An adaptative grid saves disk space and is recommended
+            for very large spectral ranges, however a regular grid is required
+            to apply an experimental slit function.
+            Note that regularizing the grid is possible a posteriori
+            using the Spectrum :py:meth:`~radis.spectrum.spectrum.Spectrum.resample`
+            method.
+            Default ``False``
+
+        Returns
+        -------
+        tuple of arrays
+            Tuple containing the common wavenumber grid and the interpolated
+            absorption coefficient arrays for each grid.
+        """
+
+        if regular_output_grid:
+            from radis.lbl.factory import _generate_wavenumber_range
+
+            w_common, _, _ = _generate_wavenumber_range(
+                self.input.wavenum_min,
+                self.input.wavenum_max,
+                self.params.wstep,
+                self.params.neighbour_lines,
+            )
+            # Create a common grid by linearly interpolating the absorption coefficient
+            # arrays to a set of wavenumber values that are evenly spaced between the
+            # minimum and maximum wavenumber values
+
+            # Get index of wavenumber groups in the common wavenumber array (will be used as a mask below to accelerate performances)
+            range_start_end = (
+                []
+            )  # (wavenumber_group_#1_start, wn#1_end, wn#2_start, wn#2_end, etc.)
+            for i in range(len(wavenumber)):
+                for j in range(len(wavenumber[i])):
+                    range_start_end.append(wavenumber[i][j][0])
+                    range_start_end.append(wavenumber[i][j][-1])
+            id_start_end = np.searchsorted(
+                w_common, range_start_end
+            )  # @dev 1 single search is faster than many during the loop
+
+            abscoeff_common = []
+            k = 0
+            # Loop over all grids :
+            for i in range(len(wavenumber)):
+                abscoeff_grid = np.zeros_like(w_common)
+                # Loop over all groups:
+                for j in range(len(wavenumber[i])):
+                    imin, imax = id_start_end[k : k + 2]
+                    abscoeff_grid[imin : imax + 1] += np.interp(
+                        w_common[imin : imax + 1],
+                        wavenumber[i][j],
+                        abscoeff[i][j],
+                        left=0,
+                        right=0,
+                    )
+                    k += 2
+                abscoeff_common.append(abscoeff_grid)
+
+            # HACK STOP POINT For RADIS Community paper. Plot different abscoeff for all grids:
+            if False:
+                import matplotlib.pyplot as plt
+
+                from radis.tools.plot_tools import add_ruler
+
+                fig = plt.figure()
+                add_ruler(fig)
+                plt.xlabel("Wavenumber (cm-1")
+                plt.ylabel("Abscoeff")
+                for j, (wavenumber_j, abscoeff_j) in enumerate(
+                    zip(wavenumber, abscoeff)
+                ):
+                    plt.plot(
+                        np.hstack(wavenumber_j),
+                        np.hstack(abscoeff_j),
+                        "-o",
+                        ms=4,
+                        label=f"Grid {j}",
+                    )
+                # plt.legend()
+                plt.yscale("log")
+                plt.xlim((4179.499119875524, 4191.051825655655))
+                plt.plot(
+                    w_common,
+                    np.sum(abscoeff_common, axis=0),
+                    "-",
+                    color="lightgrey",
+                    lw=3,
+                    zorder=-1,
+                    label="Sum",
+                )
+                plt.legend()
+
+            # Sum over all grids
+            wavenumber = w_common
+            abscoeff = np.sum(abscoeff_common, axis=0)
+
+        else:
+
+            def define_common_irregular_grid(wavenumber):
+                """
+                wavenumber:
+                    [0] = narrower
+                    [1] = coarser
+                    [2] = even coarser
+                    # etc
+                """
+
+                w_common = []
+                abscoeff_common = []
+
+                next_event = {}  # next start or end of a wavenumber group in this grid
+                grid_is_open = {}
+                indexes = np.zeros(len(wavenumber), dtype=np.int)
+                wavenumber_ranges = (
+                    {}
+                )  # (group1_start, group1_end), (group2_start, group2_end), etc. for each grid
+                grid_is_open = np.zeros(len(wavenumber), dtype=bool)
+                for i in range(len(wavenumber)):
+                    grid_is_open[i] = False
+                    wavenumber_ranges[i] = {}
+                    for j in range(len(wavenumber[i])):
+                        wavenumber_ranges[i][j] = (
+                            wavenumber[i][j][0],
+                            wavenumber[i][j][-1],
+                        )
+                    next_event[i] = wavenumber_ranges[i][0][
+                        0
+                    ]  # init next event with opening of first group
+
+                # 1st batch of numbers
+                # All grids are closed
+                i = 0
+                # j = 0
+
+                current_grid = min(next_event, key=next_event.get)
+                # min_current_group, max_current_group = wavenumber_ranges[current_grid].pop(indexes[current_grid])
+
+                while any(wavenumber_ranges[i] for i in wavenumber_ranges):
+                    i += 1
+                    igroup = indexes[current_grid]
+
+                    if grid_is_open[current_grid]:
+                        # Add to common grid
+                        w_common.append(wavenumber[current_grid][igroup])
+                        abscoeff_common.append(
+                            abscoeff[current_grid][igroup]
+                        )  # WIP 13/06/23 # TODO interpolate if needed, etc.
+                        # close grid :
+                        grid_is_open[current_grid] = False
+                        # print("==> BLA", i, "current grid", current_grid, "group", igroup, "IS now CLOSED")
+                        # reinitialize with next group start:
+                        if igroup + 1 in wavenumber_ranges[current_grid]:
+                            next_event[current_grid] = wavenumber_ranges[current_grid][
+                                igroup + 1
+                            ][0]
+                        else:
+                            del next_event[current_grid]
+                            # delete last group from ranges
+                            del wavenumber_ranges[current_grid][igroup]
+                            # print("==> BLA : finished next_event", current_grid)
+
+                    else:
+                        # open grid :
+                        grid_is_open[current_grid] = True
+                        # print("==> BLA", i, "current grid", current_grid, "group", igroup, "IS now OPEN")
+                        # remove group :
+                        min_current_group, max_current_group = wavenumber_ranges[
+                            current_grid
+                        ].pop(igroup)
+                        indexes[current_grid] += 1
+                        # reinitialize next event with end of group
+                        next_event[current_grid] = max_current_group
+
+                    for igrid in list(wavenumber_ranges.keys()):
+                        if not wavenumber_ranges[igrid]:
+                            del wavenumber_ranges[igrid]
+                            # print("==> BLA : finished grid", igrid)
+
+                    # Draw next grid event :
+                    if next_event:
+                        current_grid = min(next_event, key=next_event.get)
+
+                return w_common, abscoeff_common
+
+            w_common, abscoeff_common = define_common_irregular_grid(wavenumber)
+            wavenumber = np.hstack(w_common)
+            abscoeff = np.hstack(abscoeff_common)
+            raise NotImplementedError
+
+        return wavenumber, abscoeff
+
+    def _interpolate_and_sum_multigrid(
+        self, wavenumber, abscoeff, regular_output_grid=True
+    ):
+        """Interpolate abscoeff arrays to a common grid.
+        (this version doesn't accept different groups')
+
+        Parameters
+        ----------
+        wavenumber : list of list of arrays
+            List of wavenumber arrays for each group in each grid.
+        abscoeff : list of list of arrays
+            List of absorption coefficient arrays for each group in each grid.
+
+        Other Parameters
+        ----------------
+        regular_output_grid: bool
+            if ``True``, output grid is regularly spaced. Else, the output
+            wavenumber grid is adaptative : the narrowest grid is used for each
+            spectral range. An adaptative grid saves disk space and is recommended
+            for very large spectral ranges, however a regular grid is required
+            to apply an experimental slit function.
+            Note that regularizing the grid is possible a posteriori
+            using the Spectrum :py:meth:`~radis.spectrum.spectrum.Spectrum.resample`
+            method.
+            Default ``False``
+
+        Returns
+        -------
+        tuple of arrays
+            Tuple containing the common wavenumber grid and the interpolated
+            absorption coefficient arrays for each grid.
+        """
+
+        if regular_output_grid:
+            from radis.lbl.factory import _generate_wavenumber_range
+
+            w_common, _, _ = _generate_wavenumber_range(
+                self.input.wavenum_min,
+                self.input.wavenum_max,
+                self.params.wstep,
+                self.params.neighbour_lines,
+            )
+            # Create a common grid by linearly interpolating the absorption coefficient
+            # arrays to a set of wavenumber values that are evenly spaced between the
+            # minimum and maximum wavenumber values
+
+            # Get index of wavenumber groups in the common wavenumber array (will be used as a mask below to accelerate performances)
+            range_start_end = (
+                []
+            )  # (wavenumber_group_#1_start, wn#1_end, wn#2_start, wn#2_end, etc.)
+            for i in range(len(wavenumber)):
+                range_start_end.append(wavenumber[i][0])
+                range_start_end.append(wavenumber[i][-1])
+
+            abscoeff_common = []
+            # Loop over all grids :
+            for i in range(len(wavenumber)):
+                abscoeff_grid = np.interp(
+                    w_common,
+                    wavenumber[i],
+                    abscoeff[i],
+                    left=0,
+                    right=0,
+                )
+                abscoeff_common.append(abscoeff_grid)
+
+            # HACK STOP POINT For RADIS Community paper. Plot different abscoeff for all grids:
+            if False:
+                import matplotlib.pyplot as plt
+
+                from radis.tools.plot_tools import add_ruler
+
+                fig = plt.figure()
+                add_ruler(fig)
+                plt.xlabel("Wavenumber (cm-1")
+                plt.ylabel("Abscoeff")
+                for j, (wavenumber_j, abscoeff_j) in enumerate(
+                    zip(wavenumber, abscoeff)
+                ):
+                    plt.plot(
+                        np.hstack(wavenumber_j),
+                        np.hstack(abscoeff_j),
+                        "-o",
+                        ms=4,
+                        label=f"Grid {j}",
+                    )
+                # plt.legend()
+                plt.yscale("log")
+                plt.xlim((4179.499119875524, 4191.051825655655))
+                plt.plot(
+                    w_common,
+                    np.sum(abscoeff_common, axis=0),
+                    "-",
+                    color="lightgrey",
+                    lw=3,
+                    zorder=-1,
+                    label="Sum",
+                )
+                plt.legend()
+
+            # Sum over all grids
+            wavenumber = w_common
+            abscoeff = np.sum(abscoeff_common, axis=0)
+
+        else:
+            raise NotImplementedError
+
+        return wavenumber, abscoeff
 
     def _calc_broadening(self):
         """Loop over all lines, calculate lineshape, and returns the sum of
@@ -2966,7 +3752,70 @@ class BroadenFactory(BaseFactory):
                 + " may be inverted"
             )
 
-        (wavenumber, abscoeff) = self._broaden_lines(df)
+        if not self._multisparsegrid:
+            (wavenumber, abscoeff) = self._broaden_lines(df)
+        elif (
+            self.params.optimization in ["simple", "min-RMS"]
+            and self.params.sparse_ldm == True
+        ):
+            # spectrum is split over multiple, discontinued spectral grids.
+            # To leverage the sparse LDM algorithm, treat all discontinued groups
+            # of a same wavenumber grid together
+            wavenumber, abscoeff = [], []
+            assert len(self._ix_ranges) > 0
+            # loop over all grids :
+            for grid_number_j, grid_ranges in enumerate(self._ix_ranges):
+                # loop over all grid-ranges:
+                # Note : 1st grid is the most resolved, last grid is the coarsest
+                (wavenumber_j, abscoeff_j) = self._broaden_lines(
+                    df,  # all lines appear in every grid
+                    (grid_number_j, "all"),
+                )
+                wavenumber.append(wavenumber_j)
+                abscoeff.append(abscoeff_j)
+
+            self.profiler.start("interpolate_multigrids", 3)
+
+            # Interpolate abscoeff arrays to a common grid
+            wavenumber, abscoeff = self._interpolate_and_sum_multigrid(
+                wavenumber, abscoeff
+            )
+            self.profiler.stop(
+                "interpolate_multigrids", "Interpolated multiple, discontinued grids"
+            )
+
+        else:
+            # spectrum is split over multiple, discontinued spectral grids
+            # Deal with all of them
+            wavenumber, abscoeff = [], []
+            assert len(self._ix_ranges) > 0
+            # loop over all grids :
+            for grid_number_j, grid_ranges in enumerate(self._ix_ranges):
+                # loop over all grid-ranges:
+                # Note : 1st grid is the most resolved, last grid is the coarsest
+                wavenumber_j = []
+                abscoeff_j = []
+                for wavenumber_group_i, lines_range_i in enumerate(grid_ranges):
+                    (wavenumber_i, abscoeff_i) = self._broaden_lines(
+                        df.iloc[lines_range_i[0] : lines_range_i[-1] + 1],
+                        (grid_number_j, wavenumber_group_i),
+                    )
+                    wavenumber_j.append(wavenumber_i)
+                    abscoeff_j.append(abscoeff_i)
+                wavenumber.append(wavenumber_j)
+                abscoeff.append(abscoeff_j)
+
+            self.profiler.start("interpolate_multisparsegrids", 3)
+
+            # Interpolate abscoeff arrays to a common grid
+            wavenumber, abscoeff = self._interpolate_and_sum_multisparsegrid(
+                wavenumber, abscoeff
+            )
+            self.profiler.stop(
+                "interpolate_multisparsegrids",
+                "Interpolated multiple, discontinued grids",
+            )
+
         self.profiler.stop("calc_line_broadening", "Calculated line broadening")
 
         return wavenumber, abscoeff
@@ -3016,7 +3865,27 @@ class BroadenFactory(BaseFactory):
                 + " may be inverted"
             )
 
-        (wavenumber, abscoeff, emisscoeff) = self._broaden_lines_noneq(df)
+        if self._multisparsegrid:
+            # spectrum is split over multiple, discontinued spectral grids
+            # Deal with all of them
+            wavenumber, abscoeff, emisscoeff = [], [], []
+            assert len(self._ix_ranges) > 0
+            for wavenumber_group_i, lines_range_i in enumerate(self._ix_ranges):
+                (wavenumber_i, abscoeff_i, emisscoeff_i) = self._broaden_lines_noneq(
+                    df.iloc[lines_range_i[0] : lines_range_i[-1]], wavenumber_group_i
+                )
+                wavenumber.append(wavenumber_i)
+                abscoeff.append(abscoeff_i)
+                emisscoeff.append(emisscoeff_i)
+            wavenumber, abscoeff, emisscoeff = (
+                np.hstack(wavenumber),
+                np.hstack(abscoeff),
+                np.hstack(emisscoeff),
+            )
+        else:
+            (wavenumber, abscoeff, emisscoeff) = self._broaden_lines_noneq(
+                df, wavenumber_group_i
+            )
 
         self.profiler.stop("calc_line_broadening", "Calculated line broadening")
         return wavenumber, abscoeff, emisscoeff
@@ -3146,6 +4015,10 @@ class BroadenFactory(BaseFactory):
                 "Pseudo_continuum not needed anymore as RADIS is getting so fast🔥🔥🔥. This feature will be removed in future versions.",
                 DeprecationWarning,
             )
+            if self._multisparsegrid:
+                raise NotImplementedError(
+                    "Pseudo continuum not implemented with sparse wavenumber grid"
+                )
 
             self.profiler.start(
                 "calc_pseudo_continuum", 2, "... Calculating pseudo continuum"

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -2188,9 +2188,12 @@ class Spectrum(object):
         var: variable (`absorbance`, `transmittance`, `transmittance_noslit`, `xsection`, etc.)
             For full list see :py:meth:`~radis.spectrum.spectrum.Spectrum.get_vars()`.
             If ``None``, plot the first thing in the Spectrum. Default ``None``.
-        wunit: ``'default'``, ``'nm'``, ``'cm-1'``, ``'nm_vac'``,
+        wunit: ``'default'``, ``'nm'``, ``'cm-1'``, ``'nm_vac'``, or tuple of these
             wavelength air, wavenumber, or wavelength vacuum. If ``'default'``,
             Spectrum :py:meth:`~radis.spectrum.spectrum.Spectrum.get_waveunit` is used.
+            To use multiple units add two::
+
+                wunit=["nm", "cm-1"]  # will add a secondary axis in `cm-1`
         Iunit: unit for variable
             if `default`, default unit for quantity `var` is used.
             for radiance, one can use per wavelength (~ `W/m2/sr/nm`) or
@@ -2251,6 +2254,11 @@ class Spectrum(object):
         from radis.misc.plot import fix_style, set_style
 
         # Get variable
+        if isinstance(wunit, list) or isinstance(wunit, tuple):
+            wunit, wunit_2nd_axis = wunit
+        else:
+            wunit_2nd_axis = None
+
         x, y, wunit, Iunit = self.get(
             var, wunit=wunit, Iunit=Iunit, return_units="as_str"
         )
@@ -2338,7 +2346,8 @@ class Spectrum(object):
             ax.legend()
         fix_style()
 
-        from radis.phys.convert import cm2nm, div_safe, nm2cm
+        if wunit_2nd_axis:
+            from radis.phys.convert import cm2nm, cm2nm_air, div_safe, nm2cm, nm_air2cm
 
         if ax.child_axes != []:
             pass
@@ -2353,8 +2362,6 @@ class Spectrum(object):
                     "top", functions=(div_safe(nm2cm), div_safe(cm2nm))
                 )
             else:
-                from radis.phys.convert import cm2nm_air, nm_air2cm
-
                 secx = ax.secondary_xaxis(
                     "top", functions=(div_safe(nm_air2cm), div_safe(cm2nm_air))
                 )

--- a/radis/test/misc/test_arrays.py
+++ b/radis/test/misc/test_arrays.py
@@ -21,6 +21,7 @@ from radis.misc.arrays import (  # add_at,
     find_first,
     find_nearest,
     first_nonnan_index,
+    get_overlapping_ranges,
     is_sorted,
     is_sorted_backward,
     last_nonnan_index,
@@ -364,6 +365,44 @@ def test_non_zero_values_around(*args, **kwargs):
     assert (
         boolean_array_from_ranges(L, 8)
         == np.array([0, 0, 1, 1, 0, 1, 0, 1], dtype=bool)
+    ).all()
+
+
+def test_overalapping_ranges(*args, **kwargs):
+    """Test :py:func:`radis.misc.arrays.overlapping_ranges`
+    For a given set of lines & lineshape width, make sure the function returns
+    the correct ranges of overlapping lines, for 3 conditons :
+        - all lines containe within a same blcok
+        - 2 distinct blocks
+        - 1 single line"""
+
+    # All lines contained within a same block :
+    # print(get_overlapping_ranges(wav_positions=np.array([2300, 2305]), half_width=50.0))
+    assert (
+        get_overlapping_ranges(wav_positions=np.array([2300, 2305]), half_width=50.0)
+        == np.array([(0, 1)])
+    ).all()
+
+    # 1 single line
+    # print(get_overlapping_ranges(wav_positions=np.array([2300]), half_width=50.0))
+    assert (
+        get_overlapping_ranges(wav_positions=np.array([2300]), half_width=50.0)
+        == np.array([(0, 0)])
+    ).all()
+
+    # print(get_overlapping_ranges(wav_positions=np.array([2300, 2305, 2400]), half_width=1.0))
+
+    # 2 distinct blocks :
+    # print(
+    #     get_overlapping_ranges(
+    #         wav_positions=np.array([2300, 2301, 2305, 2500, 2505]), half_width=50.0
+    #     )
+    # )
+    assert (
+        get_overlapping_ranges(
+            wav_positions=np.array([2300, 2301, 2305, 2500, 2505]), half_width=50.0
+        )
+        == np.array([(0, 2), (3, 4)])
     ).all()
 
 


### PR DESCRIPTION
<!-- Please be sure to check out our developer guide,
https://radis.readthedocs.io/en/latest/dev/developer.html -->

New clean implementation of #606 





# Multigrid support in RADIS 

## tl;dr 
- [x] First proof-of-concept of multiple wavenumber grids (different wstep) without DIT  (`optimisation=None`) & regular grid output : 4x speed-up in CO HITRAN example
- [ ] Some accuracy issues at the junction between grids needs to be fixed
- [ ] Same with irregular grid output  (saves memory and shall be even faster than the regular grid) 
- [x] First proof-of-concept of multiple wavenumber grids with [sparse or not] DIT/DCS  (`optimization=simple`)
- [x] add non-equilibrium version 
- [ ] Refactor all code using proper parameters (for instance, remove `self._multisparsegrid` and other hidden variables)
- [ ] Optimize the `(wstep, truncation)` parameters of each grid (and the number of grids. Maybe 2 are enough)
- [x] add compiled (Cython/numba) versions of legacy convolve & aggregate method (`optimization=None`)
- [ ] Make sure it works with neigbour-lines>0

This will be particularly useful for "isolated-lines" spectra, i.e. : 

- Atomic spectra (#601 #384 )
- Very low pressure molecular spectra 

**👉 Combined with DIT (for "dense spectra") and sparse-DIT (for "dense-by-part spectra") it should make RADIS the ultimate, fastest code for every kind of spectra.** 

---

Other changes: 
- [x] do not generate all spectral quantities by-default . Only abscoeff is computed. Saves 1-2s on very large spectra.
- [ ] vectorize `get_overlapping_ranges`

(nice)
- [ ] re-add a PRECOMPUTE_ALL_QUANTITIES parameter to disallow the calculation of other-than-abscoeff parametesr https://github.com/erwanp/radis/commit/47bc34838275507b1df9fec90d08920cd6e1b11f
- [ ] re-add 2nd axis behavior https://github.com/erwanp/radis/commit/307feb2a6c1cfe3320a87625696bcc63e812eb2b
---


# Old Benchmark in #606 


# Case 1. Full-range calculations, low number of lines

## 1.1 With Optimization=None (no LDM) (HITRAN) : x4

CO-HITRAN, 500 - 10,000 cm-1

Code : see at the bottom




---


- [x] From afar, we get a good accuracy and 4x speed-up in this example    (**Fig 0.**)

![image](https://github.com/radis/radis/assets/16088743/28cab028-d81c-4b4e-9691-cb2b715f4bee)

Here are the performance details : 

```python
s_single.print_perf_profile()
```

```
1 grid : 4.1s profiler :
    spectrum_calculation      4.210s ████████████████
        check_line_databank              0.000s 
        reinitialize                     0.002s 
            copy_database                    0.000s 
            memory_usage_warning             0.002s 
            reset_population                 0.000s 
        scaled_eq_linestrength           0.003s 
        applied_linestrength_cutoff      0.001s 
        calc_lineshift                   0.001s 
        calc_hwhm                        0.005s 
        generate_wavenumber_arrays       0.012s 
        calc_line_broadening             3.830s ██████████████
            init_vectors                     0.090s 
            voigt_broadening                 3.317s ████████████
            init_vectors_apply               0.059s 
            get_matching_line                0.000s 
            aggregate__lines                 0.300s █
            others                           0.063s 
        calc_other_spectral_quan         0.267s █
        generate_spectrum_obj            0.073s 
        others                           0.079s 
```

```python
s_multi.print_perf_profile()
```

```
Multi grid : 1.1s profiler :
    spectrum_calculation      1.183s ████████████████
        check_line_databank              0.000s 
        reinitialize                     0.002s 
            copy_database                    0.000s 
            memory_usage_warning             0.002s 
            reset_population                 0.000s 
        scaled_eq_linestrength           0.002s 
        applied_linestrength_cutoff      0.002s 
        calc_lineshift                   0.001s 
        calc_hwhm                        0.005s 
        generate_wavenumber_arrays       0.037s 
        calc_line_broadening             0.858s ███████████
            init_vectors                      0.098s █
            voigt_broadening                  0.125s █
            init_vectors_apply_multigrid      0.014s 
            get_matching_line_multigrid       0.027s 
            aggregate__lines_multigrid        0.405s █████
            interpolate_multigrids            0.076s █
            others                            0.113s █
        calc_other_spectral_quan         0.209s ██
        generate_spectrum_obj            0.060s 
        others                           0.121s █
```
We see a x25 speed-up in the Voigt broadening part, and an overall x4 speedup in the full Lineshape broadening step (including aggregation of lines & interpolation of grids).

- [ ] (WIP) Looking up close, there are still some accuracy problems at the junction between the different grids . Working on it !

(**Fig.1** 13/08/23): 
![image](https://github.com/radis/radis/assets/16088743/f5cbbff8-934a-43c3-ae6c-eafc050f1853)


- [x] the different grids for the points above: 
Grids are automatically refined around the line centers . Each grid is regular (i.e. constant wstep) which (will) allow the use of the DIT Algorithm.  (**Fig 2.**)

![image](https://github.com/radis/radis/assets/16088743/5236061a-c28d-4349-b7bd-306ce6b8a2b4)

Same, zoomed-out  to see the multiple (3) and discontinued (multi-groups) grids  (**Fig 3.**)

![image](https://github.com/radis/radis/assets/16088743/6b719548-3f5f-4f81-a747-1626db7490c9)


- [x] a last image showing the component of the absorption coefficient from each wavenumber grid   (**Fig 4.**) : 

![image](https://github.com/radis/radis/assets/16088743/7454eb03-b3e7-4967-8905-ad469bff2951)






--- 

Code: 
```python

import numpy as np

import radis
radis.config["DEBUG_MODE"] = True

from radis import calc_spectrum
s, sf = calc_spectrum(
                # wavenum_min=3800,
                wavenum_min=500,
                # wavenum_max=4500,
                wavenum_max=10000,
                Tgas=300,
                path_length=0.1,
                molecule='CO',
                mole_fraction=0.2,
                isotope=1,
                pressure=1e-5,
                wstep=0.004,
                databank='hitran'  , # or 'hitemp'
                optimization=None,  
                # also measure interpolation time
                return_factory=True,
                save_memory=False,
                )
self = sf

#%%

# #Test:
import matplotlib.pyplot as plt 


# %%  
# keep only few lines
# sf.df0= sf.df0.iloc[150:153]
# keep only so many lines
# sf.df0 = sf.df0.iloc[np.arange(len(sf.df0))[::10]]

#%% 


# NOW compute a Spectrum
import radis
radis.config["MULTI_SPARSE_GRID"] = False
s_single = sf.eq_spectrum(700)
s_single.plot('abscoeff', yscale='log', lw=4, nfig=10)


# %%

# NOW compute a Spectrum
import radis
radis.config["MULTI_SPARSE_GRID"] = True
s_multi = sf.eq_spectrum(700)


s_multi.plot('abscoeff', yscale='log', nfig=10, lw=2)

# %% Plot the graphs


from radis.lbl.factory import _generate_wavenumber_range_sparse
wstep_calc_narrow = self.params.wstep
truncation = self.params.truncation
neighbour_lines = self.params.neighbour_lines

plt.figure()
plt.xlabel("Wavenumber (cm-1)")
plt.ylabel("Wstep")
plt.yscale("log")
wavenumber_arrays = []

for i, (wstep, lineshape_half_width) in enumerate(zip(self._wstep_multigrid, 
                                                      self._truncation_multigrid)):
    print("wstep", wstep)
    print("lineshape_half_width", lineshape_half_width)
    (
        wavenumber,
        wavenumber_calc,
        woutrange,
        ix_ranges,
    ) = _generate_wavenumber_range_sparse(
        self.input.wavenum_min,
        self.input.wavenum_max,
        wstep,
        neighbour_lines,
        self.df1.wav,
        lineshape_half_width,
    )    
    wavenumber_arrays.append(wavenumber)
    
    from publib import keep_color
    for wavenumber_group in wavenumber: # iterate over all wavenumber groups : 
        plt.plot(wavenumber_group, np.ones_like(wavenumber_group)*wstep, "-o", ms=3)
        if wavenumber_group[-1] != wavenumber[-1][-1]: # not the last element : 
            keep_color()
    # Plot line centers :
    for line in self.df1.wav:
        plt.axvline(line,color='k', alpha=0.05, zorder=-1)
plt.title("3 grids & Line centers\n")



# %% plot diff
s_multi.name = f"Multi grid : {s_multi.c['calculation_time']:.1f}s"
s.name = f"{s.c['calculation_time']:.1f}s"
s_single.name = f"1 grid : {s_single.c['calculation_time']:.1f}s"

from radis import plot_diff
plot_diff(s_single, s_multi, "abscoeff", yscale="log", method="diff")

```










---

## 1.2 With Sparse LDM (HITRAN)  : x4

@dcmvdbekerom  same calculations with LDM now  : x6 speed-up ; and x10 if looking only at the line broadening part    (**Fig 5.**)

![image](https://github.com/radis/radis/assets/16088743/d3677bc1-c9cc-4a2a-921c-eb6bad329928)

Code : same as above, with the following changes:  

```python

radis.config["SPARSE_WAVERANGE"] = True
(...)

s, sf = calc_spectrum( ...
                optimization="simple")
sf.params.broadening_method = "voigt"

```


```python
s_single.print_perf_profile()
```
```
1 grid, LDM : 3.4s profiler :
    spectrum_calculation      3.423s ████████████████
        check_line_databank              0.000s 
        reinitialize                     0.002s 
            copy_database                    0.000s 
            memory_usage_warning             0.001s 
            reset_population                 0.000s 
        scaled_eq_linestrength           0.003s 
        applied_linestrength_cutoff      0.002s 
        calc_lineshift                   0.002s 
        calc_hwhm                        0.004s 
        generate_wavenumber_arrays       0.012s 
        calc_line_broadening             3.148s ██████████████
            precompute_LDM_lineshapes        1.224s █████
            LDM_Initialized_vectors          0.000s 
            LDM_closest_matching_line        0.009s 
            LDM_Distribute_lines             1.484s ██████
            LDM_convolve                     0.427s █
            others                           0.006s 
        calc_other_spectral_quan         0.185s 
        generate_spectrum_obj            0.053s 
        others                           0.017s 
```

```python
s_multi.print_perf_profile()
```
```
Multi grid, LDM : 0.6s profiler :
    spectrum_calculation      0.641s ████████████████
        check_line_databank              0.000s 
        reinitialize                     0.002s 
            copy_database                    0.000s 
            memory_usage_warning             0.001s 
            reset_population                 0.000s 
        scaled_eq_linestrength           0.003s 
        applied_linestrength_cutoff      0.002s 
        calc_lineshift                   0.001s 
        calc_hwhm                        0.005s 
        generate_wavenumber_arrays       0.026s 
        calc_line_broadening             0.326s ████████
            precompute_LDM_lineshapes        0.039s 
            LDM_Initialized_vectors          0.001s 
            LDM_closest_matching_line        0.002s 
            LDM_Distribute_lines             0.108s ██
            LDM_convolve                     0.049s █
            interpolate_multigrids           0.125s ███
            others                           0.002s 
        calc_other_spectral_quan         0.206s █████
        generate_spectrum_obj            0.059s █
        others                           0.015s 

```

- [ ] still a few accuracy problems, will be fixed later !


## 1.3 With Sparse LDM (HITEMP)  : x4


Note : the example above was ran with CO HITRAN, with limited number of lines. For CO HITEMP below we see that the multigrid accelerates the LDM_convolve step, but does not change the LDM_Distribute_lines step (obviously)




```python
s, sf = calc_spectrum(...
                databank='hitemp'  , 
                ) 
# ... 
s_single.print_perf_profile()
```
```
1 grid, LDM : 9.0s profiler :
    spectrum_calculation      9.040s ████████████████
        check_line_databank             0.000s 
        reinitialize                    0.003s 
            copy_database                   0.002s 
            memory_usage_warning            0.001s 
            reset_population                0.000s 
        scaled_eq_linestrength          0.004s 
        calc_lineshift                  0.006s 
        calc_hwhm                       0.013s 
        generate_wavenumber_arrays      0.011s 
        calc_line_broadening            8.750s ███████████████
            precompute_LDM_lineshapes       2.259s ███
            LDM_Initialized_vectors         0.000s 
            LDM_closest_matching_line       0.037s 
            LDM_Distribute_lines            3.857s ██████
            LDM_convolve                    2.551s ████
            others                          0.047s 
        calc_other_spectral_quan        0.186s 
        generate_spectrum_obj           0.055s 
        others                          0.057s 
```

```python
s_multi.print_perf_profile()
```
```
Multi grid, LDM : 5.0s profiler :
    spectrum_calculation      5.039s ████████████████
        check_line_databank             0.000s 
        reinitialize                    0.003s 
            copy_database                   0.002s 
            memory_usage_warning            0.001s 
            reset_population                0.000s 
        scaled_eq_linestrength          0.004s 
        calc_lineshift                  0.007s 
        calc_hwhm                       0.014s 
        generate_wavenumber_arrays      0.151s 
        calc_line_broadening            4.603s ██████████████
            precompute_LDM_lineshapes       0.079s 
            LDM_Initialized_vectors         0.017s 
            LDM_closest_matching_line       0.045s 
            LDM_Distribute_lines            3.581s ███████████
            LDM_convolve                    0.697s ██
            interpolate_multigrids          0.148s 
            others                          0.035s 
        calc_other_spectral_quan        0.184s 
        generate_spectrum_obj           0.053s 
        others                          0.054s 

```


## 1.4 With (non-sparse) LDM (HITEMP) : x4

CO HITEMP version  (same as above)

```
1 grid, LDM : 229.1s profiler :
    spectrum_calculation      229.241s ████████████████
        check_line_databank             0.043s 
        reinitialize                    0.105s 
            copy_database                   0.049s 
            memory_usage_warning            0.056s 
            reset_population                0.000s 
        scaled_eq_linestrength          0.036s 
        calc_lineshift                  0.022s 
        calc_hwhm                       0.043s 
        generate_wavenumber_arrays      0.023s 
        calc_line_broadening            228.314s ███████████████
            precompute_LDM_lineshapes       2.570s 
            LDM_Initialized_vectors         0.000s 
            LDM_closest_matching_line       0.041s 
            LDM_Distribute_lines            0.714s 
            LDM_convolve                    222.757s ███████████████
            others                          2.232s 
        calc_other_spectral_quan        0.500s 
        generate_spectrum_obj           0.096s 
        others                          2.290s 
Multi grid, LDM : 56.5s profiler :
    spectrum_calculation      56.593s ████████████████
        check_line_databank             0.004s 
        reinitialize                    0.081s 
            copy_database                   0.053s 
            memory_usage_warning            0.028s 
            reset_population                0.000s 
        scaled_eq_linestrength          0.026s 
        calc_lineshift                  0.034s 
        calc_hwhm                       0.039s 
        generate_wavenumber_arrays      0.694s 
        calc_line_broadening            55.458s ███████████████
            precompute_LDM_lineshapes         9.239s ██
            LDM_Initialized_vectors           0.050s 
            LDM_closest_matching_line         0.320s 
            LDM_Distribute_lines              0.471s 
            LDM_convolve                      43.955s ████████████
            interpolate_multisparsegrids      0.218s 
            others                            1.204s 
        calc_other_spectral_quan        0.189s 
        generate_spectrum_obj           0.058s 
        others                          1.215s 

```

Acceleration by a factor of 5  (but non-sparse LDM is still very slow for such a large range)



---

# Case 2 (Appendix) - Adaptative grid in worse conditions

## 2.1 (non-sparse) LDM in dense regions : x1

Adaptative grid is developed for isolated-lines spectra. Below we deal with a very dense spectral region, i.E. the 4.2 µm (2300 cm-1) band of CO2 

```python

import radis
radis.config["SPARSE_WAVERANGE"] = False

# First calculation also makes sure everything is properly calculated & cached
from radis import calc_spectrum
s, sf = calc_spectrum(
                wavenum_min=1700,
                wavenum_max=2500,
                Tgas=2000,
                cutoff=0,
                path_length=0.1,
                molecule='CO2',
                isotope="all",
                pressure=1e-5,
                wstep=0.004,
                databank='hitemp'  , 
                optimization="simple",
                return_factory=True,
                save_memory=False,
                warnings={"AccuracyError":"ignore"}
                )
self = sf
self.params.broadening_method = "voigt"

#%%
# NOW compute Spectra
radis.config["MULTI_SPARSE_GRID"] = False
s_single = sf.eq_spectrum(2000)

# NOW compute a Spectrum
radis.config["MULTI_SPARSE_GRID"] = True
s_multi = sf.eq_spectrum(2000)


# %% plot diff
s_multi.name = f"Multi grid, LDM : {s_multi.c['calculation_time']:.1f}s"
s.name = f"{s.c['calculation_time']:.1f}s"
s_single.name = f"1 grid, LDM : {s_single.c['calculation_time']:.1f}s"
from radis import plot_diff
plot_diff(s_single, s_multi, "abscoeff", yscale="log", method="diff")

#%%
s_single.print_perf_profile()
s_multi.print_perf_profile()

```

![image](https://github.com/radis/radis/assets/16088743/7de03369-6e45-4d97-9b83-4c81c81bbe38)


Adaptative grid doesn't accelerate the calculations, but it doesn't slow it down neither



```
1 grid, LDM : 5.8s profiler :
    spectrum_calculation      5.854s ████████████████
        check_line_databank             0.002s 
        reinitialize                    0.082s 
            copy_database                   0.080s 
            memory_usage_warning            0.002s 
            reset_population                0.000s 
        scaled_eq_linestrength          0.209s 
        calc_lineshift                  0.264s 
        calc_hwhm                       0.467s █
        generate_wavenumber_arrays      0.005s 
        calc_line_broadening            4.776s █████████████
            precompute_LDM_lineshapes       0.627s █
            LDM_Initialized_vectors         0.000s 
            LDM_closest_matching_line       0.321s 
            LDM_Distribute_lines            0.247s 
            LDM_convolve                    3.528s █████████
            others                          0.052s 
        calc_other_spectral_quan        0.025s 
        generate_spectrum_obj           0.014s 
        others                          0.061s 
Multi grid, LDM : 5.5s profiler :
    spectrum_calculation      5.522s ████████████████
        check_line_databank             0.003s 
        reinitialize                    0.102s 
            copy_database                   0.099s 
            memory_usage_warning            0.003s 
            reset_population                0.000s 
        scaled_eq_linestrength          0.246s 
        calc_lineshift                  0.323s 
        calc_hwhm                       0.465s █
        generate_wavenumber_arrays      0.505s █
        calc_line_broadening            3.837s ███████████
            precompute_LDM_lineshapes         0.086s 
            LDM_Initialized_vectors           0.000s 
            LDM_closest_matching_line         1.046s ███
            LDM_Distribute_lines              0.545s █
            LDM_convolve                      2.027s █████
            interpolate_multisparsegrids      0.020s 
            others                            0.112s 
        calc_other_spectral_quan        0.021s 
        generate_spectrum_obj           0.013s 
        others                          0.119s 
```
