### PR TITLE
Optimize import startup time with lazy top-level loading

### DIFF
--- a/radis/__init__.py
+++ b/radis/__init__.py
@@ -30,9 +30,9 @@
 
 """
 
+import importlib
 import os
 
-from .misc.config import get_config
 from .misc.utils import Chdir as _chdir
 from .misc.utils import getProjectRoot
 
@@ -45,7 +45,72 @@ from .misc.utils import getProjectRoot
 # the default one.
 # # molecular parameters for non-HITRAN species    should also be removed #TODO
 
-config = get_config()
+
+class _LazyConfig(dict):
+    """Lazy-loading wrapper for RADIS global config."""
+
+    def __init__(self):
+        super().__init__()
+        self._is_loaded = False
+
+    def _ensure_loaded(self):
+        if self._is_loaded:
+            return
+        from .misc.config import get_config
+
+        super().update(get_config())
+        self._is_loaded = True
+
+    def __getitem__(self, key):
+        self._ensure_loaded()
+        return super().__getitem__(key)
+
+    def __setitem__(self, key, value):
+        self._ensure_loaded()
+        return super().__setitem__(key, value)
+
+    def __contains__(self, key):
+        self._ensure_loaded()
+        return super().__contains__(key)
+
+    def __iter__(self):
+        self._ensure_loaded()
+        return super().__iter__()
+
+    def __len__(self):
+        self._ensure_loaded()
+        return super().__len__()
+
+    def get(self, key, default=None):
+        self._ensure_loaded()
+        return super().get(key, default)
+
+    def items(self):
+        self._ensure_loaded()
+        return super().items()
+
+    def keys(self):
+        self._ensure_loaded()
+        return super().keys()
+
+    def values(self):
+        self._ensure_loaded()
+        return super().values()
+
+    def update(self, *args, **kwargs):
+        self._ensure_loaded()
+        return super().update(*args, **kwargs)
+
+    def copy(self):
+        self._ensure_loaded()
+        return super().copy()
+
+    def __repr__(self):
+        self._ensure_loaded()
+        return super().__repr__()
+
+
+config = _LazyConfig()
 """dict: RADIS configuration parameters
 
 Parameters
@@ -221,25 +286,131 @@ __all__ = [
     "config",
     "version",
     "__version__",
+    "cdsd2df",
+    "hit2df",
+    "MOLECULES_LIST_EQUILIBRIUM",
+    "MOLECULES_LIST_NONEQUILIBRIUM",
+    "Molecules",
+    "getMolecule",
+    "fetch_hitemp",
+    "fetch_hitran",
+    "fetch_exomol",
+    "fetch_astroquery",
+    "fetch_geisa",
+    "LevelsList",
+    "SpectrumFactory",
+    "calc_spectrum",
+    "spectrum_test",
+    "MergeSlabs",
+    "SerialSlabs",
+    "sPlanck",
+    "planck",
+    "planck_wn",
+    "get_diff",
+    "get_distance",
+    "get_ratio",
+    "get_residual",
+    "get_residual_integral",
+    "plot_diff",
+    "calculated_spectrum",
+    "experimental_spectrum",
+    "transmittance_spectrum",
+    "PerfectAbsorber",
+    "Radiance",
+    "Radiance_noslit",
+    "Transmittance",
+    "Transmittance_noslit",
+    "Spectrum",
+    "SpecDatabase",
+    "load_spec",
+    "plot_spec",
+    "save",
+    "get_eq_mole_fraction",
+    "plot_slit",
+    "get_effective_FWHM",
+    "get_FWHM",
 ]
 
