### PR TITLE
Modernize DeprecationWarning usage for cached parameters

### DIFF
--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -480,9 +480,6 @@ class SpectrumFactory(BandFactory):
                 stacklevel=2,
             )
             kwargs0.pop("db_use_cached")
-
-
-
         if "lvl_use_cached" in kwargs:
             warn(
                 "lvl_use_cached removed from SpectrumFactory init and moved in load/fetch_databank()",

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -485,12 +485,9 @@ class SpectrumFactory(BandFactory):
 
         if "lvl_use_cached" in kwargs:
             warn(
-                
                 "lvl_use_cached removed from SpectrumFactory init and moved in load/fetch_databank()",
                 DeprecationWarning,
-                stacklevel =2,
-
-                
+                stacklevel=2,
             )
             kwargs0.pop("lvl_use_cached")
         if "broadening_max_width" in kwargs:  # changed in 0.9.30

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -475,14 +475,14 @@ class SpectrumFactory(BandFactory):
             molecule = species
         if "db_use_cached" in kwargs:
             warn(
-                "db_use_cached removed from SpectrumFactory init and moved in load/fetch_databank()",
+                "'db_use_cached' removed from SpectrumFactory init and moved in load/fetch_databank()",
                 DeprecationWarning,
                 stacklevel=2,
             )
             kwargs0.pop("db_use_cached")
         if "lvl_use_cached" in kwargs:
             warn(
-                "lvl_use_cached removed from SpectrumFactory init and moved in load/fetch_databank()",
+                "'lvl_use_cached' removed from SpectrumFactory init and moved in load/fetch_databank()",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -473,19 +473,24 @@ class SpectrumFactory(BandFactory):
             )  # remove it from kwargs0 so it doesn't trigger the error later
         else:
             molecule = species
-
         if "db_use_cached" in kwargs:
             warn(
-                DeprecationWarning(
-                    "db_use_cached removed from SpectrumFactory init and moved in load/fetch_databank()"
-                )
+                "db_use_cached removed from SpectrumFactory init and moved in load/fetch_databank()",
+                DeprecationWarning,
+                stacklevel=2,
             )
             kwargs0.pop("db_use_cached")
+
+
+
         if "lvl_use_cached" in kwargs:
             warn(
-                DeprecationWarning(
-                    "lvl_use_cached removed from SpectrumFactory init and moved in load/fetch_databank()"
-                )
+                
+                "lvl_use_cached removed from SpectrumFactory init and moved in load/fetch_databank()",
+                DeprecationWarning,
+                stacklevel =2,
+
+                
             )
             kwargs0.pop("lvl_use_cached")
         if "broadening_max_width" in kwargs:  # changed in 0.9.30


### PR DESCRIPTION
Updated DeprecationWarning emission to follow standard warnings API usage.

Replaced warning instances with message + category form and added stacklevel for improved traceback accuracy.

No functional changes intended.
