### PR TITLE
Fix H2O HITEMP download issue

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ include radis/db/molparam.txt
 include radis/db/molparams_extra.json
 include radis/default_radis.json
 recursive-include radis/db *.json
+include radis/db/H2O/*.htm
 
 # Exclude test files and directories
 global-exclude */test/*


### PR DESCRIPTION
<!-- Please be sure to check out our developer guide,
https://radis.readthedocs.io/en/latest/dev/developer.html -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address the inability to download the H₂O line list from HITEMP (at least when using ExoJAX) because the required *.htm files are missing from the source distribution. Adding `include radis/db/H2O/*.htm` to MANIFEST.in bundles these files and resolves the issue.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #781

Note: this PR addresses only one of the two issues that PR #800 attempted to solve.