-# prevent cyclic imports:
-from . import api, db, io, lbl, los, misc, phys, spectrum, tools
-from .api import *  # input / output common with ExoJax
-from .db import *  # database of molecules
-from .io import *  # input / output
-from .lbl import *  # line-by-line module
-from .levels import *  # rovibrational energies and partition functions
-from .los import *  # line-of-sight module
-from .phys import *  # conversion functions, blackbody objects
-from .spectrum import *  # Spectrum object
-from .tools import *  # slit, database, line survey, etc.
+_EXPORT_TO_MODULE = {
+    "cdsd2df": "api",
+    "hit2df": "api",
+    "MOLECULES_LIST_EQUILIBRIUM": "db",
+    "MOLECULES_LIST_NONEQUILIBRIUM": "db",
+    "Molecules": "db",
+    "getMolecule": "db",
+    "fetch_hitemp": "io",
+    "fetch_hitran": "io",
+    "fetch_exomol": "io",
+    "fetch_astroquery": "io",
+    "fetch_geisa": "io",
+    "LevelsList": "lbl",
+    "SpectrumFactory": "lbl",
+    "calc_spectrum": "lbl",
+    "spectrum_test": "lbl",
+    "MergeSlabs": "los",
+    "SerialSlabs": "los",
+    "sPlanck": "phys",
+    "planck": "phys",
+    "planck_wn": "phys",
+    "get_diff": "spectrum",
+    "get_distance": "spectrum",
+    "get_ratio": "spectrum",
+    "get_residual": "spectrum",
+    "get_residual_integral": "spectrum",
+    "plot_diff": "spectrum",
+    "calculated_spectrum": "spectrum",
+    "experimental_spectrum": "spectrum",
+    "transmittance_spectrum": "spectrum",
+    "PerfectAbsorber": "spectrum",
+    "Radiance": "spectrum",
+    "Radiance_noslit": "spectrum",
+    "Transmittance": "spectrum",
+    "Transmittance_noslit": "spectrum",
+    "Spectrum": "spectrum",
+    "SpecDatabase": "tools",
+    "load_spec": "tools",
+    "plot_spec": "tools",
+    "save": "tools",
+    "get_eq_mole_fraction": "tools",
+    "plot_slit": "tools",
+    "get_effective_FWHM": "tools",
+    "get_FWHM": "tools",
+}
 
-__all__.extend(api.__all__)
-__all__.extend(db.__all__)
-__all__.extend(io.__all__)
-__all__.extend(lbl.__all__)
-__all__.extend(los.__all__)
-__all__.extend(phys.__all__)
-__all__.extend(spectrum.__all__)
-__all__.extend(tools.__all__)
+_SUBMODULES = {
+    "api",
+    "db",
+    "gpu",
+    "io",
+    "lbl",
+    "levels",
+    "los",
+    "misc",
+    "phys",
+    "spectrum",
+    "tools",
+}
+
+
+def _load_submodule(name):
+    module = importlib.import_module(f".{name}", __name__)
+    globals()[name] = module
+    return module
+
+
+def __getattr__(name):
+    if name in _SUBMODULES:
+        return _load_submodule(name)
+
+    module_name = _EXPORT_TO_MODULE.get(name)
+    if module_name is not None:
+        module = _load_submodule(module_name)
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__) | _SUBMODULES)

--- a/radis/misc/__init__.py
+++ b/radis/misc/__init__.py
@@ -1,48 +1,111 @@
 # -*- coding: utf-8 -*-
 """Misc. and support functions"""
 
+import importlib
 
