### PR TITLE
TST: Add 'fetch_test' marker to isolate slow download tests

### DIFF
--- a/radis/test/io/test_exomol.py
+++ b/radis/test/io/test_exomol.py
@@ -57,7 +57,7 @@ def test_exomol_parsing_functions(verbose=True, *args, **kwargs):
             for dat in lookup_databases:
                 assert dat in known_databases
 
-
+@pytest.mark.fetch_test
 @pytest.mark.needs_connection
 @pytest.mark.needs_HITRAN_credentials
 def test_calc_exomol_vs_hitemp(verbose=True, plot=False, *args, **kwargs):

--- a/radis/test/io/test_hitemp.py
+++ b/radis/test/io/test_hitemp.py
@@ -25,7 +25,7 @@ except ImportError:
 
 # pytestmark = pytest.mark.random_order(disabled=True)
 
-
+@pytest.mark.fetch_test
 @pytest.mark.needs_connection
 @pytest.mark.fast
 @pytest.mark.needs_HITRAN_credentials
@@ -89,7 +89,7 @@ def test_relevant_files_filter():
         "02_00750-01000_HITEMP2010.zip",
     ]
 
-
+@pytest.mark.fetch_test
 @pytest.mark.needs_HITRAN_credentials
 @pytest.mark.needs_connection
 def test_fetch_hitemp_OH_pytables(verbose=True, *args, **kwargs):
@@ -132,7 +132,7 @@ def test_fetch_hitemp_OH_pytables(verbose=True, *args, **kwargs):
         engine="pytables",
     )
 
-
+@pytest.mark.fetch_test
 @pytest.mark.needs_connection
 @pytest.mark.needs_HITRAN_credentials
 @pytest.mark.skipif(isinstance(vaex, NotInstalled), reason="Vaex not available")
@@ -233,7 +233,7 @@ def test_fetch_hitemp_OH_vaex(verbose=True, *args, **kwargs):
 #     assert len(local_files) == 1
 #     assert basename(local_files[0]).startswith("CO2-02_02500-03000_HITEMP2010.")
 
-
+@pytest.mark.fetch_test
 @pytest.mark.needs_connection
 @pytest.mark.needs_HITRAN_credentials
 def test_fetch_hitemp_partial_download_CO2(verbose=True, *args, **kwargs):
@@ -268,7 +268,7 @@ def test_read_wav_index():
     ]
     assert all_pairs == expected_pairs
 
-
+@pytest.mark.fetch_test
 @pytest.mark.needs_connection
 @pytest.mark.needs_HITRAN_credentials
 @pytest.mark.download_large_databases
@@ -322,7 +322,7 @@ def test_fetch_hitemp_all_molecules(molecule, verbose=True, *args, **kwargs):
 
     assert len(df) == Nlines
 
-
+@pytest.mark.fetch_test
 @pytest.mark.needs_connection
 @pytest.mark.needs_HITRAN_credentials
 @pytest.mark.download_large_databases
@@ -353,7 +353,7 @@ def test_fetch_hitemp_all_molecules_2010_version(
 
     assert f"HITEMP-{molecule}-2010" in getDatabankList()
 
-
+@pytest.mark.fetch_test
 @pytest.mark.fast
 @pytest.mark.needs_connection
 @pytest.mark.needs_HITRAN_credentials
@@ -412,7 +412,7 @@ def test_partial_loading(*args, **kwargs):
     )
     assert set(df.iso.unique()) == {1, 2}
 
-
+@pytest.mark.fetch_test
 @pytest.mark.fast
 @pytest.mark.needs_connection
 @pytest.mark.skipif(isinstance(vaex, NotInstalled), reason="Vaex not available")
@@ -460,7 +460,7 @@ def test_partial_loading_vaex(*args, **kwargs):
     assert df.wav.max() <= wmax2
     assert set(df.iso.unique()) == {2, 3}
 
-
+@pytest.mark.fetch_test
 @pytest.mark.fast
 @pytest.mark.needs_connection
 @pytest.mark.needs_HITRAN_credentials
@@ -493,7 +493,7 @@ def test_calc_hitemp_spectrum(*args, **kwargs):
 
     return
 
-
+@pytest.mark.fetch_test
 @pytest.mark.fast
 @pytest.mark.needs_connection
 @pytest.mark.needs_HITRAN_credentials
@@ -526,7 +526,7 @@ def test_calc_hitemp_spectrum_2010_version(*args, **kwargs):
         verbose=False,
     )
 
-
+@pytest.mark.fetch_test
 @pytest.mark.needs_connection
 @pytest.mark.needs_HITRAN_credentials
 def test_calc_hitemp_CO_noneq(verbose=True, *args, **kwargs):
@@ -569,7 +569,7 @@ def test_calc_hitemp_CO_noneq(verbose=True, *args, **kwargs):
         databank="HITEMP-CO",  # registered in ~/radis.json
     )
 
-
+@pytest.mark.fetch_test
 @pytest.mark.needs_connection
 @pytest.mark.needs_HITRAN_credentials
 @pytest.mark.download_large_databases

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,8 @@ markers =
     needs_db_HITEMP_CO2_DUNHAM: requires the HITEMP_CO2_DUNHAM line database with defined in ~/radis.json (deactivated by default. Select with '-m "needs_db_HITEMP_CO2_DUNHAM"')
     needs_db_HITEMP_CO_DUNHAM: requires the HITEMP_CO_DUNHAM line database with defined in ~/radis.json (deactivated by default. Select with '-m "needs_db_HITEMP_CO_DUNHAM"')
     deprecated: used for features that are not employed anymore (e.g. continuum)
-addopts = -m "not needs_cuda and not download_large_databases and not needs_db_CDSD_HITEMP and not needs_db_CDSD_HITEMP_PCN and not needs_db_CDSD_HITEMP_PC and not needs_db_HITEMP_CO2_DUNHAM and not needs_db_HITEMP_CO_DUNHAM"
+    fetch_test: tests that verify the downloading of databases from external servers (HITRAN/HITEMP).
+addopts = -m "not needs_cuda and not download_large_databases and not needs_db_CDSD_HITEMP and not needs_db_CDSD_HITEMP_PCN and not needs_db_CDSD_HITEMP_PC and not needs_db_HITEMP_CO2_DUNHAM and not needs_db_HITEMP_CO_DUNHAM and not fetch_test"
 
 [isort]
 profile = black


### PR DESCRIPTION
### Description
This pull request addresses the issue of slow local testing and `OSError` crashes caused by interactive download prompts during the default test suite run.

I have implemented a new `fetch_test` marker and applied it to HITEMP and ExoMol fetch functions. These tests are now excluded by default in `setup.cfg`.

### Changes
- Modified `setup.cfg`: Registered `fetch_test` marker and added `not fetch_test` to `addopts`.
- Modified `radis/test/io/test_hitemp.py`: Decorated download functions with `@pytest.mark.fetch_test`.
- Modified `radis/test/io/test_exomol.py`: Decorated download functions with `@pytest.mark.fetch_test`.

### Benchmark (Local Windows Environment)
Fixes #785 , also the result of latest pytest are as follows:

| Status | Result | Duration |
|--------|--------|----------|
| **Before** | FAILED (OSError on stdin) | ~583s (9m 43s) |
| **After**  | PASSED (Slow tests skipped) | ~388s (6m 27s) |
