### PR TITLE
Docs: clarify experimental spectra examples usage

### DIFF
--- a/examples/2_Experimental_spectra/README.rst
+++ b/examples/2_Experimental_spectra/README.rst
@@ -1,3 +1,16 @@
 Fitting experimental spectra (basics)
 ---------------
 Useful functions to upload experimental data and fit them with simple models.
+
+
+Scripts overview
+----------------
+
+This folder contains examples demonstrating how to load, process,
+and compare experimental spectra using RADIS.
+
+- ``plot_experimental_spectrum.py``: Load and visualize an experimental spectrum.
+- ``plot_remove_baseline.py``: Apply baseline correction to experimental spectra.
+- ``plot_fit_lineshape.py``: Fit spectral line shapes to experimental data.
+- ``plot_specutils_processing.py``: Demonstrate interoperability with specutils.
+- ``plot_chain_spectrum_edition.py``: Chain multiple spectrum processing steps.


### PR DESCRIPTION
This PR adds a short overview of the scripts in
examples/2_Experimental_spectra to help new users
understand which example to use for common workflows
such as loading experimental data, baseline correction,
and line-shape fitting.

No code changes are included.
