### PR TITLE
Fix inconsistent spectral_points reporting

### DIFF
--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -949,10 +949,7 @@ class SpectrumFactory(BandFactory):
                 "thermal_equilibrium": True,
                 "diluents": self._diluent,
                 "radis_version": version,
-                "spectral_points": (
-                    int(self.params.wavenum_max_calc - self.params.wavenum_min_calc)
-                    / self.params.wstep
-                ),
+                "spectral_points": len(self.wavenumber),
                 "profiler": dict(self.profiler.final),
             }
         )
@@ -1325,10 +1322,7 @@ class SpectrumFactory(BandFactory):
                 "diluents": self._diluent,
                 "radis_version": version,
                 "gpu_backend": backend,
-                "spectral_points": (
-                    int(self.params.wavenum_max_calc - self.params.wavenum_min_calc)
-                    / self.params.wstep
-                ),
+                "spectral_points": len(self.wavenumber),
                 "add_at_used": "gpu-backend",
                 "profiler": dict(self.profiler.final),
                 "NwL": iter_N_L,
@@ -1860,10 +1854,7 @@ class SpectrumFactory(BandFactory):
                 "thermal_equilibrium": False,  # dont even try to guess if it's at equilibrium
                 "diluents": self._diluent,
                 "radis_version": version,
-                "spectral_points": (
-                    int(self.params.wavenum_max_calc - self.params.wavenum_min_calc)
-                    / self.params.wstep
-                ),
+                "spectral_points": len(self.wavenumber),
                 "profiler": dict(self.profiler.final),
             }
         )
@@ -2109,10 +2100,7 @@ class SpectrumFactory(BandFactory):
         wstep = self.params.wstep
         n_lines = self.misc.total_lines
         truncation = self.params.truncation
-        spectral_points = (
-            int(self.params.wavenum_max_calc - self.params.wavenum_min_calc)
-            / self.params.wstep
-        )
+        spectral_points = len(self.wavenumber)
 
         optimization = self.params.optimization
         broadening_method = self.params.broadening_method


### PR DESCRIPTION
## Summary
- Fixes `s.conditions['spectral_points']` reporting incorrect value (e.g. `150000.0` instead of `150001`)
- The old formula `int(wavenum_max_calc - wavenum_min_calc) / wstep` used the calc range (with neighbour_lines buffer) and computed intervals instead of points (off-by-one)
- Replaced with `len(self.wavenumber)` at all 4 locations in `radis/lbl/factory.py`

Fixes #613

## Test plan
- [x] Reproduced the issue from #613 with `SpectrumFactory(2150, 2450, wstep=0.002)` — confirmed `spectral_points` now matches `len(s.get_wavenumber())`
- [x] All 18 factory tests pass