### PR TITLE
Fix spurious HITEMP HTTPError when HEAD returns HTML

### DIFF
--- a/.github/workflows/tests-develop.yml
+++ b/.github/workflows/tests-develop.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       fail-fast: false
-      max-parallel: 3
+      # max-parallel: 3
       matrix:
         include:
           # - os: ubuntu-latest

--- a/radis/api/dbmanager.py
+++ b/radis/api/dbmanager.py
@@ -441,10 +441,9 @@ class DatabaseManager(object):
                 )
 
             def _looks_like_html_payload(chunk):
-                snippet = chunk[:1024].lstrip().lower()
-                return snippet.startswith(b"<!doctype html") or snippet.startswith(
-                    b"<html"
-                )
+                snippet = chunk[:2048].lstrip().lower()
+                html_markers = (b"<!doctype html", b"<html", b"<head", b"<body")
+                return any(marker in snippet for marker in html_markers)
 
             try:
                 # Now download the file
@@ -462,9 +461,9 @@ class DatabaseManager(object):
                         first_chunk = chunk
                         break
 
-                if "text/html" in content_type and _looks_like_html_payload(
-                    first_chunk
-                ):
+                # Reject HTML responses from GET directly. Keep payload sniffing as
+                # fallback when servers mislabel an HTML page as octet-stream.
+                if "text/html" in content_type or _looks_like_html_payload(first_chunk):
                     raise requests.HTTPError(
                         "Received HTML content from GET request instead of the expected file payload. "
                         f"This may indicate authentication is required or access is restricted for URL: {urlname}."

--- a/radis/api/dbmanager.py
+++ b/radis/api/dbmanager.py
@@ -434,9 +434,9 @@ class DatabaseManager(object):
 
             # First check if we can access the file
             head_response = session.head(urlname, headers=headers, allow_redirects=True)
-            if head_response.status_code >= 400:
+            if head_response.status_code != 200:
                 raise requests.HTTPError(
-                    f"Unable to access the resource (HEAD request). Received HTTP status code {head_response.status_code} for URL: {urlname}. "
+                    f"Unable to access the resource (HEAD request). Expected HTTP status code 200, got {head_response.status_code} for URL: {urlname}. "
                     "Please verify the URL and your network access permissions."
                 )
 

--- a/radis/api/dbmanager.py
+++ b/radis/api/dbmanager.py
@@ -434,16 +434,16 @@ class DatabaseManager(object):
 
             # First check if we can access the file
             head_response = session.head(urlname, headers=headers, allow_redirects=True)
-            if head_response.status_code != 200:
+            if head_response.status_code >= 400:
                 raise requests.HTTPError(
-                    f"Unable to access the resource. Received HTTP status code {head_response.status_code} for URL: {urlname}. "
+                    f"Unable to access the resource (HEAD request). Received HTTP status code {head_response.status_code} for URL: {urlname}. "
                     "Please verify the URL and your network access permissions."
                 )
 
-            # Check if we got redirected to login page
-            if "text/html" in head_response.headers.get("content-type", "").lower():
-                raise requests.HTTPError(
-                    "Received an HTML response instead of the expected file content. This may indicate authentication is required or access to the resource is restricted. Please verify your credentials and permissions for the requested URL: ({urlname})."
+            def _looks_like_html_payload(chunk):
+                snippet = chunk[:1024].lstrip().lower()
+                return snippet.startswith(b"<!doctype html") or snippet.startswith(
+                    b"<html"
                 )
 
             try:
@@ -452,6 +452,23 @@ class DatabaseManager(object):
                     urlname, headers=headers, stream=True, allow_redirects=True
                 )
                 response.raise_for_status()  # Raise an error if request fails
+                content_type = response.headers.get("content-type", "").lower()
+                chunks = response.iter_content(chunk_size=8192)
+
+                # Peek the first non-empty chunk to detect HTML/login pages.
+                first_chunk = b""
+                for chunk in chunks:
+                    if chunk:
+                        first_chunk = chunk
+                        break
+
+                if "text/html" in content_type and _looks_like_html_payload(
+                    first_chunk
+                ):
+                    raise requests.HTTPError(
+                        "Received HTML content from GET request instead of the expected file payload. "
+                        f"This may indicate authentication is required or access is restricted for URL: {urlname}."
+                    )
 
                 # Create a temporary file to store the downloaded content
                 temp_file_path = urlname.split("/")[-1]
@@ -474,7 +491,11 @@ class DatabaseManager(object):
                         desc="Downloading",
                         disable=not verbose,
                     ) as pbar:
