### PR TITLE
Refactor: switch from os.path to pathlib (partial)

### DIFF
--- a/radis/db/hitemp_co2.py
+++ b/radis/db/hitemp_co2.py
@@ -9,7 +9,7 @@ database using block-aligned bzip2 decompression for specific wavenumber ranges.
 
 import bz2
 import io
-import os
+from pathlib import Path
 
 import numpy as np
 from tqdm import tqdm
@@ -17,8 +17,8 @@ from tqdm import tqdm
 from radis.misc.utils import getProjectRoot
 
 # Use absolute path to avoid issues
-project_root = getProjectRoot()
-offset_path = os.path.join(project_root, "db", "offset_arr.npy")
+project_root = Path(getProjectRoot())
+offset_path = project_root / "db" / "offset_arr.npy"
 
 offsets, pads = np.load(offset_path)
 sizes = offsets[1:] - offsets[:-1]
@@ -103,7 +103,7 @@ def partial_download_co2_chunk(
         If True, prints progress and status messages
     """
 
-    wavenumber_path = os.path.join(project_root, "db", "wavenumber_arr.npy")
+    wavenumber_path = project_root / "db" / "wavenumber_arr.npy"
     wavenumbers = np.load(wavenumber_path)
     i_min = np.searchsorted(wavenumbers, target_wn_min, side="left")
     i_max = np.searchsorted(wavenumbers, target_wn_max, side="right")
@@ -118,7 +118,7 @@ def partial_download_co2_chunk(
             f"Wavenumber range: {wavenumbers[i_min]:.6f} to {wavenumbers[i_max]:.6f} cm-1"
         )
 
-    os.makedirs(os.path.dirname(output_file_path), exist_ok=True)
+    Path(output_file_path).parent.mkdir(parents=True, exist_ok=True)
 
     offset = offsets[i_min]
     size = offsets[i_max + 1] - offsets[i_min]

--- a/radis/db/utils.py
+++ b/radis/db/utils.py
@@ -6,9 +6,8 @@
 
 
 import json
-import os
 from collections import OrderedDict
-from os.path import abspath
+from pathlib import Path
 
 from radis.misc.basics import is_number
 
@@ -25,10 +24,9 @@ def getFile(*relpath):
 
     """
 
-    #    return os.path.join(os.path.dirname(__file__), *relpath)
     from radis.misc.utils import getProjectRoot
 
-    return os.path.join(getProjectRoot(), "db", *relpath)
+    return str(Path(getProjectRoot()) / "db" / Path(*relpath))
 
 
 def check_molecule_data_structure(fname, verbose=True):
@@ -198,7 +196,7 @@ def get_default_jsonfile(molecule):
 
     name = config["spectroscopic_constants"][molecule]
 
-    return abspath(getFile(f"{molecule}/{name}"))
+    return str(Path(getFile(f"{molecule}/{name}")).resolve())
 
 
 def get_dunham_coefficients(

--- a/radis/misc/utils.py
+++ b/radis/misc/utils.py
@@ -196,7 +196,7 @@ def get_files_from_regex(path):
     """Returns a list of absolute paths of all the files whose names match the
     input regular expression."""
     path = Path(path)
-    directory_name = path.parent if path.parent != Path() else Path(".")
+    directory_name = path.parent
     regex = path.name
 
     file_names = []

--- a/radis/misc/utils.py
+++ b/radis/misc/utils.py
@@ -14,14 +14,14 @@ import inspect
 import os
 import sys
 from fnmatch import translate
-from os.path import basename, dirname, join
+from pathlib import Path
 from re import IGNORECASE, compile
 
 
 def getProjectRoot():
     """Return the full path of the project root."""
 
-    return dirname(dirname(__file__))
+    return str(Path(__file__).parent.parent)
 
 
 def import_from_module(module, name):
@@ -195,18 +195,17 @@ not_installed_nvidia_args = (
 def get_files_from_regex(path):
     """Returns a list of absolute paths of all the files whose names match the
     input regular expression."""
-    directory_name = dirname(path)
-    if directory_name == "":
-        directory_name = "."
-    regex = basename(path)
+    path = Path(path)
+    directory_name = path.parent if path.parent != Path() else Path(".")
+    regex = path.name
 
     file_names = []
 
     pattern = compile(translate(regex), IGNORECASE)
 
-    for file in os.listdir(directory_name):
-        if pattern.fullmatch(file):
-            file_names.append(join(directory_name, file))
+    for file in directory_name.iterdir():
+        if pattern.fullmatch(file.name):
+            file_names.append(str(directory_name / file.name))
 
     return file_names
 


### PR DESCRIPTION
<!-- Please be sure to check out our developer guide,
https://radis.readthedocs.io/en/latest/dev/developer.html -->

### Description
<!-- Provide a general description of what your pull request does. -->
 Fix for #53 - switching os.path to pathlib in a few files.

Changed:
- radis/db/utils.py
- radis/db/hitemp_co2.py
- radis/misc/utils.py
