### PR TITLE
Fix ReadTheDocs Python version for docs buildFix ReadTheDocs Python version for Sphinx compatibility

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,7 @@ build:
   os: ubuntu-22.04
   tools:
     #According to error message: Expected one of (2.7, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, miniconda3-4.7, miniconda3-3.12-24.1, miniconda3-3.12-24.9, mambaforge-4.10, mambaforge-22.9, mambaforge-23.11, 3, latest, miniconda-latest, mambaforge-latest), got type str (miniforge3-23.11).
-    python: "mambaforge-4.10"
+    python: "3.11"
   apt_packages:
     - mesa-vulkan-drivers #for running GPU examples
     - libvulkan1          #for running GPU examples


### PR DESCRIPTION
### Description

This pull request updates the ReadTheDocs configuration to use a supported
Python version instead of mambaforge, fixing Sphinx/docutils compatibility
issues during documentation builds.

Fixes #888
