### PR TITLE
Refactor: Remove mutable default arguments in fitting and factory modules

### DIFF
--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -1392,7 +1392,7 @@ class SpectrumFactory(BandFactory):
         var="transmittance",
         slit_function=0.0,
         mpl_backend="",
-        plotkwargs={},
+        plotkwargs=None,
         *vargs,
         **kwargs,
     ) -> Spectrum:
@@ -1444,6 +1444,8 @@ class SpectrumFactory(BandFactory):
             :add-heading:
 
         """
+        if plotkwargs is None:
+            plotkwargs = {}
         if self.input.isatom:
             raise NotImplementedError(
                 "eq_spectrum_gpu hasn't been implemented for atomic spectra"
@@ -2348,9 +2350,9 @@ class SpectrumFactory(BandFactory):
         s_exp,
         model,
         fit_parameters,
-        bounds={},
+        bounds=None,
         plot=False,
-        solver_options={"maxiter": 300},
+        solver_options=None,
         **kwargs,
     ) -> Union[Spectrum, OptimizeResult]:
         """Fit an experimental spectrum with an arbitrary model and an arbitrary
@@ -2417,6 +2419,12 @@ class SpectrumFactory(BandFactory):
         :py:mod:`fitroom`
 
         """
+        # Avoid mutable default arguments
+        if bounds is None:
+            bounds = {}
+
+        if solver_options is None:
+            solver_options = {"maxiter": 300}
         from radis.tools.fitting import fit_legacy
 
         return fit_legacy(

--- a/radis/tools/fitting.py
+++ b/radis/tools/fitting.py
@@ -27,7 +27,7 @@ from radis.spectrum.compare import get_default_units, get_diff, get_residual
 
 
 # Calculate a new spectrum for given parameters:
-def LTEModel(factory, fittable_parameters, fixed_parameters={}) -> Spectrum:
+def LTEModel(factory, fittable_parameters, fixed_parameters=None) -> Spectrum:
     """A model returning a single-slab LTE spectrum
 
     Parameters
@@ -52,7 +52,8 @@ def LTEModel(factory, fittable_parameters, fixed_parameters={}) -> Spectrum:
     :py:func:`~radis.tools.new_fitting.residual_LTE`
 
     """
-
+    if fixed_parameters is None:
+        fixed_parameters = {}
     kwargs = {"name": "fit"}
 
     # ... create whatever model below (can have several slabs with SerialSlabs
@@ -74,7 +75,7 @@ def LTEModel(factory, fittable_parameters, fixed_parameters={}) -> Spectrum:
 
 # Calculate a new spectrum for given parameters:
 def Tvib12Tvib3Trot_NonLTEModel(
-    factory, fittable_parameters, fixed_parameters={}
+    factory, fittable_parameters, fixed_parameters=None
 ) -> Spectrum:
     """A model returning a single-slab non-LTE spectrum with Tvib=(T12, T12, T3), Trot
 
@@ -106,7 +107,8 @@ def Tvib12Tvib3Trot_NonLTEModel(
     :py:func:`~radis.tools.fitting.LTEModel`
     :py:func:`~radis.tools.new_fitting.residual_NonLTE`
     """
-
+    if fixed_parameters is None:
+        fixed_parameters = {}
     fittable_parameters = fittable_parameters.copy()
 
     # ... input should remain a dict
@@ -146,11 +148,11 @@ def fit_legacy(
     s_exp,
     model,
     fit_parameters,
-    bounds={},
-    fixed_parameters={},
+    bounds=None,
+    fixed_parameters=None,
     plot=False,
     verbose=True,
-    solver_options={"maxiter": 300},
+    solver_options=None,
 ) -> Union[Spectrum, OptimizeResult]:
     """Fit an experimental spectrum with an arbitrary model and an arbitrary
     number of fit parameters. This legacy function is replaced by :py:func:`~radis.tools.new_fitting.fit_spectrum`
@@ -213,6 +215,15 @@ def fit_legacy(
     :py:func:`~radis.tools.new_fitting.fit_spectrum`,
     :py:mod:`fitroom`
     """
+    # Avoid mutable default arguments
+    if bounds is None:
+        bounds = {}
+
+    if fixed_parameters is None:
+        fixed_parameters = {}
+
+    if solver_options is None:
+        solver_options = {"maxiter": 300}
 
     # Get model being fitted:
     compute_los_model = lambda fit_parameters: model(

--- a/radis/tools/new_fitting.py
+++ b/radis/tools/new_fitting.py
@@ -562,7 +562,7 @@ def fit_spectrum(
     input_file=None,
     verbose=True,
     show_plot=True,
-    fit_kws={},
+    fit_kws=None,
 ) -> Union[Spectrum, MinimizerResult, dict]:
     """Fit an experimental spectrum (referred to as the "data spectrum") with a modeled spectrum,
     and derive the fit results.
@@ -608,7 +608,9 @@ def fit_spectrum(
     :py:mod:`fitroom`
 
     """
-
+    # Avoid mutable default argument
+    if fit_kws is None:
+        fit_kws = {}
     begin = time.time()  # Start the fitting time counter
 
     if verbose:


### PR DESCRIPTION
- Replaced mutable default arguments (e.g., `{}`) with `None`.
- Added explicit initialization inside function bodies.
- Preserved existing default values and behavior.
- Applied changes in fitting and factory-related modules only.
- No functional changes introduced.