### PR TITLE
feat: Auto-truncation as a function of HWHM (fixes #612)

### DIFF
--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -2070,10 +2070,7 @@ class BroadenFactory(BaseFactory):
                     n_hwhm = 100.0
                 else:
                     val = (
-                        _truncation.lower()
-                        .replace("hwhm", "")
-                        .replace("x", "")
-                        .strip()
+                        _truncation.lower().replace("hwhm", "").replace("x", "").strip()
                     )
                     n_hwhm = float(val)
                 hwhm_max = self.df1["hwhm_voigt"].max()
@@ -2417,7 +2414,11 @@ class BroadenFactory(BaseFactory):
                 LDM_ranges = {}
                 LDM_reduced = {}
                 for groupby_param, group in dgb:
-                    _trunc = self.params.truncation if not isinstance(self.params.truncation, str) else 50.0
+                    _trunc = (
+                        self.params.truncation
+                        if not isinstance(self.params.truncation, str)
+                        else 50.0
+                    )
                     truncation_pts = int(_trunc // self.params.wstep)
                     # note: truncation can be unique for each point of the LDM basis
                     # (allow to have line-dependant truncation, at least as all

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -2058,7 +2058,33 @@ class BroadenFactory(BaseFactory):
         # index of truncation half width
         iwbroad_half = len(wbroad_centered) // 2
         ineighbour = arange_len(0, self.params.neighbour_lines, self.params.wstep)
-        itruncation = arange_len(0, self.truncation, self.params.wstep)
+
+        # ── NEW: resolve HWHM-based truncation (only below 1 atm) ───────
+        _truncation = self.truncation
+        if isinstance(_truncation, str):
+            pressure_atm = self.input.pressure / 1.01325
+            if pressure_atm >= 1.0:
+                _truncation = 50.0
+            else:
+                if _truncation == "auto":
+                    n_hwhm = 100.0
+                else:
+                    val = (
+                        _truncation.lower()
+                        .replace("hwhm", "")
+                        .replace("x", "")
+                        .strip()
+                    )
+                    n_hwhm = float(val)
+                hwhm_max = self.df1["hwhm_voigt"].max()
+                _truncation = float(n_hwhm * hwhm_max)
+                if self.verbose >= 2:
+                    print(
+                        f"Auto-truncation: {n_hwhm:.0f} x HWHM_max "
+                        f"({hwhm_max:.5f} cm-1) = {_truncation:.4f} cm-1"
+                    )
+        # ── END NEW ──────────────────────────────────────────────────────
+        itruncation = arange_len(0, _truncation, self.params.wstep)
 
         # Calculate matrix of broadened parameter (for all lines)
         # ... Note @dev : this is the memory bottleneck !
@@ -2391,7 +2417,8 @@ class BroadenFactory(BaseFactory):
                 LDM_ranges = {}
                 LDM_reduced = {}
                 for groupby_param, group in dgb:
-                    truncation_pts = int(self.params.truncation // self.params.wstep)
+                    _trunc = self.params.truncation if not isinstance(self.params.truncation, str) else 50.0
+                    truncation_pts = int(_trunc // self.params.wstep)
                     # note: truncation can be unique for each point of the LDM basis
                     # (allow to have line-dependant truncation, at least as all
                     # lines with same truncation are grouped together in the LDM basis)

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -637,12 +637,7 @@ class SpectrumFactory(BandFactory):
             if truncation == "auto":
                 truncation = "auto"  # resolved later in calc_hwhm
             else:
-                val = (
-                    truncation.lower()
-                    .replace("hwhm", "")
-                    .replace("x", "")
-                    .strip()
-                )
+                val = truncation.lower().replace("hwhm", "").replace("x", "").strip()
                 try:
                     float(val)
                     truncation = truncation  # valid, resolved later
@@ -1992,7 +1987,11 @@ class SpectrumFactory(BandFactory):
         truncation = self.params.truncation
         neighbour_lines = self.params.neighbour_lines
 
-        if truncation and not isinstance(truncation, str) and neighbour_lines > truncation:
+        if (
+            truncation
+            and not isinstance(truncation, str)
+            and neighbour_lines > truncation
+        ):
             self.warn(
                 f"Neighbour lines resolved up to {neighbour_lines} cm-1 away from the spectrum. "
                 + f"But lines are anyway truncated at {truncation:.2f} cm-1. "

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -632,7 +632,28 @@ class SpectrumFactory(BandFactory):
         # Time Based variables
         self.verbose = verbose
 
-        if truncation == 0:
+        # ── NEW: resolve string-based HWHM truncation ──────────────────
+        if isinstance(truncation, str):
+            if truncation == "auto":
+                truncation = "auto"  # resolved later in calc_hwhm
+            else:
+                val = (
+                    truncation.lower()
+                    .replace("hwhm", "")
+                    .replace("x", "")
+                    .strip()
+                )
+                try:
+                    float(val)
+                    truncation = truncation  # valid, resolved later
+                except ValueError:
+                    raise ValueError(
+                        f"truncation='{truncation}' not understood. "
+                        "Use a float (cm-1), None, 'auto', or 'NxHWHM' "
+                        "(e.g. '100xHWHM')."
+                    )
+        # ── END NEW ──────────────────────────────────────────────────────
+        elif truncation == 0:
             raise ValueError(
                 "Lineshape truncation must be > 0. If you want no truncation (compute lineshape on the full spectral range), use `truncation=None`. \nNote (advanced) : no truncation is not physically more accurate. Most molecules exhibit a sub-lorentzian behavior far from the line centers. A truncation at around 40-50 cm-1 is a good choice"
             )
@@ -1971,7 +1992,7 @@ class SpectrumFactory(BandFactory):
         truncation = self.params.truncation
         neighbour_lines = self.params.neighbour_lines
 
-        if truncation and neighbour_lines > truncation:
+        if truncation and not isinstance(truncation, str) and neighbour_lines > truncation:
             self.warn(
                 f"Neighbour lines resolved up to {neighbour_lines} cm-1 away from the spectrum. "
                 + f"But lines are anyway truncated at {truncation:.2f} cm-1. "
@@ -1992,7 +2013,11 @@ class SpectrumFactory(BandFactory):
             # (note that this means 3x wavenumber_calc will be required when applying lineshapes)
             truncation = wavenumber_calc[-1] - wavenumber_calc[0]
 
-        wbroad_centered = _generate_broadening_range(self.params.wstep, truncation)
+        # Resolve string truncation to float before broadening range
+        _trunc = truncation
+        if isinstance(_trunc, str):
+            _trunc = 50.0  # fallback, actual resolve happens in broadening.py
+        wbroad_centered = _generate_broadening_range(self.params.wstep, _trunc)
         self.truncation = truncation
         # store value for use in lineshape broadening.
         # Note : may be different from self.params.truncation if None was given.


### PR DESCRIPTION
Adds HWHM-based auto-truncation for low-pressure spectra where 
default truncation=50 cm⁻¹ is unnecessarily large.

## Changes
- New syntax: `truncation='auto'` and `truncation='NxHWHM'` (e.g. `'100xHWHM'`)
- Auto-truncation applies **only below 1 atm** 
- Backward compatible: existing `truncation=float` behavior unchanged
- `radis/lbl/factory.py`: string truncation validation and parsing
- `radis/lbl/broadening.py`: HWHM-based resolution logic with pressure check

## Closes
Closes #612