### PR TITLE
Docs: clarify built-in test spectrum in experimental spectrum example

### DIFF
--- a/examples/2_Experimental_spectra/README.rst
+++ b/examples/2_Experimental_spectra/README.rst
@@ -1,3 +1,16 @@
 Fitting experimental spectra (basics)
 ---------------
 Useful functions to upload experimental data and fit them with simple models.
+
+
+Scripts overview
+----------------
+
+This folder contains examples demonstrating how to load, process,
+and compare experimental spectra using RADIS.
+
+- ``plot_experimental_spectrum.py``: Load and visualize an experimental spectrum.
+- ``plot_remove_baseline.py``: Apply baseline correction to experimental spectra.
+- ``plot_fit_lineshape.py``: Fit spectral line shapes to experimental data.
+- ``plot_specutils_processing.py``: Demonstrate interoperability with specutils.
+- ``plot_chain_spectrum_edition.py``: Chain multiple spectrum processing steps.

--- a/examples/2_Experimental_spectra/plot_experimental_spectrum.py
+++ b/examples/2_Experimental_spectra/plot_experimental_spectrum.py
@@ -16,7 +16,9 @@ See more loading and post-processing functions on the :ref:`Spectrum page <label
 from radis.test.utils import getTestFile
 from radis.tools.database import load_spec
 
-my_file = getTestFile("CO2_measured_spectrum_4-5um.spec")  # for the example here
+# RADIS provides a built-in test spectrum so this example runs without external data
+my_file = getTestFile("CO2_measured_spectrum_4-5um.spec")
+
 
 s = load_spec(my_file)
 s.plot()


### PR DESCRIPTION
This PR adds a short clarifying comment in the experimental spectrum example to indicate that the spectrum file is provided by RADIS test utilities.

This helps new users understand that the script runs out-of-the-box and does not require an external data file.

No functional changes.
