### PR TITLE
Add h5py fallback memory-mapping backend when Vaex is unavailable

### DIFF
--- a/radis/api/dbmanager.py
+++ b/radis/api/dbmanager.py
@@ -49,11 +49,11 @@ LAST_VALID_DATE = (
 def get_auto_MEMORY_MAPPING_ENGINE():
     """see https://github.com/radis/radis/issues/653
 
-    Use Vaex by default if it exists (only Python <= 3.11 as of June 2024) ,
-    else use PyTables"""
+    Use Vaex by default if it exists, else use h5py as a lightweight
+    memory-mapped backend."""
     # Check if vaex is available
     if isinstance(vaex, NotInstalled):
-        return "pytables"
+        return "h5py"
     else:
         return "vaex"
 
@@ -604,7 +604,7 @@ class DatabaseManager(object):
         """
         engine = self.engine
         mgr = self.get_datafile_manager()
-        if engine in ["pytables", "feather"]:
+        if engine in ["pytables", "feather", "h5py"]:
             df_all = []
             for local_file in local_files:
                 df_all.append(
@@ -655,7 +655,14 @@ class DatabaseManager(object):
             df.close()
 
         elif engine in ["h5py"]:
-            raise NotImplementedError
+            import h5py
+
+            with h5py.File(local_file, "r") as hf:
+                group = hf
+                if "table" in hf and isinstance(hf["table"], h5py.Group):
+                    group = hf["table"]
+                first_column = next(iter(group.keys()))
+                nrows = len(group[first_column])
         else:
             raise ValueError(engine)
         return nrows

--- a/radis/api/hdf5.py
+++ b/radis/api/hdf5.py
@@ -10,6 +10,7 @@ from os.path import abspath, exists, expanduser, splitext
 from time import time
 
 import h5py
+import numpy as np
 import pandas as pd
 from tables.exceptions import NoSuchNodeError
 
@@ -27,6 +28,33 @@ def vaexsafe_colname(name):
     https://github.com/vaexio/vaex/issues/1255
     """
     return name.replace("/", "_")
+
+
+def _decode_if_bytes(arr):
+    """Decode byte arrays loaded from HDF5 to UTF-8 strings."""
+    if isinstance(arr, np.ndarray) and arr.dtype.kind == "S":
+        return np.char.decode(arr, "utf-8", errors="ignore")
+    return arr
+
+
+def _series_to_h5py_array(series):
+    """Convert a pandas Series into an h5py-compatible 1D array."""
+    arr = series.to_numpy()
+    if arr.dtype.kind in {"U", "O"}:
+        arr = arr.astype(str)
+        return arr, h5py.string_dtype(encoding="utf-8")
+    return arr, None
+
+
+def _get_h5_group(hf, key):
+    """Return the target HDF5 group for key.
+
+    If key is None, returns the root group.
+    """
+    if key is None:
+        return hf
+    key = key.lstrip("/")
+    return hf.require_group(key)
 
 
 def update_pytables_to_vaex(fname, remove_initial=False, verbose=True, key="df"):
@@ -218,6 +246,36 @@ class DataFileManager(object):
                 self._temp_batch_files.append(file)
             # Write:
             df.export_hdf5(file, group=key, mode="w")
+        elif self.engine == "h5py":
+            if key == "default":
+                key = None
+
+            # Convert to pandas for a consistent write path.
+            if not isinstance(df, pd.DataFrame):
+                if not isinstance(vaex, NotInstalled) and isinstance(
+                    df, vaex.dataframe.DataFrameLocal
+                ):
+                    df = df.to_pandas_df()
+                else:
+                    df = pd.DataFrame(df)
+
+            mode = "a" if append else "w"
+            with h5py.File(file, mode) as hf:
+                group = _get_h5_group(hf, key)
+
+                for col in df.columns:
+                    arr, dtype = _series_to_h5py_array(df[col])
+
+                    if col in group:
+                        ds = group[col]
+                        old_len = ds.shape[0]
+                        ds.resize((old_len + len(arr),))
+                        ds[old_len:] = arr
+                    else:
+                        kwargs = {"maxshape": (None,), "chunks": True}
+                        if dtype is not None:
+                            kwargs["dtype"] = dtype
+                        group.create_dataset(col, data=arr, **kwargs)
         elif self.engine == "feather":
             df.to_feather(file)
         else:
@@ -238,7 +296,11 @@ class DataFileManager(object):
             with pd.HDFStore(local_file, "r") as store:
                 columns = store.select("df", start=1, stop=1).columns
         elif engine in ["h5py"]:
-            raise NotImplementedError
+            with h5py.File(local_file, "r") as hf:
+                group = hf
+                if "table" in hf and isinstance(hf["table"], h5py.Group):
+                    group = hf["table"]
+                columns = list(group.keys())
         else:
             raise ValueError(engine)
 
@@ -378,6 +440,11 @@ class DataFileManager(object):
                 df = df
             else:
                 raise NotImplementedError(f"output {output} for engine {engine}")
+        elif engine == "h5py":
+            if output == "pandas":
+                df = df
+            else:
+                raise NotImplementedError(f"output {output} for engine {engine}")
         elif engine == "feather":
             if output == "pandas":
                 df = df
@@ -490,18 +557,27 @@ class DataFileManager(object):
 
         elif self.engine == "h5py":
             fname = expanduser(fname)
-            # TODO: define default key ?
-            if key == "default":
-                key = None
+            with h5py.File(fname, "r") as hf:
+                if key == "default":
+                    if "table" in hf and isinstance(hf["table"], h5py.Group):
+                        key = "/table"
+                    else:
+                        key = None
 
-            with h5py.File(fname, "r") as f:
                 if key is None:  # load from root level
-                    load_from = f
+                    load_from = hf
                 else:
-                    load_from = f[key]
+                    load_from = hf[key]
+
+                all_columns = list(load_from.keys())
+                if columns is None:
+                    columns_to_load = all_columns
+                else:
+                    columns_to_load = [c for c in columns if c in all_columns]
+
                 out = {}
-                for k in load_from.keys():
-                    out[k] = f[k][()]
+                for col in columns_to_load:
+                    out[col] = _decode_if_bytes(load_from[col][()])
             return pd.DataFrame(out)
 
         elif self.engine == "feather":
@@ -559,8 +635,58 @@ class DataFileManager(object):
             # Selection is done after opening the file time in vaex
             # see end of this function
             where = None
+        elif self.engine == "h5py":
+            # Selection is implemented below with direct column access.
+            where = None
         else:
             raise NotImplementedError(self.engine)
+
+        if self.engine == "h5py":
+            fname = expanduser(fname)
+            key = store_kwargs.get("key", "default")
+            with h5py.File(fname, "r") as hf:
+                if key == "default":
+                    if "table" in hf and isinstance(hf["table"], h5py.Group):
+                        key = "/table"
+                    else:
+                        key = None
+                load_from = hf if key is None else hf[key]
+
+                all_columns = list(load_from.keys())
+                filter_columns = {column for column, _ in lower_bound}
+                filter_columns.update(column for column, _ in upper_bound)
+                filter_columns.update(column for column, _ in within)
+
+                if columns is None:
+                    target_columns = all_columns
+                else:
+                    target_columns = [c for c in columns if c in all_columns]
+                required_columns = list(set(target_columns).union(filter_columns))
+
+                out = {}
+                for col in required_columns:
+                    out[col] = _decode_if_bytes(load_from[col][()])
+
+            if len(out) == 0:
+                return pd.DataFrame()
+
+            first_col = next(iter(out))
+            mask = np.ones(len(out[first_col]), dtype=bool)
+            for column, lbound in lower_bound:
+                mask &= out[column] > lbound
+            for column, ubound in upper_bound:
+                mask &= out[column] < ubound
+            for column, withinv in within:
+                values = [v for v in withinv.split(",") if v != ""]
+                arr = out[column]
+                if np.issubdtype(arr.dtype, np.number):
+                    values = [arr.dtype.type(float(v)) for v in values]
+                mask &= np.isin(arr, values)
+
+            selected = {}
+            for col in target_columns:
+                selected[col] = out[col][mask]
+            return pd.DataFrame(selected)
 
         # Load :
         df = self.read(fname, columns=columns, where=where, **store_kwargs)
@@ -821,6 +947,10 @@ class DataFileManager(object):
             return b.sum() > 0
         elif self.engine in ["pytables", "feather"]:
             return column.hasnans
+        elif self.engine == "h5py":
+            if np.issubdtype(column.dtype, np.number):
+                return np.isnan(column).any()
+            return False
         else:
             raise NotImplementedError(self.engine)
 

--- a/radis/default_radis.json
+++ b/radis/default_radis.json
@@ -22,7 +22,7 @@
     "WARN_LARGE_DOWNLOAD_ABOVE_X_GB": 1  # Warn the user when downloading databases larger than X GB but does *not* stop the download,
     "GRIDPOINTS_PER_LINEWIDTH_WARN_THRESHOLD": 3    # raise a warning if less than THIS number of grid points per lineshape,
     "GRIDPOINTS_PER_LINEWIDTH_ERROR_THRESHOLD": 1   # raise an error if less than THIS number of grid points per lineshape,
-    "MEMORY_MAPPING_ENGINE": "auto"         # "vaex",/"pytables"/"feather". "auto" uses "vaex" in most cases
+    "MEMORY_MAPPING_ENGINE": "auto"         # "vaex"/"h5py"/"pytables"/"feather". "auto" uses "vaex" when available, else "h5py"
     "SPARSE_WAVERANGE": "auto"              # true,/false. sparse LDM algorithm. May be smaller on dense spectra. If "auto", a scarcity criterion is used (Nlines/Ngrids > 1)
     "DEFAULT_DOWNLOAD_PATH": "~/.radisdb"   # default path for downloading databases with databank='hitran'/'hitemp'/'exomol' . You can also specify a local path for each entry of the, "database" list.
     "RESAMPLING_TOLERANCE_THRESHOLD": 5e-3  # an error if raises if areas do not match by a value above, this threshold during resampling. See :py:meth:`~radis.spectrum.spectrum.Spectrum.resample`

--- a/radis/misc/utils.py
+++ b/radis/misc/utils.py
@@ -181,8 +181,8 @@ not_installed_vaex_args = (
     "vaex",
     "You must install Vaex to use these features. Vaex is a fast, "
     + "memory-mapped DataFrame library. However is not available yet on latest Python versions. "
-    + "Use Pytables (slower) as an alternative in your Radis.json config file. To use Pytables, set "
-    + '"MEMORY_MAPPING_ENGINE": "pytables" and "DATAFRAME_ENGINE": "pandas"',
+    + "Use h5py or Pytables as alternatives in your Radis.json config file. "
+    + 'For h5py, set "MEMORY_MAPPING_ENGINE": "h5py" and "DATAFRAME_ENGINE": "pandas".',
 )
 not_installed_nvidia_args = (
     "nvidia-cufft",

--- a/radis/test/io/test_hdf5.py
+++ b/radis/test/io/test_hdf5.py
@@ -19,7 +19,6 @@ except ImportError:
 
 
 @pytest.mark.fast
-@pytest.mark.skipif(isinstance(vaex, NotInstalled), reason="Vaex not available")
 def test_hdf5_io_engines(*args, **kwargs):
     """Test different engines implemented in :py:class:`radis.api.hdf5.DataFileManager`"""
 
@@ -60,25 +59,73 @@ def test_hdf5_io_engines(*args, **kwargs):
     assert (df == df0).all().all()
     assert manager.read_metadata("test_h5py.h5") == metadata0
 
-    # Test vaex engine : add_metadata ; load ; read_
-    # .. also able to read h5py files
-    manager = DataFileManager(engine="vaex")
-    manager.add_metadata("test_h5py.h5", metadata0, key=None)
-    df = manager.read("test_h5py.h5", key=None)
-    # this time; df is a vaex DataFrame
-    # ... it keeps the file open so we should close the file handle
-    assert (df.to_pandas_df() == df0).all().all()
-    df.close()
-    assert manager.read_metadata("test_h5py.h5", key=None) == metadata0
+    if not isinstance(vaex, NotInstalled):
+        # Test vaex engine : add_metadata ; load ; read_
+        # .. also able to read h5py files
+        manager = DataFileManager(engine="vaex")
+        manager.add_metadata("test_h5py.h5", metadata0, key=None)
+        df = manager.read("test_h5py.h5", key=None)
+        # this time; df is a vaex DataFrame
+        # ... it keeps the file open so we should close the file handle
+        assert (df.to_pandas_df() == df0).all().all()
+        df.close()
+        assert manager.read_metadata("test_h5py.h5", key=None) == metadata0
 
     # Test get_columns function of DataFileManager
-    # For vaex
-    manager = DataFileManager(engine="vaex")
-    assert list(manager.get_columns("test_h5py.h5")) == ["a", "b"]
+    if not isinstance(vaex, NotInstalled):
+        # For vaex
+        manager = DataFileManager(engine="vaex")
+        assert list(manager.get_columns("test_h5py.h5")) == ["a", "b"]
 
     # For pytables
     manager = DataFileManager(engine="pytables")
     assert list(manager.get_columns("test_pytables.h5")) == ["a", "b"]
+
+
+@pytest.mark.fast
+def test_h5py_append_and_filter():
+    import os
+
+    import numpy as np
+    import pandas as pd
+
+    fname = "test_h5py_append.hdf5"
+    if os.path.exists(fname):
+        os.remove(fname)
+
+    df1 = pd.DataFrame({"wav": np.array([1000.0, 1001.0, 1002.0]), "iso": [1, 2, 1]})
+    df2 = pd.DataFrame({"wav": np.array([1003.0, 1004.0, 1005.0]), "iso": [2, 1, 2]})
+
+    manager = DataFileManager(engine="h5py")
+    manager.write(fname, df1, append=False)
+    manager.write(fname, df2, append=True)
+    manager.add_metadata(fname, {"source": "unit_test"}, key=None)
+
+    loaded = manager.load(
+        fname,
+        columns=["wav", "iso"],
+        lower_bound=[("wav", 1001.5)],
+        upper_bound=[("wav", 1004.5)],
+        within=[("iso", "1")],
+        output="pandas",
+    )
+
+    assert list(loaded["wav"]) == [1002.0, 1004.0]
+    assert list(loaded["iso"]) == [1, 1]
+    assert manager.read_metadata(fname, key=None)["source"] == "unit_test"
+
+
+@pytest.mark.fast
+def test_auto_memory_mapping_engine_fallback(monkeypatch):
+    from radis.api import dbmanager
+
+    monkeypatch.setattr(
+        dbmanager,
+        "vaex",
+        NotInstalled(*not_installed_vaex_args),
+        raising=False,
+    )
+    assert dbmanager.get_auto_MEMORY_MAPPING_ENGINE() == "h5py"
 
 
 @pytest.mark.needs_connection


### PR DESCRIPTION
### Description
This pull request is to address part of #658 by making `h5py` a practical fallback memory-mapping backend when Vaex is unavailable.

Changes included:
- Implemented missing `h5py` engine pieces in `DataFileManager`:
  - write/append support for DataFrames,
  - column discovery,
  - filtered loading (`lower_bound`, `upper_bound`, `within`),
  - output handling in `load(...)` for `engine='h5py'` and `output='pandas'`.
- Enabled `DatabaseManager` usage with `engine='h5py'`:
  - loading from multiple local files,
  - row count retrieval.
- Updated auto engine selection:
  - `get_auto_MEMORY_MAPPING_ENGINE()` now returns `h5py` when Vaex is not installed.
- Updated user-facing fallback guidance/messages:
  - `default_radis.json` engine comment,
  - `not_installed_vaex_args` hint in `radis.misc.utils`.
- Extended tests in `radis/test/io/test_hdf5.py`:
  - removed unconditional skip of `test_hdf5_io_engines` when Vaex is absent,
  - added `test_h5py_append_and_filter`,
  - added `test_auto_memory_mapping_engine_fallback`.

Scope note:
- This PR does not add Polars/DuckDB integration yet.
- It provides an immediately available, dependency-light fallback path for Python environments where Vaex is unavailable.

Fixes #658
