### PR TITLE
Update hitranapi.py

### DIFF
--- a/radis/api/hitranapi.py
+++ b/radis/api/hitranapi.py
@@ -1861,7 +1861,7 @@ class HITRANDatabaseManager(DatabaseManager):
             local_file = local_file[0]
 
         wmin = 0
-        wmax = 40000
+        wmax = 1e10
 
         def download_all_hitran_isotopes(molecule, directory, extra_params):
             """Blindly try to download all isotopes 1 - 9 for the given molecule


### PR DESCRIPTION
### Description
When plotting spectra from the hitran database, some lines at very small wavenumbers are missing currently, compared to spectra obtain from hapi. This is because radis.api.hitranapi has a fixed limit at >1 cm^-1. This limit is not necessary, hapi.fetch will accept 0. Therefore I suggest changing this limit to 0.
