### PR TITLE
[hot fix] Restriction to numpy<2 for vaex compatibility

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,8 @@ dependencies:
 - joblib  # for parallel loading of SpecDatabase
 - lmfit  # for new fitting modules
 - matplotlib
-- numpy
+- numpy ; python_version > '3.10' # numpy 2.0 is not compatible with vaex-hdf5, see https://github.com/vaexio/vaex/issues/2468
+- numpy<2 ; python_version < '3.11'
 - numba  # just-in-time compiler
 - pandas
 - plotly>=2.5.1  # for line survey HTML output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ dependencies = [
     "matplotlib",  # for plotting
     "mpldatacursor",  # interactive data cursors for matplotlib
     "numba",  # just-in-time compiler
-    "numpy",  # numerical computations
     "pandas",  # data manipulation and analysis
     "peakutils",  # peak detection and fitting
     "periodictable",  # periodic table data
@@ -86,6 +85,8 @@ dependencies = [
     "termcolor",  # terminal colors
     "toml",
     "tqdm",  # for progress bars
+    'numpy;  python_version > "3.10"', # numpy 2.0 is not compatible with vaex-hdf5, see https://github.com/vaexio/vaex/issues/2468
+    'numpy<2;  python_version < "3.11"', # numpy 2.0 is not compatible with vaex-hdf5, see https://github.com/vaexio/vaex/issues/2468
     'vaex-core; python_version < "3.11"',  # out-of-core dataframes
     'vaex-hdf5; python_version < "3.11"',  # HDF5 support for vaex
     'vaex-viz; python_version < "3.11"',  # visualization for vaex


### PR DESCRIPTION
The `vaex-core` package is now compatible with `numpy 2.0` which is great news! More info in https://github.com/vaexio/vaex/pull/2449 and https://github.com/vaexio/vaex/pull/2466
Thus, in an empty environment, `numpy 2.0` is now installed with `radis`. However, `vaex-hdf5` is still not compatible with `numpy 2.0` and this incompatibility is not in the requirements of `vaex-hdf5`. This hot fix imposes `numpy < 2.0` to make sure vaex-hdf5 still works.