### PR TITLE
Fix HITEMP detection by checking urlname.lower()

### DIFF
--- a/radis/api/dbmanager.py
+++ b/radis/api/dbmanager.py
@@ -413,7 +413,7 @@ class DatabaseManager(object):
                 )
 
             # Download file with requests
-            if "hitemp" in self.local_databases:
+            if "hitemp" in urlname.lower():
                 # Get session from HITEMP API
                 from radis.api.hitempapi import login_to_hitran
 


### PR DESCRIPTION
<!-- Please be sure to check out our developer guide,
https://radis.readthedocs.io/en/latest/dev/developer.html -->

### Description
<!-- Provide a general description of what your pull request does. -->

Fixes a bug in HITEMP download.   
Related to #834.

I encountered the following error when trying HITEMP download:
```
Traceback (most recent call last):
  File ".../transmission.py", line 89, in <module>
    mdb = MdbHitemp(path, nu_grid, gpu_transfer=False, isotope=1, engine="vaex")
  File ".../exojax/database/api.py", line 776, in __init__
    self.download_and_parse(download_urls, download_files)
  File ".../radis/api/dbmanager.py", line 508, in download_and_parse
    download_and_parse_one_file(urlname, local_file, Ndownload)
  File ".../radis/api/dbmanager.py", line 416, in download_and_parse_one_file
    if "hitemp" in self.local_databases:
TypeError: argument of type 'PosixPath' is not iterable
```

This happens because `self.local_databases` is a `Path` object, not a string or list.

Changing `self.local_databases` to `str(self.local_databases)` would resolve the immediate error,  
but using `urlname.lower()` seems more appropriate for detecting HITEMP.