-                        for chunk in response.iter_content(chunk_size=8192):
+                        if first_chunk:
+                            f.write(first_chunk)
+                            pbar.update(len(first_chunk))
+
+                        for chunk in chunks:
                             if chunk:  # filter out keep-alive new chunks
                                 f.write(chunk)
                                 pbar.update(len(chunk))

--- a/radis/test/api/test_dbmanager_download.py
+++ b/radis/test/api/test_dbmanager_download.py
@@ -63,9 +63,37 @@ class _DummyDownloadManager(DatabaseManager):
         return 1
 
 
+@pytest.fixture
+def manager(tmp_path):
+    return _DummyDownloadManager(tmp_path)
+
+
+@pytest.fixture
+def run_download(tmp_path, monkeypatch):
+    def _run(
+        manager, session, *, urlname="https://example.org/test.par.bz2", hitemp=False
+    ):
+        if hitemp:
+            import radis.api.hitempapi as hitempapi
+
+            monkeypatch.setattr(
+                hitempapi, "login_to_hitran", lambda verbose=False: session
+            )
+        else:
+            monkeypatch.setattr(requests, "Session", lambda: session)
+
+        monkeypatch.chdir(tmp_path)
+        manager.download_and_parse(
+            urlnames=[urlname],
+            local_files=[str(tmp_path / "dummy_output.hdf5")],
+            N_files_total=1,
+        )
+
+    return _run
+
+
 @pytest.mark.fast
-def test_hitemp_head_html_get_binary_does_not_fail(tmp_path, monkeypatch):
-    manager = _DummyDownloadManager(tmp_path)
+def test_hitemp_head_html_get_binary_does_not_fail(manager, run_download):
     session = _FakeSession(
         head_response=_FakeResponse(
             status_code=200,
@@ -77,16 +105,11 @@ def test_hitemp_head_html_get_binary_does_not_fail(tmp_path, monkeypatch):
             chunks=[b"BZh9", b"DATA"],
         ),
     )