-from .arrays import (
-    array_allclose,
-    autoturn,
-    bining,
-    calc_diff,
-    centered_diff,
-    count_nans,
-    evenly_distributed,
-    find_first,
-    find_nearest,
-    is_sorted,
-    is_sorted_backward,
-    logspace,
-    nantrapz,
-    norm,
-    norm_on,
-    scale_to,
-)
-from .basics import (
-    compare_dict,
-    compare_lists,
-    compare_paths,
-    exec_file,
-    is_float,
-    key_max_val,
-    list_if_float,
-    make_folders,
-    merge_lists,
-    partition,
-    remove_duplicates,
-)
-from .config import getDatabankEntries, getDatabankList
-from .curve import (
-    curve_add,
-    curve_distance,
-    curve_divide,
-    curve_multiply,
-    curve_substract,
-)
-from .database_progress import DatabaseProgressPrinter, get_progress_printer
-from .debug import export
-from .progress_bar import ProgressBar
-from .signal import resample, resample_even
-from .utils import DatabankNotFound, NotInstalled, getProjectRoot
+__all__ = [
+    "array_allclose",
+    "autoturn",
+    "bining",
+    "calc_diff",
+    "centered_diff",
+    "count_nans",
+    "evenly_distributed",
+    "find_first",
+    "find_nearest",
+    "is_sorted",
+    "is_sorted_backward",
+    "logspace",
+    "nantrapz",
+    "norm",
+    "norm_on",
+    "scale_to",
+    "compare_dict",
+    "compare_lists",
+    "compare_paths",
+    "exec_file",
+    "is_float",
+    "key_max_val",
+    "list_if_float",
+    "make_folders",
+    "merge_lists",
+    "partition",
+    "remove_duplicates",
+    "getDatabankEntries",
+    "getDatabankList",
+    "curve_add",
+    "curve_distance",
+    "curve_divide",
+    "curve_multiply",
+    "curve_substract",
+    "DatabaseProgressPrinter",
+    "get_progress_printer",
+    "export",
+    "ProgressBar",
+    "resample",
+    "resample_even",
+    "DatabankNotFound",
+    "NotInstalled",
+    "getProjectRoot",
+]
+
+_EXPORT_TO_MODULE = {
+    "array_allclose": "arrays",
+    "autoturn": "arrays",
+    "bining": "arrays",
+    "calc_diff": "arrays",
+    "centered_diff": "arrays",
+    "count_nans": "arrays",
+    "evenly_distributed": "arrays",
+    "find_first": "arrays",
+    "find_nearest": "arrays",
+    "is_sorted": "arrays",
+    "is_sorted_backward": "arrays",
+    "logspace": "arrays",
+    "nantrapz": "arrays",
+    "norm": "arrays",
+    "norm_on": "arrays",
+    "scale_to": "arrays",
+    "compare_dict": "basics",
+    "compare_lists": "basics",
+    "compare_paths": "basics",
+    "exec_file": "basics",
+    "is_float": "basics",
+    "key_max_val": "basics",
+    "list_if_float": "basics",
+    "make_folders": "basics",
+    "merge_lists": "basics",
+    "partition": "basics",
+    "remove_duplicates": "basics",
+    "getDatabankEntries": "config",
+    "getDatabankList": "config",
+    "curve_add": "curve",
+    "curve_distance": "curve",
+    "curve_divide": "curve",
+    "curve_multiply": "curve",
+    "curve_substract": "curve",
+    "DatabaseProgressPrinter": "database_progress",
+    "get_progress_printer": "database_progress",
+    "export": "debug",
+    "ProgressBar": "progress_bar",
+    "resample": "signal",
+    "resample_even": "signal",
+    "DatabankNotFound": "utils",
+    "NotInstalled": "utils",
+    "getProjectRoot": "utils",
+}
+
+
+def __getattr__(name):
+    module_name = _EXPORT_TO_MODULE.get(name)
+    if module_name is None:
+        raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+    module = importlib.import_module(f".{module_name}", __name__)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/radis/test/test_import_radis.py
+++ b/radis/test/test_import_radis.py
@@ -13,6 +13,50 @@ which uses tuna
 https://github.com/nschloe/tuna
 """
 
+import json
+import subprocess
+import sys
+
+import pytest
+
 import radis
 
 assert radis  # silences pyflakes
+
+
+def _run_python(code):
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    )
+    return proc.stdout.strip()
+
+
+@pytest.mark.fast
+def test_import_radis_is_lazy():
+    loaded = json.loads(
+        _run_python(
+            "import json, sys; import radis; "
+            "print(json.dumps({"
+            "'radis.misc.arrays': 'radis.misc.arrays' in sys.modules, "
+            "'radis.tools.slit': 'radis.tools.slit' in sys.modules, "
+            "'radis.lbl.broadening': 'radis.lbl.broadening' in sys.modules"
+            "}))"
+        )
+    )
+    assert loaded["radis.misc.arrays"] is False
+    assert loaded["radis.tools.slit"] is False
+    assert loaded["radis.lbl.broadening"] is False
+
+
+@pytest.mark.fast
+def test_import_radis_public_symbols():
+    result = _run_python(
+        "from radis import SpectrumFactory, calc_spectrum, config, load_spec; "
+        "print(all(["
+        "callable(calc_spectrum), "
+        "isinstance(config, dict), "
+        "callable(load_spec), "
+        "isinstance(SpectrumFactory, type)"
+        "]))"
+    )
+    assert result == "True"


### PR DESCRIPTION
### Description
This pull request is to address startup-time bottlenecks tracked in #937 by removing eager top-level imports in `import radis`.

Main changes:
- Replaced eager top-level API imports in `radis/__init__.py` with lazy attribute resolution (`__getattr__`) while preserving the same public symbols in `__all__`.
- Added lazy loading for `radis.config` via `_LazyConfig` so config parsing happens only when config is used.
- Refactored `radis/misc/__init__.py` to lazy-load exports, avoiding eager import of `radis.misc.arrays` (and its heavy transitive imports) during plain `import radis`.
- Added regression tests in `radis/test/test_import_radis.py` to ensure:
  - heavy modules are not imported eagerly;
  - public top-level imports (e.g. `from radis import calc_spectrum, config`) still work.

### Benchmark notes (local)
Command used:
- `python -c "import time; t=time.perf_counter(); import radis; print(time.perf_counter()-t)"` (5 independent subprocesses)

Before (this branch base):
- run1 26.6566s, run2 5.7458s, run3 4.7028s, run4 4.5999s, run5 4.4917s

After:
- run1 0.0323s, run2 0.0243s, run3 0.0231s, run4 0.0180s, run5 0.0189s

`-X importtime` also shows top-level `radis` no longer eagerly imports the previous heavy module tree.

### Validation
- `python -m black radis/__init__.py radis/misc/__init__.py radis/test/test_import_radis.py`
- `python -m pytest radis/test/test_import_radis.py radis/test/misc/test_config.py radis/test/test_misc.py -q`

Fixes #937
