### PR TITLE
Parallel parsing of hitemp CO2 chunks 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
 #- cython          # Not needed, see #647
 - habanero>=1.2.0  # CrossRef API to retrieve data from doi
 - h5py>=3.2.1   # load HDF5
-- joblib  # for parallel loading of SpecDatabase
+- joblib>=1.3  # for parallel loading of SpecDatabase ; >=1.3 for `return_as="generator"`
 - lmfit  # for new fitting modules
 - matplotlib
 - numpy~=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "h5py>=3.2.1",  # load HDF5
     "hjson",  # Json with comments (for default_radis.json)
     "hitran-api",  # HAPI, used to access TIPS partition functions
-    "joblib",  # for parallel loading of SpecDatabase
+    "joblib>=1.3",  # for parallel loading of SpecDatabase ; >=1.3 for `return_as="generator"`
     "json-tricks>=3.15.0",  # to deal with non jsonable formats
     "lmfit",  # for new fitting modules
     "lxml",  # parser used for ExoMol website

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -827,7 +827,7 @@ def make_j2b_m0(bdat, alpha_ref_default=0.07, n_Texp_default=0.5, jlower_max=Non
 
     # Raise a minor warning if default values are used for high J values
     if Nblower > (np.max(jlower_arr) + 1):
-        
+
         from radis.misc.warning import AccuracyWarning
 
         warnings.warn(

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -721,7 +721,6 @@ def make_j2b(
 
     # Raise a minor warning if default values are used for high J values
     if Nblower > (np.max(jlower_arr) + 1):
-        import warnings
 
         from radis.misc.warning import AccuracyWarning
 
@@ -828,8 +827,7 @@ def make_j2b_m0(bdat, alpha_ref_default=0.07, n_Texp_default=0.5, jlower_max=Non
 
     # Raise a minor warning if default values are used for high J values
     if Nblower > (np.max(jlower_arr) + 1):
-        import warnings
-
+        
         from radis.misc.warning import AccuracyWarning
 
         warnings.warn(

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -723,6 +723,62 @@ def _parse_with_progress_multiprocess(
         return res
 
 
+def _parse_uncached_chunks(
+    uncached,
+    local_paths,
+    wav_pairs,
+    results,
+    printer,
+    columns,
+    engine,
+    output,
+    verbose,
+    parallel,
+):
+
+    if uncached:
+        parse_kwargs = dict(
+            columns=columns, engine=engine, output=output, verbose=False
+        )
+        cpu_threads = os.cpu_count() or 1
+        if parallel and len(uncached) > 1 and cpu_threads > 1:
+            n_workers = min(len(uncached), cpu_threads, max(4, cpu_threads // 2))
+
+            from joblib import Parallel, delayed
+
+            parallel_results = Parallel(n_jobs=n_workers)(
+                delayed(_parse_with_progress_multiprocess)(
+                    p_idx,
+                    local_paths[i],
+                    wav_pairs[i],
+                    len(uncached),
+                    verbose,
+                    parse_kwargs,
+                )
+                for p_idx, i in enumerate(uncached)
+            )
+            for idx, i in enumerate(uncached):
+                results[i] = parallel_results[idx]
+        else:
+            from tqdm import tqdm
+
+            with tqdm(
+                total=len(local_paths),
+                initial=len(local_paths) - len(uncached),
+                desc="Processing chunks",
+                disable=not verbose,
+            ) as pbar:
+                for i in uncached:
+                    results[i] = parse_one_CO2_block(
+                        local_paths[i],
+                        wav_range=wav_pairs[i],
+                        **parse_kwargs,
+                    )
+                    pbar.update(1)
+    else:
+        printer.info("All files already cached.", indent=1)
+
+
 def read_and_write_chunked_for_CO2(
     load_wavenum_max,
     load_wavenum_min,
@@ -854,8 +910,6 @@ def read_and_write_chunked_for_CO2(
 
     printer.section("Caching to HDF5/H5 format")
 
-    from tqdm import tqdm
-
     # Load cached chunks, collect uncached indices
     results = [None] * len(local_paths)
     uncached = []
@@ -868,46 +922,19 @@ def read_and_write_chunked_for_CO2(
             results[i] = cached_df
         else:
             uncached.append(i)
-    # Parse uncached chunks
-    if uncached:
-        parse_kwargs = dict(
-            columns=columns, engine=engine, output=output, verbose=False
-        )
-        cpu_threads = os.cpu_count() or 1
-        if parallel and len(uncached) > 1 and cpu_threads > 1:
-            n_workers = min(len(uncached), cpu_threads, max(4, cpu_threads // 2))
 
-            from joblib import Parallel, delayed
-
-            parallel_results = Parallel(n_jobs=n_workers)(
-                delayed(_parse_with_progress_multiprocess)(
-                    p_idx,
-                    local_paths[i],
-                    wav_pairs[i],
-                    len(uncached),
-                    verbose,
-                    parse_kwargs,
-                )
-                for p_idx, i in enumerate(uncached)
-            )
-            for idx, i in enumerate(uncached):
-                results[i] = parallel_results[idx]
-        else:
-            with tqdm(
-                total=len(local_paths),
-                initial=len(local_paths) - len(uncached),
-                desc="Processing chunks",
-                disable=not verbose,
-            ) as pbar:
-                for i in uncached:
-                    results[i] = parse_one_CO2_block(
-                        local_paths[i],
-                        wav_range=wav_pairs[i],
-                        **parse_kwargs,
-                    )
-                    pbar.update(1)
-    else:
-        printer.info("All files already cached.", indent=1)
+    _parse_uncached_chunks(
+        uncached,
+        local_paths,
+        wav_pairs,
+        results,
+        printer,
+        columns,
+        engine,
+        output,
+        verbose,
+        parallel,
+    )
 
     # Register metadata
     for i, file in enumerate(local_paths):

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -707,6 +707,7 @@ def read_and_write_chunked_for_CO2(
     output="pandas",
     verbose=True,
     local_databases=None,
+    parallel=True,
 ):
     """
     Download, parse and cache CO2 data chunks for specified wavenumber range.
@@ -827,45 +828,90 @@ def read_and_write_chunked_for_CO2(
         printer.info("All files already downloaded.", indent=1)
 
     printer.section("Caching to HDF5/H5 format")
-    if len(local_paths) == len(
-        [f for f in local_paths if os.path.exists(_fcache_file_name(f, engine))]
-    ):
-        printer.info("All files already cached.", indent=1)
 
     from tqdm import tqdm
 
-    with tqdm(
-        total=len(local_paths), desc="Processing chunks", disable=not verbose
-    ) as pbar:
-        for i, file in enumerate(local_paths):
-            file_name = _fcache_file_name(file, engine)
-            cached_df = _load_cache_file(file_name, engine=engine, columns=columns)
+    # Load cached chunks, collect uncached indices
+    results = [None] * len(local_paths)
+    uncached = []
 
-            if cached_df is not None:
-                _append_dataframe(cached_df)
-                pbar.set_postfix_str("from cache")
-            else:
-                pbar.set_postfix_str("parsing")
-                df = parse_one_CO2_block(
-                    file,
-                    columns=columns,
-                    engine=engine,
-                    output=output,
-                    wav_range=wav_pairs[i],
-                    verbose=False,
-                )
-                _append_dataframe(df)
+    for i, file in enumerate(local_paths):
+        cached_df = _load_cache_file(
+            _fcache_file_name(file, engine), engine=engine, columns=columns
+        )
+        if cached_df is not None:
+            results[i] = cached_df
+        else:
+            uncached.append(i)
 
-            # Register (or update last_used for) this file
-            wmin, wmax = wav_pairs[i]
-            file_entry = _build_file_entry(file, wmin, wmax, engine)
-            register_partial_hitemp_co2(file_entry)
+    # Parse uncached chunks
+    if uncached:
+        parse_kwargs = dict(
+            columns=columns, engine=engine, output=output, verbose=False
+        )
+        cpu_threads = os.cpu_count() or 1
+        if parallel and len(uncached) > 1 and cpu_threads > 1:
+            n_workers = min(len(uncached), cpu_threads, max(4, cpu_threads // 2))
 
-            # Always remove .par file after processing
-            # if os.path.exists(file):
-            #     os.remove(file)
+            def _parse_with_progress(p_idx, file, wav_range, kwargs):
+                with tqdm(
+                    total=1,
+                    desc=f"Caching chunk {p_idx+1}/{len(uncached)}",
+                    position=p_idx + 1,
+                    leave=False,
+                    disable=not verbose,
+                    bar_format="{desc} {percentage:3.0f}%|{bar}| [{elapsed}]",
+                ) as p:
+                    res = parse_one_CO2_block(file, wav_range=wav_range, **kwargs)
+                    p.update(1)
+                    return res
 
-            pbar.update(1)
+            with ThreadPoolExecutor(max_workers=n_workers) as pool:
+                futures = {
+                    pool.submit(
+                        _parse_with_progress,
+                        p_idx,
+                        local_paths[i],
+                        wav_pairs[i],
+                        parse_kwargs,
+                    ): i
+                    for p_idx, i in enumerate(uncached)
+                }
+                with tqdm(
+                    total=len(local_paths),
+                    initial=len(local_paths) - len(uncached),
+                    desc="Total progress",
+                    position=0,
+                    leave=True,
+                    disable=not verbose,
+                ) as pbar:
+                    for future in as_completed(futures):
+                        results[futures[future]] = future.result()
+                        pbar.update(1)
+        else:
+            with tqdm(
+                total=len(local_paths),
+                initial=len(local_paths) - len(uncached),
+                desc="Processing chunks",
+                disable=not verbose,
+            ) as pbar:
+                for i in uncached:
+                    results[i] = parse_one_CO2_block(
+                        local_paths[i],
+                        wav_range=wav_pairs[i],
+                        **parse_kwargs,
+                    )
+                    pbar.update(1)
+    else:
+        printer.info("All files already cached.", indent=1)
+
+    # Register metadata
+    for i, file in enumerate(local_paths):
+        _append_dataframe(results[i])
+        wmin, wmax = wav_pairs[i]
+        register_partial_hitemp_co2(_build_file_entry(file, wmin, wmax, engine))
+        if os.path.exists(file):
+            os.remove(file)
 
     # Combine DataFrames
     if dataframes:
@@ -904,6 +950,7 @@ def download_and_decompress_CO2_into_df(
     verbose=True,
     engine="pytables",
     output="pandas",
+    parallel=True,
 ):
     """
     This function handles downloading the HITEMP CO2 database. The full 2024 database is downloaded in smaller files of approximately 50-70 MB (500 MB decompressed chunks in h5 format), locating the appropriate data chunk based on the provided wavenumber range and reading the relevant data into a DataFrame.
@@ -955,6 +1002,7 @@ def download_and_decompress_CO2_into_df(
         engine=engine,
         output=output,
         verbose=verbose,
+        parallel=parallel,
         local_databases=local_databases,
     )
     combined_df = combined_df[

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -705,22 +705,20 @@ def _build_file_entry(par_path, wmin, wmax, engine):
     return entry
 
 
-def _parse_with_progress_multiprocess(
-    p_idx, file, wav_range, total_chunks, verbose, kwargs
-):
-    from tqdm import tqdm
+def _parse_and_cache_one_chunk(file, wav_range, kwargs):
+    """Parse one CO2 chunk in a worker process and return its cache file path.
 
-    with tqdm(
-        total=1,
-        desc=f"Caching chunk {p_idx+1}/{total_chunks}",
-        position=p_idx + 1,
-        leave=False,
-        disable=not verbose,
-        bar_format="{desc} {percentage:3.0f}%|{bar}| [{elapsed}]",
-    ) as p:
-        res = parse_one_CO2_block(file, wav_range=wav_range, **kwargs)
-        p.update(1)
-        return res
+    Returning the path rather than the DataFrame keeps joblib from pickling a
+    several-hundred-MB frame back into the parent process, which doubles peak
+    memory. The parent reads the chunk back from disk instead.
+
+    Returns ``None`` if the cache file could not be written (e.g. read-only
+    cache directory), so that the caller parses the chunk itself.
+    """
+    parse_one_CO2_block(file, wav_range=wav_range, **kwargs)
+
+    fcache = _fcache_file_name(file, kwargs["engine"])
+    return str(fcache) if os.path.exists(fcache) else None
 
 
 def _parse_uncached_chunks(
@@ -759,19 +757,34 @@ def _parse_uncached_chunks(
 
         if use_parallel:
             from joblib import Parallel, delayed
+            from tqdm import tqdm
 
             try:
-                parallel_results = Parallel(n_jobs=n_workers)(
-                    delayed(_parse_with_progress_multiprocess)(
-                        p_idx,
-                        local_paths[i],
-                        wav_pairs[i],
-                        len(uncached),
-                        verbose,
-                        parse_kwargs,
+                fcaches = []
+                with tqdm(
+                    total=len(uncached), desc="Parsing chunks", disable=not verbose
+                ) as pbar:
+                    # `return_as="generator"` lets the bar advance as chunks are
+                    # cached, instead of jumping to 100% once they all are.
+                    for fcache in Parallel(n_jobs=n_workers, return_as="generator")(
+                        delayed(_parse_and_cache_one_chunk)(
+                            local_paths[i], wav_pairs[i], parse_kwargs
+                        )
+                        for i in uncached
+                    ):
+                        fcaches.append(fcache)
+                        pbar.update(1)
+
+                # The workers wrote the chunks to disk rather than sending them
+                # back, so read them in here, one at a time.
+                for idx, i in enumerate(uncached):
+                    results[i] = (
+                        _load_cache_file(fcaches[idx], engine=engine, columns=columns)
+                        if fcaches[idx]
+                        else parse_one_CO2_block(
+                            local_paths[i], wav_range=wav_pairs[i], **parse_kwargs
+                        )
                     )
-                    for p_idx, i in enumerate(uncached)
-                )
             except MemoryError:
                 raise MemoryError(
                     "Out of memory while loading HITEMP CO2 chunks in parallel "
@@ -779,8 +792,6 @@ def _parse_uncached_chunks(
                     "Try reducing the number of workers, e.g. parallel=2, "
                     "or use serial loading with parallel=False."
                 ) from None
-            for idx, i in enumerate(uncached):
-                results[i] = parallel_results[idx]
         else:
             from tqdm import tqdm
 
@@ -967,6 +978,7 @@ def read_and_write_chunked_for_CO2(
     # Register metadata
     for i, file in enumerate(local_paths):
         _append_dataframe(results[i])
+        results[i] = None  # `dataframes` holds it now; don't keep it twice
         wmin, wmax = wav_pairs[i]
         register_partial_hitemp_co2(_build_file_entry(file, wmin, wmax, engine))
         if os.path.exists(file):

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -741,22 +741,44 @@ def _parse_uncached_chunks(
             columns=columns, engine=engine, output=output, verbose=False
         )
         cpu_threads = os.cpu_count() or 1
-        if parallel and len(uncached) > 1 and cpu_threads > 1:
-            n_workers = min(len(uncached), cpu_threads, max(4, cpu_threads // 2))
 
+        # Determine whether to use parallel processing and how many workers:
+        #   parallel=True  → auto-detect worker count
+        #   parallel=N (int > 1) → use exactly N workers
+        #   parallel=False / parallel=0 / parallel=1 → serial
+        use_parallel = False
+        n_workers = 1
+
+        if type(parallel) is bool:
+            if parallel and len(uncached) > 1 and cpu_threads > 1:
+                use_parallel = True
+                n_workers = min(len(uncached), cpu_threads, max(4, cpu_threads // 2))
+        elif isinstance(parallel, int) and parallel > 1 and len(uncached) > 1:
+            use_parallel = True
+            n_workers = min(parallel, len(uncached))
+
+        if use_parallel:
             from joblib import Parallel, delayed
 
-            parallel_results = Parallel(n_jobs=n_workers)(
-                delayed(_parse_with_progress_multiprocess)(
-                    p_idx,
-                    local_paths[i],
-                    wav_pairs[i],
-                    len(uncached),
-                    verbose,
-                    parse_kwargs,
+            try:
+                parallel_results = Parallel(n_jobs=n_workers)(
+                    delayed(_parse_with_progress_multiprocess)(
+                        p_idx,
+                        local_paths[i],
+                        wav_pairs[i],
+                        len(uncached),
+                        verbose,
+                        parse_kwargs,
+                    )
+                    for p_idx, i in enumerate(uncached)
                 )
-                for p_idx, i in enumerate(uncached)
-            )
+            except MemoryError:
+                raise MemoryError(
+                    "Out of memory while loading HITEMP CO2 chunks in parallel "
+                    f"({n_workers} workers). "
+                    "Try reducing the number of workers, e.g. parallel=2, "
+                    "or use serial loading with parallel=False."
+                ) from None
             for idx, i in enumerate(uncached):
                 results[i] = parallel_results[idx]
         else:
@@ -808,6 +830,12 @@ def read_and_write_chunked_for_CO2(
         Print progress messages (default True)
     local_databases : str, optional
         Custom cache directory
+    parallel : bool or int
+        If ``True``, uses joblib with an auto-detected number of workers.
+        If ``False`` or ``0`` or ``1``, uses serial (single-process) loading.
+        If an integer N > 1, uses exactly N parallel workers. This is useful
+        on memory-constrained machines where auto-detected parallelism may
+        cause MemoryError (e.g. ``parallel=2``). Default ``True``.
 
     Returns
     -------
@@ -1004,6 +1032,12 @@ def download_and_decompress_CO2_into_df(
         Output format for the data. Default is "pandas" DataFrame.
     local_databases : str or None, optional
         Directory to store/read local database files. If None, uses the default directory.
+    parallel : bool or int
+        If ``True``, uses joblib with an auto-detected number of workers.
+        If ``False`` or ``0`` or ``1``, uses serial (single-process) loading.
+        If an integer N > 1, uses exactly N parallel workers. This is useful
+        on memory-constrained machines where auto-detected parallelism may
+        cause MemoryError (e.g. ``parallel=2``). Default ``True``.
     Returns
     -------
     DataFrame or object

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -86,8 +86,15 @@ def read_config():
         or an empty dictionary if the file does not exist.
     """
     if os.path.exists(CONFIG_PATH_JSON):
-        with open(CONFIG_PATH_JSON, "r") as f:
-            config = json.load(f)
+        try:
+            with open(CONFIG_PATH_JSON, "r") as f:
+                config = json.load(f)
+        except json.JSONDecodeError as e:
+            warnings.warn(
+                f"RADIS config file {CONFIG_PATH_JSON} is corrupted and could not be read ({e}). Ignoring it.",
+                UserWarning,
+            )
+            config = {}
     else:
         config = {}
     return config
@@ -698,6 +705,24 @@ def _build_file_entry(par_path, wmin, wmax, engine):
     return entry
 
 
+def _parse_with_progress_multiprocess(
+    p_idx, file, wav_range, total_chunks, verbose, kwargs
+):
+    from tqdm import tqdm
+
+    with tqdm(
+        total=1,
+        desc=f"Caching chunk {p_idx+1}/{total_chunks}",
+        position=p_idx + 1,
+        leave=False,
+        disable=not verbose,
+        bar_format="{desc} {percentage:3.0f}%|{bar}| [{elapsed}]",
+    ) as p:
+        res = parse_one_CO2_block(file, wav_range=wav_range, **kwargs)
+        p.update(1)
+        return res
+
+
 def read_and_write_chunked_for_CO2(
     load_wavenum_max,
     load_wavenum_min,
@@ -781,7 +806,7 @@ def read_and_write_chunked_for_CO2(
         version="2024",
     )
     printer.header(
-        f"Downloading and processing {len(wav_pairs)} chunks for range {load_wavenum_min}-{load_wavenum_max} cm⁻¹"
+        f"Downloading and processing {len(wav_pairs)} chunks for range {load_wavenum_min}-{load_wavenum_max} cm-1"
     )
 
     # Download section
@@ -843,7 +868,6 @@ def read_and_write_chunked_for_CO2(
             results[i] = cached_df
         else:
             uncached.append(i)
-
     # Parse uncached chunks
     if uncached:
         parse_kwargs = dict(
@@ -853,41 +877,21 @@ def read_and_write_chunked_for_CO2(
         if parallel and len(uncached) > 1 and cpu_threads > 1:
             n_workers = min(len(uncached), cpu_threads, max(4, cpu_threads // 2))
 
-            def _parse_with_progress(p_idx, file, wav_range, kwargs):
-                with tqdm(
-                    total=1,
-                    desc=f"Caching chunk {p_idx+1}/{len(uncached)}",
-                    position=p_idx + 1,
-                    leave=False,
-                    disable=not verbose,
-                    bar_format="{desc} {percentage:3.0f}%|{bar}| [{elapsed}]",
-                ) as p:
-                    res = parse_one_CO2_block(file, wav_range=wav_range, **kwargs)
-                    p.update(1)
-                    return res
+            from joblib import Parallel, delayed
 
-            with ThreadPoolExecutor(max_workers=n_workers) as pool:
-                futures = {
-                    pool.submit(
-                        _parse_with_progress,
-                        p_idx,
-                        local_paths[i],
-                        wav_pairs[i],
-                        parse_kwargs,
-                    ): i
-                    for p_idx, i in enumerate(uncached)
-                }
-                with tqdm(
-                    total=len(local_paths),
-                    initial=len(local_paths) - len(uncached),
-                    desc="Total progress",
-                    position=0,
-                    leave=True,
-                    disable=not verbose,
-                ) as pbar:
-                    for future in as_completed(futures):
-                        results[futures[future]] = future.result()
-                        pbar.update(1)
+            parallel_results = Parallel(n_jobs=n_workers)(
+                delayed(_parse_with_progress_multiprocess)(
+                    p_idx,
+                    local_paths[i],
+                    wav_pairs[i],
+                    len(uncached),
+                    verbose,
+                    parse_kwargs,
+                )
+                for p_idx, i in enumerate(uncached)
+            )
+            for idx, i in enumerate(uncached):
+                results[i] = parallel_results[idx]
         else:
             with tqdm(
                 total=len(local_paths),

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -158,6 +158,7 @@ def fetch_hitemp(
             verbose=verbose,
             engine=engine,
             output=output,
+            parallel=parallel,
         )
 
         if return_local_path:

--- a/radis/io/hitemp.py
+++ b/radis/io/hitemp.py
@@ -77,8 +77,12 @@ def fetch_hitemp(
             Vaex DataFrames are memory-mapped. They do not take any space in RAM
             and are extremely useful to deal with the largest databases.
 
-    parallel: bool
-        if ``True``, uses joblib.parallel to load database with multiple processes
+    parallel: bool or int
+        if ``True``, uses joblib with an auto-detected number of parallel workers.
+        if ``False``, uses serial (single-process) loading.
+        if an integer N > 1, uses exactly N parallel workers. Useful on
+        memory-constrained machines to avoid MemoryError (e.g. ``parallel=2``).
+        Default ``True``.
     database: ``str``
         The database version to retrieve. Options include:
         - `"most_recent"`: Fetches the latest available database version.

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -300,6 +300,13 @@ class SpectrumFactory(BandFactory):
 
         See :py:data:`~radis.misc.warning.default_warning_status` for more
         information.
+    parallel: bool or int
+        If ``True``, uses joblib with an auto-detected number of parallel workers
+        when loading the database. If ``False``, uses serial (single-process) loading.
+        If an integer N > 1, uses exactly N parallel workers. Useful on
+        memory-constrained machines to avoid MemoryError (e.g. ``parallel=2``).
+        This value is used as the default for :meth:`~radis.lbl.loader.DatabankLoader.fetch_databank`.
+        Default ``True``.
     verbose: boolean, or int
         If ``False``, stays quiet. If ``True``, tells what is going on.
         If ``>=2``, gives more detailed messages (for instance, details of
@@ -450,6 +457,7 @@ class SpectrumFactory(BandFactory):
         lbfunc=None,
         potential_lowering=None,
         pfsource="default",
+        parallel=True,
         **kwargs,
     ):
 
@@ -693,6 +701,8 @@ class SpectrumFactory(BandFactory):
 
         # used to split lines into blocks not too big for memory
         self.misc.chunksize = chunksize
+        # parallel loading of database chunks (bool or int number of workers)
+        self.misc.parallel = parallel
         # Other parameters:
         self.save_memory = save_memory
         self.autoupdatedatabase = False  # a boolean to automatically store calculated

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -1031,7 +1031,7 @@ class DatabankLoader(object):
         lvl_use_cached=True,
         memory_mapping_engine="default",
         load_columns="equilibrium",
-        parallel=True,
+        parallel=None,
         extra_params=None,
         **kwargs,
     ):
@@ -1076,9 +1076,12 @@ class DatabankLoader(object):
         memory_mapping_engine: str
             Which library to use to read HDF5 files. Options are ``'pytables'``, ``'vaex'``, ``'feather'``.
             Default is ``'default'``.
-        parallel: bool
-            If ``True``, uses joblib.parallel to load database with multiple processes.
-            Default is ``True``.
+        parallel: bool or int
+            If ``True``, uses joblib with an auto-detected number of parallel workers.
+            If ``False``, uses serial (single-process) loading.
+            If an integer N > 1, uses exactly N parallel workers. Useful on
+            memory-constrained machines to avoid MemoryError (e.g. ``parallel=2``).
+            Default ``True``.
         load_columns: list, ``'all'``, ``'equilibrium'``, ``'noneq'``, ``diluent``
             Columns names to load. Default is ``'equilibrium'``.
 
@@ -1102,6 +1105,11 @@ class DatabankLoader(object):
         # | see implementation in load_databank.
 
         self.profiler.start("db_loading", self._db_loading_profiler_level())
+
+        # Resolve parallel: caller-supplied value takes precedence;
+        # fall back to SpectrumFactory-level setting (self.misc.parallel) or True.
+        if parallel is None:
+            parallel = getattr(self.misc, "parallel", True)
 
         # Check inputs
         compare_source = source.casefold()

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -579,6 +579,7 @@ class MiscParams(ConditionDict):
         "zero_padding",
         "memory_mapping_engine",
         "add_at_used",  # function used in DIT ; a Cython and a pure-Python version exist
+        "parallel",
     ]
 
     def __init__(self):

--- a/radis/test/io/test_hitemp.py
+++ b/radis/test/io/test_hitemp.py
@@ -247,6 +247,7 @@ def test_fetch_hitemp_partial_download_CO2(verbose=True, *args, **kwargs):
         load_wavenum_max=2500,
         verbose=3,
         return_local_path=True,
+        parallel=True,
     )
 
     assert df.shape[1] == 24


### PR DESCRIPTION

I was in the assumption that the python parsing of hitemp data internally happens in parallel therefore we can't make it use multiprocessing but that is not the case and I now added multiprocessing and the results are as follow.

Benchmark on CPU with 8 core and 16 threads.

For 6 chunks 
**Only Parsing time from 337.51s to 169.42s that is ~2x faster** 
Total Time from 560.21s to 409.80s

For 3 chuncks 
**Only Parsing time from 151.81s to 77.13s  that is  about ~2x faster**
Total Time from 391.89s to 197.76s 

TODO:
- [x] Write better logic for selecting number of cpu threads
- [x] Refactoring 



```python
from radis import fetch_hitemp
df, local_files = fetch_hitemp(
    "CO2",
    load_wavenum_min=0,  # cm-1
    load_wavenum_max=600,
    verbose=3,
    return_local_path=True,
    #parallel=True, # default True
)
print(local_files)
```