-
-    import radis.api.hitempapi as hitempapi
-
-    monkeypatch.setattr(hitempapi, "login_to_hitran", lambda verbose=False: session)
-    monkeypatch.chdir(tmp_path)
-
-    manager.download_and_parse(
-        urlnames=["https://hitran.org/files/HITEMP/bzip2format/06_HITEMP2020.par.bz2"],
-        local_files=[str(tmp_path / "dummy_output.hdf5")],
-        N_files_total=1,
+    run_download(
+        manager,
+        session,
+        urlname="https://hitran.org/files/HITEMP/bzip2format/06_HITEMP2020.par.bz2",
+        hitemp=True,
     )
 
     assert manager.parse_calls == 1
@@ -95,67 +118,40 @@ def test_hitemp_head_html_get_binary_does_not_fail(tmp_path, monkeypatch):
 
 
 @pytest.mark.fast
-def test_get_html_payload_raises_httperror(tmp_path, monkeypatch):
-    manager = _DummyDownloadManager(tmp_path)
-    session = _FakeSession(
-        head_response=_FakeResponse(
-            status_code=200, headers={"content-type": "text/html"}
-        ),
-        get_response=_FakeResponse(
-            status_code=200,
-            headers={"content-type": "text/html", "content-length": "32"},
-            chunks=[b"<html><body>login</body></html>"],
-        ),
-    )
-
-    monkeypatch.setattr(requests, "Session", lambda: session)
-    monkeypatch.chdir(tmp_path)
-
-    with pytest.raises(requests.HTTPError, match="HTML content from GET request"):
-        manager.download_and_parse(
-            urlnames=["https://example.org/test.par.bz2"],
-            local_files=[str(tmp_path / "dummy_output.hdf5")],
-            N_files_total=1,
-        )
-
-    assert manager.parse_calls == 0
-
-
-@pytest.mark.fast
-def test_get_html_content_type_with_non_html_chunk_raises_httperror(
-    tmp_path, monkeypatch
+@pytest.mark.parametrize(
+    "content_type,chunks",
+    [
+        ("text/html", [b"<html><body>login</body></html>"]),
+        ("text/html; charset=utf-8", [b"\x00\x00"]),
+        ("application/octet-stream", [b"<!doctype html><html>login</html>"]),
+    ],
+)
+def test_get_invalid_payload_raises_httperror(
+    manager, run_download, content_type, chunks
 ):
-    manager = _DummyDownloadManager(tmp_path)
     session = _FakeSession(
         head_response=_FakeResponse(
             status_code=200, headers={"content-type": "text/html"}
         ),
         get_response=_FakeResponse(
             status_code=200,
-            headers={"content-type": "text/html; charset=utf-8", "content-length": "2"},
-            chunks=[b"\x00\x00"],
+            headers={"content-type": content_type, "content-length": "32"},
+            chunks=chunks,
         ),
     )
 
-    monkeypatch.setattr(requests, "Session", lambda: session)
-    monkeypatch.chdir(tmp_path)
-
     with pytest.raises(requests.HTTPError, match="HTML content from GET request"):
-        manager.download_and_parse(
-            urlnames=["https://example.org/test.par.bz2"],
-            local_files=[str(tmp_path / "dummy_output.hdf5")],
-            N_files_total=1,
-        )
+        run_download(manager, session)
 
     assert manager.parse_calls == 0
 
 
 @pytest.mark.fast
-def test_head_http_error_raises_before_get(tmp_path, monkeypatch):
-    manager = _DummyDownloadManager(tmp_path)
+@pytest.mark.parametrize("status_code", [404, 302])
+def test_head_non_200_raises_before_get(manager, run_download, status_code):
     session = _FakeSession(
         head_response=_FakeResponse(
-            status_code=404, headers={"content-type": "text/html"}
+            status_code=status_code, headers={"content-type": "text/html"}
         ),
         get_response=_FakeResponse(
             status_code=200,
@@ -164,46 +160,8 @@ def test_head_http_error_raises_before_get(tmp_path, monkeypatch):
         ),
     )
 
-    monkeypatch.setattr(requests, "Session", lambda: session)
-
     with pytest.raises(requests.HTTPError, match="HEAD request"):
-        manager.download_and_parse(
-            urlnames=["https://example.org/test.par.bz2"],
-            local_files=[str(tmp_path / "dummy_output.hdf5")],
-            N_files_total=1,
-        )
-
-    assert manager.parse_calls == 0
-    assert len(session.get_calls) == 0
-
-
-@pytest.mark.fast
-def test_head_redirect_status_raises_before_get(tmp_path, monkeypatch):
-    manager = _DummyDownloadManager(tmp_path)
-    session = _FakeSession(
-        head_response=_FakeResponse(
-            status_code=302,
-            headers={
-                "content-type": "text/html",
-                "location": "https://example.org/final",
-            },
-        ),
-        get_response=_FakeResponse(
-            status_code=200,
-            headers={"content-type": "application/octet-stream", "content-length": "4"},
-            chunks=[b"data"],
-        ),
-    )
-
-    monkeypatch.setattr(requests, "Session", lambda: session)
-    monkeypatch.chdir(tmp_path)
-
-    with pytest.raises(requests.HTTPError, match="HEAD request"):
-        manager.download_and_parse(
-            urlnames=["https://example.org/test.par.bz2"],
-            local_files=[str(tmp_path / "dummy_output.hdf5")],
-            N_files_total=1,
-        )
+        run_download(manager, session)
 
     assert manager.parse_calls == 0
     assert len(session.get_calls) == 0

--- a/radis/test/api/test_dbmanager_download.py
+++ b/radis/test/api/test_dbmanager_download.py
@@ -178,7 +178,7 @@ def test_head_http_error_raises_before_get(tmp_path, monkeypatch):
 
 
 @pytest.mark.fast
-def test_head_redirect_status_is_accepted(tmp_path, monkeypatch):
+def test_head_redirect_status_raises_before_get(tmp_path, monkeypatch):
     manager = _DummyDownloadManager(tmp_path)
     session = _FakeSession(
         head_response=_FakeResponse(
@@ -198,10 +198,12 @@ def test_head_redirect_status_is_accepted(tmp_path, monkeypatch):
     monkeypatch.setattr(requests, "Session", lambda: session)
     monkeypatch.chdir(tmp_path)
 
-    manager.download_and_parse(
-        urlnames=["https://example.org/test.par.bz2"],
-        local_files=[str(tmp_path / "dummy_output.hdf5")],
-        N_files_total=1,
-    )
+    with pytest.raises(requests.HTTPError, match="HEAD request"):
+        manager.download_and_parse(
+            urlnames=["https://example.org/test.par.bz2"],
+            local_files=[str(tmp_path / "dummy_output.hdf5")],
+            N_files_total=1,
+        )
 
-    assert manager.parse_calls == 1
+    assert manager.parse_calls == 0
+    assert len(session.get_calls) == 0

--- a/radis/test/api/test_dbmanager_download.py
+++ b/radis/test/api/test_dbmanager_download.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-import requests
 import pytest
+import requests
 
 from radis.api.dbmanager import DatabaseManager
 

--- a/radis/test/api/test_dbmanager_download.py
+++ b/radis/test/api/test_dbmanager_download.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+import requests
+import pytest
+
+from radis.api.dbmanager import DatabaseManager
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, headers=None, chunks=None):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._chunks = chunks or []
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"status {self.status_code}")
+
+    def iter_content(self, chunk_size=8192):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _FakeSession:
+    def __init__(self, head_response, get_response):
+        self._head_response = head_response
+        self._get_response = get_response
+        self.head_calls = []
+        self.get_calls = []
+
+    def head(self, *args, **kwargs):
+        self.head_calls.append((args, kwargs))
+        return self._head_response
+
+    def get(self, *args, **kwargs):
+        self.get_calls.append((args, kwargs))
+        return self._get_response
+
+
+class _DummyDownloadManager(DatabaseManager):
+    def __init__(self, local_databases):
+        super().__init__(
+            name="TEST-DOWNLOAD",
+            molecule="CH4",
+            local_databases=str(local_databases),
+            engine="pytables",
+            verbose=False,
+            parallel=False,
+        )
+        self.parse_calls = 0
+
+    def parse_to_local_file(
+        self,
+        opener,
+        urlname,
+        local_file,
+        pbar_active=True,
+        pbar_t0=0,
+        pbar_Ntot_estimate_factor=None,
+        pbar_Nlines_already=0,
+        pbar_last=True,
+    ):
+        self.parse_calls += 1
+        return 1
+
+
+@pytest.mark.fast
+def test_hitemp_head_html_get_binary_does_not_fail(tmp_path, monkeypatch):
+    manager = _DummyDownloadManager(tmp_path)
+    session = _FakeSession(
+        head_response=_FakeResponse(
+            status_code=200,
+            headers={"content-type": "text/html"},
+        ),
+        get_response=_FakeResponse(
+            status_code=200,
+            headers={"content-type": "application/octet-stream", "content-length": "8"},
+            chunks=[b"BZh9", b"DATA"],
+        ),
+    )
+
+    import radis.api.hitempapi as hitempapi
+
+    monkeypatch.setattr(hitempapi, "login_to_hitran", lambda verbose=False: session)
+    monkeypatch.chdir(tmp_path)
+
+    manager.download_and_parse(
+        urlnames=["https://hitran.org/files/HITEMP/bzip2format/06_HITEMP2020.par.bz2"],
+        local_files=[str(tmp_path / "dummy_output.hdf5")],
+        N_files_total=1,
+    )
+
+    assert manager.parse_calls == 1
+    assert len(session.head_calls) == 1
+    assert len(session.get_calls) == 1
+
+
+@pytest.mark.fast
+def test_get_html_payload_raises_httperror(tmp_path, monkeypatch):
+    manager = _DummyDownloadManager(tmp_path)
+    session = _FakeSession(
+        head_response=_FakeResponse(
+            status_code=200, headers={"content-type": "text/html"}
+        ),
+        get_response=_FakeResponse(
+            status_code=200,
+            headers={"content-type": "text/html", "content-length": "32"},
+            chunks=[b"<html><body>login</body></html>"],
+        ),
+    )
+
+    monkeypatch.setattr(requests, "Session", lambda: session)
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(requests.HTTPError, match="HTML content from GET request"):
+        manager.download_and_parse(
+            urlnames=["https://example.org/test.par.bz2"],
+            local_files=[str(tmp_path / "dummy_output.hdf5")],
+            N_files_total=1,
+        )
+
+    assert manager.parse_calls == 0
+
+
+@pytest.mark.fast
+def test_head_http_error_raises_before_get(tmp_path, monkeypatch):
+    manager = _DummyDownloadManager(tmp_path)
+    session = _FakeSession(
+        head_response=_FakeResponse(
+            status_code=404, headers={"content-type": "text/html"}
+        ),
+        get_response=_FakeResponse(
+            status_code=200,
+            headers={"content-type": "application/octet-stream"},
+            chunks=[b"data"],
+        ),
+    )
+
+    monkeypatch.setattr(requests, "Session", lambda: session)
+
+    with pytest.raises(requests.HTTPError, match="HEAD request"):
+        manager.download_and_parse(
+            urlnames=["https://example.org/test.par.bz2"],
+            local_files=[str(tmp_path / "dummy_output.hdf5")],
+            N_files_total=1,
+        )
+
+    assert manager.parse_calls == 0
+    assert len(session.get_calls) == 0
+
+
+@pytest.mark.fast
+def test_head_redirect_status_is_accepted(tmp_path, monkeypatch):
+    manager = _DummyDownloadManager(tmp_path)
+    session = _FakeSession(
+        head_response=_FakeResponse(
+            status_code=302,
+            headers={
+                "content-type": "text/html",
+                "location": "https://example.org/final",
+            },
+        ),
+        get_response=_FakeResponse(
+            status_code=200,
+            headers={"content-type": "application/octet-stream", "content-length": "4"},
+            chunks=[b"data"],
+        ),
+    )
+
+    monkeypatch.setattr(requests, "Session", lambda: session)
+    monkeypatch.chdir(tmp_path)
+
+    manager.download_and_parse(
+        urlnames=["https://example.org/test.par.bz2"],
+        local_files=[str(tmp_path / "dummy_output.hdf5")],
+        N_files_total=1,
+    )
+
+    assert manager.parse_calls == 1

--- a/radis/test/api/test_dbmanager_download.py
+++ b/radis/test/api/test_dbmanager_download.py
@@ -122,6 +122,35 @@ def test_get_html_payload_raises_httperror(tmp_path, monkeypatch):
 
 
 @pytest.mark.fast
+def test_get_html_content_type_with_non_html_chunk_raises_httperror(
+    tmp_path, monkeypatch
+):
+    manager = _DummyDownloadManager(tmp_path)
+    session = _FakeSession(
+        head_response=_FakeResponse(
+            status_code=200, headers={"content-type": "text/html"}
+        ),
+        get_response=_FakeResponse(
+            status_code=200,
+            headers={"content-type": "text/html; charset=utf-8", "content-length": "2"},
+            chunks=[b"\x00\x00"],
+        ),
+    )
+
+    monkeypatch.setattr(requests, "Session", lambda: session)
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(requests.HTTPError, match="HTML content from GET request"):
+        manager.download_and_parse(
+            urlnames=["https://example.org/test.par.bz2"],
+            local_files=[str(tmp_path / "dummy_output.hdf5")],
+            N_files_total=1,
+        )
+
+    assert manager.parse_calls == 0
+
+
+@pytest.mark.fast
 def test_head_http_error_raises_before_get(tmp_path, monkeypatch):
     manager = _DummyDownloadManager(tmp_path)
     session = _FakeSession(


### PR DESCRIPTION
### Description
This pull request is to address false-positive download failures in `DatabaseManager.download_and_parse` (issue #893).

Problem:
- Some HITEMP URLs return `text/html` on `HEAD` even when `GET` returns the correct binary payload.
- Current code treats `HEAD content-type == text/html` as a hard error, causing spurious `HTTPError`.

What changed:
- Keep `HEAD` as a lightweight availability check only:
  - raise only when `HEAD` status is `>= 400`.
- Move HTML/login-page detection to the actual `GET` response:
  - inspect `GET` `content-type` and first payload chunk,
  - raise only when both indicate HTML (e.g., login page),
  - otherwise continue download/parse.
- Preserve streamed downloading behavior by peeking first non-empty chunk and then continuing over the same iterator.

Tests added:
- `test_hitemp_head_html_get_binary_does_not_fail`
- `test_get_html_payload_raises_httperror`
- `test_head_http_error_raises_before_get`
- `test_head_redirect_status_is_accepted`

Validation run:
- `python -m pytest radis/test/api/test_dbmanager_download.py -q`

Fixes #893
