### PR TITLE
fix(phys): add validation for non-positive temperatures in planck fun…

### DIFF
--- a/radis/phys/blackbody.py
+++ b/radis/phys/blackbody.py
@@ -23,6 +23,7 @@ Generate Earth blackbody::
 
 """
 
+import numpy as np
 from numpy import arange, exp, inf, ones_like, zeros_like
 
 from radis.phys.air import air2vacuum
@@ -57,6 +58,9 @@ def planck(lambda_, T, eps=1, unit="mW/cm2/sr/nm"):
     --------
     :py:func:`~radis.tools.blackbody.sPlanck`, :py:func:`~radis.phys.blackbody.planck_wn`
     """
+    if np.any(np.asarray(T) <= 0):
+        raise ValueError(f"Temperature must be strictly positive (K), got T={T}")
+
     k = k_b
     lbd = lambda_ * 1e-9
     iplanck = (
@@ -97,6 +101,9 @@ def planck_wn(wavenum, T, eps=1, unit="mW/cm2/sr/cm-1"):
     --------
     :py:func:`~radis.tools.blackbody.sPlanck`, :py:func:`~radis.phys.blackbody.planck`
     """
+    if np.any(np.asarray(T) <= 0):
+        raise ValueError(f"Temperature must be strictly positive (K), got T={T}")
+
     k = k_b_CGS
     h = h_CGS
     c = c_CGS

--- a/radis/test/phys/test_blackbody.py
+++ b/radis/test/phys/test_blackbody.py
@@ -38,6 +38,47 @@ def test_exceptions(verbose=True, *args, **kwargs):
         sPlanck(wavelength_min=300, wavelength_max=2000, T=300, eps=10)
 
 
+def test_invalid_temperature(*args, **kwargs):
+    """Test that planck() and planck_wn() raise ValueError for T <= 0.
+
+    Covers scalar and array inputs for both functions.
+    """
+
+    import pytest
+
+    # --- planck: scalar T ---
+    with pytest.raises(ValueError, match="strictly positive"):
+        planck(500, T=0)
+    with pytest.raises(ValueError, match="strictly positive"):
+        planck(500, T=-300)
+
+    # --- planck_wn: scalar T ---
+    with pytest.raises(ValueError, match="strictly positive"):
+        planck_wn(2000, T=0)
+    with pytest.raises(ValueError, match="strictly positive"):
+        planck_wn(2000, T=-100)
+
+    # --- planck: array containing a non-positive value ---
+    with pytest.raises(ValueError, match="strictly positive"):
+        planck(np.array([400, 500]), T=np.array([300, -10]))
+
+    # --- planck_wn: array containing a non-positive value ---
+    with pytest.raises(ValueError, match="strictly positive"):
+        planck_wn(np.array([1000, 2000]), T=np.array([0, 500]))
+
+    # --- sPlanck: T=0 and T<0 are also caught ---
+    with pytest.raises(ValueError, match="strictly positive"):
+        sPlanck(wavelength_min=300, wavelength_max=2000, T=0, eps=1)
+    with pytest.raises(ValueError, match="strictly positive"):
+        sPlanck(wavelength_min=300, wavelength_max=2000, T=-50, eps=1)
+
+    # --- Sanity: valid T still works ---
+    result = planck(500, T=300)
+    assert np.isfinite(result)
+    result = planck_wn(2000, T=300)
+    assert np.isfinite(result)
+
+
 def test_planck_nm(verbose=True, plot=False, *args, **kwargs):
     """Test blackbody with Wien's law, Stefan's law and tabulated data
     of maximum
@@ -177,6 +218,7 @@ def _run_testcases(plot=True, verbose=True, warnings=True, *args, **kwargs):
     # Test all Spectrum methods
     # -------------------------
     test_exceptions()
+    test_invalid_temperature()
     test_planck_nm(verbose=verbose, plot=plot, *args, **kwargs)
     test_planck_cm(verbose=verbose, plot=plot, *args, **kwargs)
 


### PR DESCRIPTION
### Description
This pull request addresses a physical inconsistency in the blackbody radiation functions `planck()` and `planck_wn()` within `radis/phys/blackbody.py`. 

**Changes:**
* **Input Validation:** Added vectorized guard clauses to ensure that the temperature $T$ is strictly positive. 
* **Error Handling:** Replaced cryptic `ZeroDivisionError` or nonsensical negative radiance results with a descriptive `ValueError` when $T \le 0$.
* **Performance:** Used `np.any(np.asarray(T) <= 0)` to maintain high performance for both scalar and NumPy array inputs, ensuring the check is efficient for large-scale spectroscopic data.
* **Testing:** Implemented `test_invalid_temperature()` in `radis/test/phys/test_blackbody.py` to cover edge cases ($T=0$, $T<0$) and ensure regression safety for valid inputs ($T=300K$).

**Compliance:**
* Code formatted using **Black** as per the developer guide.
* Tests are non-blocking and verified locally with a 100% pass rate.

Fixes #932 