### PR TITLE
Replace numpy.trapz with scipy.integrate.trapezoid (#846)

### DIFF
--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -67,7 +67,8 @@ import numpy as np
 from numba import float64, jit
 from numpy import arange, exp
 from numpy import log as ln
-from numpy import pi, sin, sqrt, trapz, zeros, zeros_like
+from numpy import pi, sin, sqrt, zeros, zeros_like
+from scipy.integrate import trapezoid
 from scipy.signal import oaconvolve
 
 import radis
@@ -815,12 +816,12 @@ def voigt_lineshape(w_centered, hwhm_lorentz, hwhm_voigt, jit=True):
     # Normalization
     #    integral = wv*(1.065+0.447*(wl/wv)+0.058*(wl/wv)**2)
     # ... approximation used by Whiting, equation (7)
-    # ... performance: ~ 6µs vs ~84µs for np.trapz(lineshape, w_centered) ):
+    # ... performance: ~ 6µs vs ~84µs for trapezoid(lineshape, w_centered) ):
     # ... But not used because:
     # ... - it may yield wrong results when the broadening range is not refined enough
     # ... - it is defined for wavelengths only. Here we may have wavenumbers as well
 
-    integral = np.trapz(lineshape, w_centered, axis=0)
+    integral = trapezoid(lineshape, w_centered, axis=0)
 
     # Normalize
     lineshape /= integral
@@ -1507,7 +1508,7 @@ class BroadenFactory(BaseFactory):
         # ... Normalization should not be needed as Lorentzian is normalized already
         # ... but that's only with a good enough wavestep
         # ... Here we compute the integral to check the error that is made
-        area = trapz(lineshape.T, x=wbroad_centered.T)
+        area = trapezoid(lineshape.T, x=wbroad_centered.T)
         err = abs((area - 1))
         if self.warnings and self.warnings["CollisionalBroadeningWarning"] != "ignore":
             if (err > self.misc.warning_broadening_threshold).any():
@@ -1573,7 +1574,7 @@ class BroadenFactory(BaseFactory):
         # ... normalisation not really needed as the analytical function is normalized
         # ... but that's only with a good enough wavestep
         # ... Here we compute the integral to check the error that is made
-        area = trapz(lineshape.T, x=wbroad_centered.T)
+        area = trapezoid(lineshape.T, x=wbroad_centered.T)
         err = abs((area - 1))
         if self.warnings and self.warnings["GaussianBroadeningWarning"] != "ignore":
             # In a "performance" mode (vs "safe" mode), these warnings would be disabled
@@ -1764,7 +1765,7 @@ class BroadenFactory(BaseFactory):
             line_profile = np.empty_like(pressure_profile)  # size (B, N)
             for i, (x, y) in enumerate(zip(pressure_profile.T, gaussian_profile.T)):
                 line_profile[:, i] = np.convolve(x, y, "same")
-            line_profile = line_profile / trapz(line_profile.T, x=wbroad.T)  # normalize
+            line_profile = line_profile / trapezoid(line_profile.T, x=wbroad.T)  # normalize
             self.profiler.stop("convolve_l_g", "Convolved both profiles")
             # ... Note that normalization should not be needed as broadening profiles
             # ... are created normalized already. However, we do normalize to reduce
@@ -1886,7 +1887,7 @@ class BroadenFactory(BaseFactory):
                 line_profile_LDM[l] = {}
                 for m in range(len(wL)):
                     lineshape = np.convolve(IL[m], IG[l], mode="same")
-                    lineshape /= np.trapz(lineshape, x=wbroad_centered)
+                    lineshape /= trapezoid(lineshape, x=wbroad_centered)
                     line_profile_LDM[l][m] = lineshape
 
         elif broadening_method == "fft":
@@ -1983,7 +1984,7 @@ class BroadenFactory(BaseFactory):
         pressure_profile = self._collisional_lineshape(dg, wbroad_centered)
         gaussian_profile = self._gaussian_lineshape(dg, wbroad_centered)
         line_profile = np.convolve(pressure_profile, gaussian_profile, "same")
-        line_profile /= trapz(line_profile.T, x=wbroad.T)  # normalize
+        line_profile /= trapezoid(line_profile.T, x=wbroad.T)  # normalize
 
         # Plot!
         set_style()
@@ -3148,11 +3149,11 @@ class BroadenFactory(BaseFactory):
 
                 if __debug__:
                     printdbg(
-                        f"Intensity of k continuum: {np.trapz(k_continuum, wavenumber_calc)}\n"
+                        f"Intensity of k continuum: {trapezoid(k_continuum, wavenumber_calc)}\n"
                         + f"Intensity of lines removed: {df_weak_lines.S.sum()}"
                     )
                     printdbg(
-                        f"Intensity of j continuum: {np.trapz(j_continuum, wavenumber_calc)}\n"
+                        f"Intensity of j continuum: {trapezoid(j_continuum, wavenumber_calc)}\n"
                         + f"Intensity of lines removed: {df_weak_lines.Ei.sum()}"
                     )
 
@@ -3163,7 +3164,7 @@ class BroadenFactory(BaseFactory):
 
                 if __debug__:
                     printdbg(
-                        f"Intensity of continuum: {np.trapz(k_continuum, wavenumber_calc)}\n"
+                        f"Intensity of continuum: {trapezoid(k_continuum, wavenumber_calc)}\n"
                         + f"Intensity of lines removed: {df_weak_lines.S.sum()}"
                     )
 

--- a/radis/misc/arrays.py
+++ b/radis/misc/arrays.py
@@ -43,6 +43,7 @@ import numpy as np
 from numba import bool_, float64, int32, int64
 from numpy import hstack
 from scipy.interpolate import interp1d
+from scipy.integrate import trapezoid
 
 # Normalize
 
@@ -134,9 +135,9 @@ def array_allclose(a, b, rtol=1e-5, atol=1e-8, equal_nan=True):
 
 
 def nantrapz(I, w, dx=1.0, axis=-1):
-    """Returns :py:func:`~numpy.trapz` (I, w) discarding nan."""
+    """Returns :py:func:`~numpy.trapezoid` (I, w) discarding nan."""
     b = ~np.isnan(I)
-    return np.trapz(I[b], w[b], dx=dx, axis=axis)
+    return trapezoid(I[b], w[b], dx=dx, axis=axis)
 
 
 # %%

--- a/radis/misc/signal.py
+++ b/radis/misc/signal.py
@@ -18,9 +18,10 @@ import math
 
 import numpy as np
 import scipy.linalg as LA
-from numpy import abs, isnan, linspace, nan, trapz, zeros_like
+from numpy import abs, isnan, linspace, nan, zeros_like
 from scipy.interpolate import splev, splrep
 from scipy.linalg import solveh_banded
+from scipy.integrate import trapezoid
 
 from radis.misc.arrays import (
     anynan,
@@ -194,8 +195,8 @@ def resample(
     # Check energy conservation:
 
     # ... calculate energy
-    energy0 = abs(trapz(vector[b], x=xspace[b]))
-    energy_new = abs(trapz(vector_new[b_new], x=xspace_new[b_new]))
+    energy0 = abs(trapezoid(vector[b], x=xspace[b]))
+    energy_new = abs(trapezoid(vector_new[b_new], x=xspace_new[b_new]))
     if energy_new == 0:  # deal with particular case of energy = 0
         if energy0 == 0:
             energy_ratio = 1

--- a/radis/phys/units.py
+++ b/radis/phys/units.py
@@ -7,7 +7,7 @@
 """
 
 import warnings
-
+from scipy.integrate import trapezoid
 
 def Unit(st, *args, **kwargs):
     """Radis evaluation of an unit, using :py:class:`~astropy.units.Unit`
@@ -153,8 +153,8 @@ def convert_emi2cm(j_nm, wavenum, Iunit0, Iunit):
 
         w_nm, j_nm = s.get('emisscoeff', 'nm', 'mW/cm2/sr/nm')
         w_cm, j_cm = s.get('emisscoeff', 'cm', 'mW/cm2/sr/cm-1')
-        print(trapz(y_nm, x_nm))
-        print(trapz(y_cm, x_cm))
+        print(trapezoid(y_nm, x_nm))
+        print(trapezoid(y_cm, x_cm))
 
     Both integrals are to be the same
     """
@@ -164,8 +164,8 @@ def convert_emi2cm(j_nm, wavenum, Iunit0, Iunit):
     # Convert ''mW/cm3/sr/nm' to 'mW/cm3/sr/cm-1'
     j_cm = j_nm * 1e7 / wavenum**2
     # note that we discard the - sign.
-    # This means that one of the integrals `trapz(j_nm, wavelen)` or
-    # `trapz(j_cm, wavenum)` will be < 0 as they are sorted in opposite order.
+    # This means that one of the integrals `trapezoid(j_nm, wavelen)` or
+    # `trapezoid(j_cm, wavenum)` will be < 0 as they are sorted in opposite order.
     # But both plots look alright
 
     # Convert to whatever was wanted
@@ -208,8 +208,8 @@ def convert_emi2nm(j_cm, wavenum, Iunit0, Iunit):
     # Convert 'mW/cm3/sr/cm-1' to 'mW/cm3/sr/nm'
     j_nm = j_cm * 1e-7 * wavenum**2
     # note that we discard the - sign.
-    # This means that one of the integrals `trapz(L_nm, wavelen)` or
-    # `trapz(L_cm, wavenum)` will be < 0 as they are sorted in opposite order.
+    # This means that one of the integrals `trapezoid(L_nm, wavelen)` or
+    # `trapezoid(L_cm, wavenum)` will be < 0 as they are sorted in opposite order.
     # But both plots look alright
 
     # Convert to whatever was wanted
@@ -262,8 +262,8 @@ def convert_rad2cm(
 
         x_nm, y_nm = s.get('radiance_noslit', 'nm', 'mW/cm2/sr/nm')
         x_cm, y_cm = s.get('radiance_noslit', 'cm', 'mW/cm2/sr/cm-1')
-        print(trapz(y_nm, x_nm))
-        print(trapz(y_cm, x_cm))
+        print(trapezoid(y_nm, x_nm))
+        print(trapezoid(y_cm, x_cm))
 
     Both integrals are to be the same
     """
@@ -273,8 +273,8 @@ def convert_rad2cm(
     # Convert ''mW/cm2/sr/nm' to 'mW/cm2/sr/cm-1'
     l_cm = l_nm * 1e7 / wavenum**2
     # note that we discard the - sign.
-    # This means that one of the integrals `trapz(L_nm, wavelen)` or
-    # `trapz(L_cm, wavenum)` will be < 0 as they are sorted in opposite order.
+    # This means that one of the integrals `trapezoid(L_nm, wavelen)` or
+    # `trapezoid(L_cm, wavenum)` will be < 0 as they are sorted in opposite order.
     # But both plots look alright
 
     # Convert to whatever was wanted
@@ -323,8 +323,8 @@ def convert_rad2nm(
     # Convert 'mW/cm2/sr/cm-1' to 'mW/cm2/sr/nm'
     l_nm = l_cm * 1e-7 * wavenum**2
     # note that we discard the - sign.
-    # This means that one of the integrals `trapz(L_nm, wavelen)` or
-    # `trapz(L_cm, wavenum)` will be < 0 as they are sorted in opposite order.
+    # This means that one of the integrals `trapezoid(L_nm, wavelen)` or
+    # `trapezoid(L_cm, wavenum)` will be < 0 as they are sorted in opposite order.
     # But both plots look alright
 
     # Convert to whatever was wanted

--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -33,6 +33,7 @@ from radis.misc.basics import compare_dict, compare_lists
 from radis.misc.curve import curve_distance, curve_divide, curve_substract
 from radis.spectrum.spectrum import Spectrum
 from radis.spectrum.utils import cast_waveunit, format_xlabel, make_up, make_up_unit
+from scipy.integrate import trapezoid
 
 # %% ======================================================================
 # External functions
@@ -412,14 +413,14 @@ def get_residual_integral(
 
     ::
 
-        res = trapz(I2-I1, w1) / trapz(I1, w1)
+        res = trapezoid(I2-I1, w1) / trapezoid(I1, w1)
 
     Note: when the considered variable is ``transmittance`` or ``transmittance_noslit``,
     the *upper* integral is used (up to 1) to normalize the integral difference
 
     ::
 
-        res = trapz(I2-I1, w1) / trapz(1-I1, w1)
+        res = trapezoid(I2-I1, w1) / trapezoid(1-I1, w1)
 
     Parameters
     ----------
@@ -445,7 +446,7 @@ def get_residual_integral(
     For I1, I2, the values of 'var' in s1 and s2, respectively, residual
     is calculated as::
 
-        res = trapz(I2-I1, w1) / trapz(I1, w1)
+        res = trapezoid(I2-I1, w1) / trapezoid(I1, w1)
 
     0 values for I1 yield nans except if I2 = I1 = 0
 
@@ -477,11 +478,11 @@ def get_residual_integral(
         w1, I1 = w1[~b], I1[~b]
 
     if var in ["transmittance", "transmittance_noslit"]:
-        norm = 1 - np.trapz(I1, w1)
+        norm = 1 - trapezoid(I1, w1)
     else:
-        norm = np.trapz(I1, w1)
+        norm = trapezoid(I1, w1)
 
-    return np.abs(np.trapz(dI, wdiff)) / norm
+    return np.abs(trapezoid(dI, wdiff)) / norm
 
 
 def get_default_units(

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -57,7 +57,7 @@ import numpy as np
 import pandas as pd
 import plotly.express as px
 from numpy import abs, diff
-
+from scipy.integrate import trapezoid
 from radis.db.references import doi
 
 # from radis.lbl.base import print_conditions
@@ -4734,7 +4734,7 @@ class Spectrum(object):
 
         for index, line in enumerate(g_fit_list):
             if isinstance(line, models.Voigt1D):
-                area = np.abs(np.trapz(y_fit_list[index], w_fit))  # slow, but accurate
+                area = np.abs(trapezoid(y_fit_list[index], w_fit))  # slow, but accurate
             elif isinstance(line, models.Gaussian1D):
                 area = line.amplitude * line.stddev * np.sqrt(2 * np.pi)
             elif isinstance(line, models.Lorentz1D):

--- a/radis/test/spectrum/test_operations.py
+++ b/radis/test/spectrum/test_operations.py
@@ -14,6 +14,7 @@ from radis.spectrum.compare import get_diff, plot_diff
 from radis.spectrum.operations import add_constant, crop, multiply, offset, sub_baseline
 from radis.test.utils import getTestFile
 from radis.tools.database import load_spec
+from scipy.integrate import trapezoid
 
 
 @pytest.mark.fast
@@ -171,7 +172,7 @@ def test_multiplyAndAddition(verbose=True, plot=False, *args, **kwargs):
     s_ter = multiply(multiply(s, 50), 1 / 50)
     #    plot_diff(s_ter, s_5)
     diff = get_diff(s_ter, s, "radiance")
-    ratio = abs(np.trapz(diff[1], x=diff[0]) / s.get_integral("radiance"))
+    ratio = abs(trapezoid(diff[1], x=diff[0]) / s.get_integral("radiance"))
     assert ratio < 1e-10
 
 

--- a/radis/test/spectrum/test_spectrum.py
+++ b/radis/test/spectrum/test_spectrum.py
@@ -24,6 +24,7 @@ import numpy as np
 import pytest
 from numpy import allclose, linspace
 
+from scipy.integrate import trapezoid
 from radis.phys.convert import nm2cm
 from radis.spectrum import Spectrum, calculated_spectrum
 
@@ -334,7 +335,7 @@ def test_emisscoeff_conversion(verbose=True, *args, **kwargs):
 
     # compare. Integral should be the same
     assert (I_nm != I_cm).all()
-    assert abs(np.trapz(I_nm, w_nm) / np.trapz(I_cm, -w_cm) - 1) < 0.001
+    assert abs(trapezoid(I_nm, w_nm) / trapezoid(I_cm, -w_cm) - 1) < 0.001
 
 
 def test_rescaling_function(verbose=True, *args, **kwargs):

--- a/radis/test/tools/test_slit.py
+++ b/radis/test/tools/test_slit.py
@@ -34,6 +34,8 @@ from radis.misc.printer import printm
 from radis.phys.convert import dcm2dnm, dnm2dcm
 from radis.phys.units import is_homogeneous
 
+from scipy.integrate import trapezoid
+
 # from radis.lbl import SpectrumFactory
 from radis.spectrum.models import calculated_spectrum, transmittance_spectrum
 from radis.spectrum.spectrum import _cut_slices
@@ -438,7 +440,7 @@ def test_slit_energy_conservation(
     P = s.get_power(unit="mW/cm2/sr")
     s.apply_slit(0.5, norm_by="area")
     w, I = s.get("radiance", wunit="nm", Iunit="mW/cm2/sr/nm")
-    Pc = abs(np.trapz(I[~np.isnan(I)], x=w[~np.isnan(I)]))  # mW/cm2/sr
+    Pc = abs(trapezoid(I[~np.isnan(I)], x=w[~np.isnan(I)]))  # mW/cm2/sr
 
     b = np.isclose(P, Pc, 3e-2)
 

--- a/radis/tools/slit.py
+++ b/radis/tools/slit.py
@@ -46,9 +46,10 @@ from warnings import warn
 import numpy as np
 from numpy import exp
 from numpy import log as ln
-from numpy import sqrt, trapz
+from numpy import sqrt
 from scipy.interpolate import splev, splrep
 from scipy.signal import oaconvolve
+from scipy.integrate import trapezoid
 
 from radis.misc.arrays import anynan, evenly_distributed, evenly_distributed_fast
 from radis.misc.basics import is_float
@@ -383,7 +384,7 @@ def get_slit_function(
         # ... get unit
         # Normalize
         if norm_by == "area":  # normalize by the area
-            #        I_slit /= np.trapz(I_slit, x=w_slit)
+            #        I_slit /= trapezoid(I_slit, x=w_slit)
             Iunit = f"1/{unit}"
         elif norm_by == "max":  # set maximum to 1
             Iunit = ""
@@ -410,7 +411,7 @@ def get_slit_function(
                 energy_threshold=energy_threshold,
                 print_conservation=True,
             )
-            scale_slit = trapz(Iold, wold) / trapz(Islit, wslit)  # [unit/return_unit]
+            scale_slit = trapezoid(Iold, wold) / trapezoid(Islit, wslit)  # [unit/return_unit]
             renormalize = True
         elif return_unit == "nm" and unit == "cm-1":  # wavenumber > wavelength
             wold, Iold = wslit, Islit
@@ -421,7 +422,7 @@ def get_slit_function(
                 energy_threshold=energy_threshold,
                 print_conservation=True,
             )
-            scale_slit = trapz(Iold, wold) / trapz(Islit, wslit)  # [unit/return_unit]
+            scale_slit = trapezoid(Iold, wold) / trapezoid(Islit, wslit)  # [unit/return_unit]
             renormalize = True
         else:  # return_unit == unit
             renormalize = False
@@ -433,7 +434,7 @@ def get_slit_function(
             if __debug__:
                 printdbg("get_slit_function: renormalize")
             if norm_by == "area":  # normalize by the area
-                Islit /= abs(np.trapz(Islit, x=wslit))
+                Islit /= abs(trapezoid(Islit, x=wslit))
                 Iunit = f"1/{return_unit}"
             elif norm_by == "max":  # set maximum to 1
                 Islit /= abs(np.max(Islit))
@@ -837,7 +838,7 @@ def get_effective_FWHM(w, I):
 
     Imax = I.max()
 
-    area = abs(np.trapz(I, w))
+    area = abs(trapezoid(I, w))
 
     return area / Imax
 
@@ -980,7 +981,7 @@ def normalize_slit(w_slit, I_slit, norm_by="area"):
     # ---------
 
     if norm_by == "area":  # normalize by the area
-        I_slit = I_slit / abs(np.trapz(I_slit, x=w_slit))
+        I_slit = I_slit / abs(trapezoid(I_slit, x=w_slit))
     elif norm_by == "max":  # set maximum to 1
         I_slit = I_slit / abs(np.max(I_slit))
     elif norm_by is None:
@@ -1210,7 +1211,7 @@ def plot_slit(
         label=(
             f"FWHM: {FWHM:.3f} {plot_unit}\n"
             f"Eff. FWHM: {FWHM_eff:.3f} {plot_unit}\n"
-            f"Area: {abs(np.trapz(I, x=w)):.3f}"
+            f"Area: {abs(trapezoid(I, x=w)):.3f}"
         ),
     )
 
@@ -1456,8 +1457,8 @@ def import_experimental_slit(
 
     # Normalize
     if norm_by == "area":  # normalize by the area
-        #        I_slit /= np.trapz(I_slit, x=w_slit)
-        I_slit /= abs(np.trapz(I_slit, x=w_slit))
+        #        I_slit /= trapezoid(I_slit, x=w_slit)
+        I_slit /= abs(trapezoid(I_slit, x=w_slit))
         Iunit = f"1/{wunit}"
     elif norm_by == "max":  # set maximum to 1
         I_slit /= abs(np.max(I_slit))
@@ -1581,7 +1582,7 @@ def triangular_slit(
 
     # Normalize
     if norm_by == "area":  # normalize by the area
-        I /= np.trapz(I, x=w)
+        I /= trapezoid(I, x=w)
         Iunit = f"1/{wunit}"
     elif norm_by == "max":  # set maximum to 1
         I /= np.max(I)
@@ -1717,7 +1718,7 @@ def trapezoidal_slit(
 
     # Normalize
     if norm_by == "area":  # normalize by the area
-        I /= np.trapz(I, x=w)
+        I /= trapezoid(I, x=w)
         Iunit = f"1/{wunit}"
     elif norm_by == "max":  # set maximum to 1
         I /= np.max(I)
@@ -1831,7 +1832,7 @@ def gaussian_slit(
 
     # Normalize
     if norm_by == "area":  # normalize by the area
-        I /= np.trapz(I, x=w)
+        I /= trapezoid(I, x=w)
         Iunit = f"1/{wunit}"
     elif norm_by == "max":  # set maximum to 1
         I /= np.max(I)


### PR DESCRIPTION
### Description

This pull request replaces all usages of the deprecated `numpy.trapz` function with `scipy.integrate.trapezoid`. This change addresses deprecation warnings during CI checks and aligns the codebase with current best practices for numerical integration.

All import statements and function calls have been updated accordingly. Function behavior and output remain unchanged.

Fixes #846 

