### PR TITLE
fix: Resolve recalc_gpu plotting error caused by padded GPU output

### DIFF
--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -6504,6 +6504,11 @@ class Spectrum(object):
         self.conditions["NwL"] = iter_N_L
         self.conditions["NwG"] = iter_N_G
 
+        # Trim GPU output to match wavespace size
+        if "wavespace" in self._q:
+            n = len(self._q["wavespace"])
+            abscoeff = abscoeff[:n]
+
         # TODO : refactor this function and the update() mechanism. Ensure conditions are correct.
         for k in list(self._q.keys()):  # reset all quantities
             if k in ["wavespace", "wavelength", "wavenumber"]:


### PR DESCRIPTION
<!-- Please be sure to check out our developer guide,
https://radis.readthedocs.io/en/latest/dev/developer.html -->

### Description
This PR fixes a plotting error in GPU mode when neighbour_lines is enabled.
gpu_app.iterate() returns a padded absorption array larger than the user-defined wavespace.
Trimming the GPU output to the wavespace length restores consistent array sizes and fixes plotting.

This PR Fixes issue #840