### PR TITLE
Fixing `plot_specutils_processing.py` not running with `specutils>=2.0`

### DIFF
--- a/.github/workflows/python-package-master.yml
+++ b/.github/workflows/python-package-master.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest
+          python -m pip install pytest specutils
           pip install -e .
       - name: Fast tests with pytest
         env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest
+          python -m pip install pytest specutils
           pip install -e .
       - name: Fast tests with pytest
         env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -43,10 +43,10 @@ jobs:
           HITRAN_EMAIL: ${{ secrets.HITRAN_EMAIL }}
           HITRAN_PASSWORD: ${{ secrets.HITRAN_PASSWORD }}
         run: |
-          pytest -m "fast and not needs_db_CDSD_HITEMP_PCN and not needs_db_CDSD_HITEMP and not needs_db_CDSD_HITEMP_PC and not needs_gpu and not needs_specutils" --durations=10
+          pytest -m "fast and not needs_db_CDSD_HITEMP_PCN and not needs_db_CDSD_HITEMP and not needs_db_CDSD_HITEMP_PC and not needs_gpu" --durations=10
       - name: Long tests with pytest
         env:
           HITRAN_EMAIL: ${{ secrets.HITRAN_EMAIL }}
           HITRAN_PASSWORD: ${{ secrets.HITRAN_PASSWORD }}
         run: |
-          pytest -m "not fast and not needs_cuda and not download_large_databases and not needs_db_CDSD_HITEMP and not needs_db_CDSD_HITEMP_PCN and not needs_db_CDSD_HITEMP_PC and not needs_db_HITEMP_CO2_DUNHAM and not needs_db_HITEMP_CO_DUNHAM and not needs_gpu and not needs_specutils" --durations=10
+          pytest -m "not fast and not needs_cuda and not download_large_databases and not needs_db_CDSD_HITEMP and not needs_db_CDSD_HITEMP_PCN and not needs_db_CDSD_HITEMP_PC and not needs_db_HITEMP_CO2_DUNHAM and not needs_db_HITEMP_CO_DUNHAM and not needs_gpu" --durations=10

--- a/environment.yml
+++ b/environment.yml
@@ -32,7 +32,7 @@ dependencies:
 - scipy>=1.4.0
 - seaborn   # other matplotlib themes
 - termcolor  # terminal colors
-- specutils<2 #Incompatibility with specutils 2.0.0, readthedocs not passing the tests, notably plot_specutils_processing.py, see #834
+- specutils  # spectroscopic data handling
 - pip
 - pip:
   - cryptography

--- a/examples/2_Experimental_spectra/plot_specutils_processing.py
+++ b/examples/2_Experimental_spectra/plot_specutils_processing.py
@@ -39,9 +39,19 @@ spectrum = s_exp.to_specutils()
 
 from specutils import SpectralRegion
 from specutils.manipulation import noise_region_uncertainty
+from specutils.spectra import Spectrum1D
 
 noise_region = SpectralRegion(2010.5 / u.cm, 2009.5 / u.cm)
 spectrum = noise_region_uncertainty(spectrum, noise_region)
+if not isinstance(spectrum, Spectrum1D):
+    spectrum = Spectrum1D(
+        flux=spectrum.flux,
+        spectral_axis=spectrum.spectral_axis,
+        uncertainty=getattr(spectrum, "uncertainty", None),
+        wcs=getattr(spectrum, "wcs", None),
+        mask=getattr(spectrum, "mask", None),
+        meta=getattr(spectrum, "meta", None),
+    )
 
 
 # %%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ docs = [
     "sphinx-gallery",  # for documentation examples gallery
     "lmfit",  # for documentation examples
     "pytest",  # Sphinx autodoc also parses test suite
-    "specutils,  # spectroscopic data handling
+    "specutils",  # spectroscopic data handling
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ docs = [
     "sphinx-gallery",  # for documentation examples gallery
     "lmfit",  # for documentation examples
     "pytest",  # Sphinx autodoc also parses test suite
-    "specutils<2.0",  # spectroscopic data handling, <2.0 see #834
+    "specutils,  # spectroscopic data handling
 ]
 
 [tool.setuptools]

--- a/radis/test/spectrum/test_spectrum.py
+++ b/radis/test/spectrum/test_spectrum.py
@@ -571,7 +571,7 @@ def test_argmax_argmin(*args, **kwargs):
     assert np.isclose(s.take("abscoeff").argmin(value_only=True), 2144.215391118094)
 
 
-@pytest.mark.needs_specutils
+@pytest.mark.fast
 def test_fitting_lineshape(verbose=False, plot=False, *args, **kwargs):
     """Test :py:meth:`~radis.spectrum.spectrum.Spectrum.fit_model``"""
 

--- a/radis/test/spectrum/test_spectrum_io.py
+++ b/radis/test/spectrum/test_spectrum_io.py
@@ -9,7 +9,6 @@ from radis import Spectrum, get_residual, spectrum_test
 
 
 @pytest.mark.fast
-@pytest.mark.needs_specutils
 def test_specutils_io(verbose=True, plot=False, *args, **kwargs):
     """Test Radis/specutils  interface in particular when dealing with wavelengths
 


### PR DESCRIPTION
This is addressing issue #835. After version 2.0.0 `specutils` uses a single `Spectrum` class for most operations, and some functions like `noise_region_uncertainty` return `specutils.spectra.spectrum.Spectrum`. `radis.Spectrum.from_specutils` asserts `Spectrum1D` which breaks this.

Changes made: If the input is not a `Spectrum1D`, it wraps it into a `Spectrum1D` using the same data. 

Note: Since `Spectrum1D` is now deprecated in `specutils>=2.0`, it may be preferable to update the assertion in `radis/spectrum/spectrum.py` to also accept `Spectrum` directly.