### PR TITLE
Add file-like object support to spectrum.store() (fixes #506)

### DIFF
--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -4104,12 +4104,18 @@ class Spectrum(object):
 
         Parameters
         ----------
-        path: path to folder (database) or file
-            if a folder, file is saved to database and name is generated automatically.
-            if a file name, then Spectrum is saved to this file and the later
-            formatting options dont apply
-        file: str
-            explicitly give a filename to save
+        path: str or file-like object
+            If a string: path to folder (database) or file. If a folder, file
+            is saved to database and name is generated automatically. If a file
+            name, then Spectrum is saved to this file and the later formatting
+            options dont apply.
+
+            If a file-like object (e.g., ``io.BytesIO``, ``io.StringIO``):
+            writes directly to the object without any file system operations.
+            Use ``BytesIO`` when ``compress=True`` (binary output), use
+            ``StringIO`` when ``compress=False`` (text output). When using
+            file-like objects, the ``add_date``, ``add_info``, and
+            ``if_exists_then`` parameters are ignored.
         compress: boolean
             if ``False``, save under text format, readable with any editor.
             if ``True``, saves under binary format. Faster and takes less space.
@@ -4138,7 +4144,10 @@ class Spectrum(object):
 
         Returns
         -------
-        Returns filename used
+        str or file-like object
+            If path was a string: filename used (may be different from given
+            path as new info or incremental identifiers are added).
+            If path was a file-like object: returns the same object.
 
 
         Notes
@@ -4156,6 +4165,14 @@ class Spectrum(object):
             s.store('test.spec', compress=True)   # s is a Spectrum
             s2 = load_spec('test.spec')
             s2.update()                           # regenerate missing quantities
+
+        Store a spectrum to a BytesIO buffer (no disk write)::
+
+            from io import BytesIO
+            buffer = BytesIO()
+            s.store(buffer, compress=True)
+            buffer.seek(0)  # Reset position for reading
+            # buffer.getvalue() contains the serialized spectrum
 
         .. minigallery:: radis.spectrum.spectrum.Spectrum.store
             :add-heading:

--- a/radis/test/tools/test_database.py
+++ b/radis/test/tools/test_database.py
@@ -353,6 +353,93 @@ def test_fit_spectrum_plotting(plot=True, close_plots=True, *args, **kwargs):
         shutil.rmtree(db_path)
 
 
+@pytest.mark.fast
+def test_store_to_bytesio(verbose=True, *args, **kwargs):
+    """Test storing a spectrum to a BytesIO buffer."""
+    from io import BytesIO
+
+    import json_tricks
+
+    from radis.test.utils import getTestFile
+    from radis.tools.database import load_spec
+
+    s = load_spec(getTestFile("N2C_specair_380nm.spec"))
+
+    buffer = BytesIO()
+    result = s.store(buffer, compress=True, verbose=verbose)
+
+    assert result is buffer
+    assert buffer.tell() > 0
+
+    buffer.seek(0)
+    sload = json_tricks.load(buffer, preserve_order=False)
+    assert "conditions" in sload
+    assert "_q" in sload
+
+
+@pytest.mark.fast
+def test_store_to_stringio(verbose=True, *args, **kwargs):
+    """Test storing a spectrum to a StringIO buffer."""
+    from io import StringIO
+
+    from radis.test.utils import getTestFile
+    from radis.tools.database import load_spec
+
+    s = load_spec(getTestFile("N2C_specair_380nm.spec"))
+
+    buffer = StringIO()
+    result = s.store(buffer, compress=False, verbose=verbose)
+
+    assert result is buffer
+
+    buffer.seek(0)
+    content = buffer.read()
+    assert len(content) > 0
+    assert '"conditions"' in content
+
+
+@pytest.mark.fast
+def test_store_filelike_warns_on_path_params(verbose=True, *args, **kwargs):
+    """Test that path-related parameters emit warnings with file-like objects."""
+    import warnings
+    from io import BytesIO
+
+    from radis.test.utils import getTestFile
+    from radis.tools.database import load_spec
+
+    s = load_spec(getTestFile("N2C_specair_380nm.spec"))
+    buffer = BytesIO()
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        s.store(buffer, compress=True, add_date="%Y%m%d", verbose=False)
+        assert len(w) >= 1
+        assert "add_date" in str(w[0].message)
+
+
+@pytest.mark.fast
+def test_store_roundtrip_via_buffer(verbose=True, *args, **kwargs):
+    """Test that spectrum stored to buffer can be loaded back."""
+    from io import BytesIO
+
+    import json_tricks
+
+    from radis.test.utils import getTestFile
+    from radis.tools.database import _fix_format, _json_to_spec, load_spec
+
+    s = load_spec(getTestFile("N2C_specair_380nm.spec"))
+
+    buffer = BytesIO()
+    s.store(buffer, compress=True, discard=[], verbose=verbose)
+
+    buffer.seek(0)
+    sload = json_tricks.load(buffer, preserve_order=False)
+    sload, _ = _fix_format("buffer", sload)
+    s2 = _json_to_spec(sload, "buffer")
+
+    assert s.compare_with(s2, spectra_only=True, plot=False, verbose=verbose)
+
+
 if __name__ == "__main__":
     import pytest
 

--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -89,6 +89,11 @@ def is_jsonable(x):
         return False
 
 
+def _is_file_like(obj):
+    """Check if obj is a file-like object."""
+    return hasattr(obj, "write") and callable(obj.write)
+
+
 # def jsonize(x):
 #    ''' Converts x so it can be stored in JSON
 #    Replaced by call to json-tricks '''
@@ -153,10 +158,17 @@ def save(
     ----------
     s: Spectrum
         to save
-    path: str
-        filename to save. No extension needed. If filename already
+    path: str or file-like object
+        If a string: filename to save. No extension needed. If filename already
         exists then a digit is added. If filename is a directory then a new
         file is created within this directory.
+
+        If a file-like object (e.g., ``io.BytesIO``, ``io.StringIO``): writes
+        directly to the object without any file system operations. Use
+        ``BytesIO`` when ``compress=True`` (binary output), use ``StringIO``
+        when ``compress=False`` (text output). When using file-like objects,
+        the ``add_date``, ``add_info``, and ``if_exists_then`` parameters are
+        ignored.
     discard: list of str
         parameters to discard. To save some memory.
     compress: boolean
@@ -186,9 +198,10 @@ def save(
 
     Returns
     -------
-    fout: str
-        filename used (may be different from given path as new info or
-        incremental identifiers are added)
+    fout: str or file-like object
+        If path was a string: filename used (may be different from given path
+        as new info or incremental identifiers are added).
+        If path was a file-like object: returns the same object.
 
 
     See Also
@@ -201,12 +214,31 @@ def save(
     # 1) Format to JSON writable dictionary
     sjson = _format_to_jsondict(s, discard, compress, verbose=verbose)
 
-    # 2) Get final output name (add info, extension, increment number if needed)
+    # 2) Write to file-like object if provided
+    if _is_file_like(path):
+        if add_date and warnings:
+            warn("add_date ignored for file-like object")
+        if add_info and warnings:
+            warn("add_info ignored for file-like object")
+
+        if compress:
+            json_tricks.dump(
+                sjson, path, compression=True, properties={"ndarray_compact": True}
+            )
+        else:
+            json_tricks.dump(sjson, path, indent=4)
+
+        if verbose:
+            print(f"Spectrum stored to buffer ({path.tell() / 1e6:.2f} MB)")
+
+        return path
+
+    # 3) Get final output name (add info, extension, increment number if needed)
     fout = _get_fout_name(path, if_exists_then, add_date, add_info, sjson, verbose)
     if exists(fout) and if_exists_then == "ignore":
         return fout
 
-    # 3) Now is time to save
+    # 4) Now is time to save
     if compress:
         with open(fout, "wb") as f:
             json_tricks.dump(


### PR DESCRIPTION
<!-- Please be sure to check out our developer guide,
https://radis.readthedocs.io/en/latest/dev/developer.html -->

### Description
<!-- Provide a general description of what your pull request does. -->

## Description

Allow spectrum.store() to accept file-like objects (BytesIO, StringIO) instead of only file paths.

```python
from io import BytesIO
buffer = BytesIO()
spectrum.store(buffer)
```
Fixes #506
