### PR TITLE
fix: prevent incorrect conversion of molecular ions like NO+ to atomic notation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,8 +12,7 @@ channels:
 - conda-forge
 - nodefaults  # no defaults packages (only conda-forge)
 dependencies:
-- python=3.11
-- spyder
+- python
 - astropy>=4.3.1  # Unit aware calculations
 - astroquery>=0.4.6  # to fetch HITRAN databases
 - beautifulsoup4>=4.10.0 # parse ExoMol website


### PR DESCRIPTION
<!-- Please be sure to check out our developer guide,
https://radis.readthedocs.io/en/latest/dev/developer.html -->

### Description
This pull request fixes a bug where the `to_conventional_name` function was incorrectly converting molecular ions like `'NO+'` to atomic notation `'NO_II'`. This caused `calc_spectrum(mole_fraction={'NO+':1})` to fail to produce spectra for molecular ions.

The fix adds validation to only treat species with `+` as atomic ions if the base part is a valid atomic symbol. Molecular ions now remain unchanged, while atomic ions still convert correctly.

This pull request is to address ...

The bug where molecular ions like 'NO+' were incorrectly converted to atomic notation 'NO_II' in the to_conventional_name function, which prevented spectrum calculations for molecular ions."


Fixes #871 
