### PR TITLE
perf: optimize startup time by lazy loading heavy dependencies

### DIFF
--- a/examples/2_Experimental_spectra/plot_chain_spectrum_edition.py
+++ b/examples/2_Experimental_spectra/plot_chain_spectrum_edition.py
@@ -114,7 +114,7 @@ import numpy as np
 
 print("Absorbance of original line : ", s.get_integral("absorbance"))
 print(
-    "Absorbance of fitted line   :", np.trapz(y_fit, w_fit)
+    "Absorbance of fitted line   :", np.trapezoid(y_fit, w_fit)
 )  # negative because w_fit in descending order
 #
 

--- a/radis/api/dbmanager.py
+++ b/radis/api/dbmanager.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """ """
+
 import os
 import shutil
 from os.path import abspath, dirname, exists, expanduser, join, split, splitext
@@ -37,7 +38,6 @@ import re
 from datetime import date
 
 import pandas as pd
-import requests
 from dateutil.parser import parse as parse_date
 from joblib import Parallel, delayed
 
@@ -418,6 +418,8 @@ class DatabaseManager(object):
             )
 
             # Download file with requests
+            import requests
+
             if "hitemp" in urlname.lower():
                 # Get session from HITEMP API
                 from radis.api.hitempapi import login_to_hitran

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -25,7 +25,6 @@ import re
 from urllib.request import HTTPError, urlopen
 
 import pandas as pd
-from bs4 import BeautifulSoup
 
 from radis.api.hdf5 import vaexsafe_colname
 
@@ -945,6 +944,8 @@ def get_exomol_database_list(molecule, isotope_full_name=None):
         else:
             extra = ""
         raise ValueError(f"HTTPError opening url={url}" + extra) from err
+
+    from bs4 import BeautifulSoup
 
     soup = BeautifulSoup(
         response, features="lxml"

--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -9,6 +9,7 @@ https://stackoverflow.com/questions/55610891/numpy-load-from-io-bytesio-stream
 https://stupidpythonideas.blogspot.com/2014/07/three-ways-to-read-files.html
 
 """
+
 import json
 import os
 import re
@@ -21,10 +22,6 @@ from typing import Union
 
 import numpy as np
 import pandas as pd
-import requests
-from bs4 import BeautifulSoup
-from cryptography.fernet import Fernet
-from tqdm import tqdm
 
 from radis.api.hdf5 import update_pytables_to_vaex
 from radis.db.hitemp_co2 import partial_download_co2_chunk
@@ -292,6 +289,8 @@ def setup_credentials():
 
 def get_encryption_key():
     """Get or create encryption key for HITRAN credentials"""
+    from cryptography.fernet import Fernet
+
     # Read existing radis.json
     config = read_config()
 
@@ -321,6 +320,8 @@ def get_encryption_key():
 
 def encrypt_password(password):
     """Encrypt password using Fernet symmetric encryption"""
+    from cryptography.fernet import Fernet
+
     key = get_encryption_key()
     f = Fernet(key)
     return f.encrypt(password.encode()).decode()
@@ -328,6 +329,8 @@ def encrypt_password(password):
 
 def decrypt_password(encrypted_password):
     """Decrypt password using Fernet symmetric encryption"""
+    from cryptography.fernet import Fernet
+
     key = get_encryption_key()
     f = Fernet(key)
     return f.decrypt(encrypted_password.encode()).decode()
@@ -365,6 +368,9 @@ def store_credentials(email, password):
 def login_to_hitran(verbose=False):
     """Login to HITRAN using stored credentials from radis.json or prompt if not available"""
     login_url = "https://hitran.org/login/"
+
+    import requests
+
     session = requests.Session()
 
     class LoginError(Exception):
@@ -409,6 +415,8 @@ def login_to_hitran(verbose=False):
                     f"HITRAN login failed due to a request error: {exc}. "
                     "Please check your network connection and try again."
                 )
+
+        from bs4 import BeautifulSoup
 
         soup = BeautifulSoup(response.text, "html.parser")
         csrf = soup.find("input", {"name": "csrfmiddlewaretoken"})["value"]
@@ -510,6 +518,8 @@ def download_hitemp_file(session, file_url, output_filename, verbose=False):
             warnings.warn(warning_msg, UserWarning)
 
         with open(output_filename, "wb") as f:
+            from tqdm import tqdm
+
             with tqdm(
                 total=total_size,
                 unit="B",
@@ -775,6 +785,8 @@ def read_and_write_chunked_for_CO2(
     ):
         printer.info("All files already cached.", indent=1)
 
+    from tqdm import tqdm
+
     with tqdm(
         total=len(local_paths), desc="Processing chunks", disable=not verbose
     ) as pbar:
@@ -964,6 +976,8 @@ class HITEMPDatabaseManager(DatabaseManager):
             text = file_response.text
 
             # Parse the HTML then Extract valid file URLs
+            from bs4 import BeautifulSoup
+
             soup = BeautifulSoup(text, "html.parser")
             table = soup.find("table")
             links = table.find_all("a", href=True)

--- a/radis/io/__init__.py
+++ b/radis/io/__init__.py
@@ -5,12 +5,6 @@
 
 """
 
-from .exomol import fetch_exomol
-from .geisa import fetch_geisa
-from .hitemp import fetch_hitemp
-from .hitran import fetch_hitran
-from .query import fetch_astroquery
-
 __all__ = [
     "fetch_hitemp",
     "fetch_hitran",
@@ -18,3 +12,26 @@ __all__ = [
     "fetch_astroquery",
     "fetch_geisa",
 ]
+
+_lazy_imports = {
+    "fetch_exomol": ".exomol",
+    "fetch_geisa": ".geisa",
+    "fetch_hitemp": ".hitemp",
+    "fetch_hitran": ".hitran",
+    "fetch_astroquery": ".query",
+}
+
+
+def __getattr__(name):
+    if name in _lazy_imports:
+        import importlib
+
+        module = importlib.import_module(_lazy_imports[name], __name__)
+        attr = getattr(module, name)
+        globals()[name] = attr  # cache for subsequent access
+        return attr
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(list(globals().keys()) + list(__all__)))

--- a/radis/lbl/bands.py
+++ b/radis/lbl/bands.py
@@ -40,13 +40,13 @@ PRIVATE METHODS
 
 
 """
+
 # TODO: merge common parts of BandList.eq_bands  and SpectrumFactory.eq_spectrum,
 # under a same function call
 
 from time import time
 from warnings import warn
 
-import astropy.units as u
 import numpy as np
 import pandas as pd
 from numpy import exp, expm1
@@ -162,6 +162,8 @@ class BandFactory(BroadenFactory):
         """
 
         # Convert units
+        import astropy.units as u
+
         Tgas = convert_and_strip_units(Tgas, u.K)
         path_length = convert_and_strip_units(path_length, u.cm)
         pressure = convert_and_strip_units(pressure, u.bar)
@@ -461,6 +463,8 @@ class BandFactory(BroadenFactory):
         """
 
         # Convert units
+        import astropy.units as u
+
         Tvib = convert_and_strip_units(Tvib, u.K)
         Trot = convert_and_strip_units(Trot, u.K)
         Ttrans = convert_and_strip_units(Ttrans, u.K)
@@ -894,7 +898,7 @@ class BandFactory(BroadenFactory):
         for i, (band, dg) in enumerate(gb):
             if optimization in ("simple", "min-RMS"):
                 line_profile_LDM, wL, wG, wL_dat, wG_dat = self._calc_lineshape_LDM(dg)
-                (wavenumber, absorption) = self._apply_lineshape_LDM(
+                wavenumber, absorption = self._apply_lineshape_LDM(
                     dg.S.values,
                     line_profile_LDM,
                     dg.shiftwav.values,
@@ -906,7 +910,7 @@ class BandFactory(BroadenFactory):
                 )
             else:
                 line_profile = self._calc_lineshape(dg)
-                (wavenumber, absorption) = self._apply_lineshape(
+                wavenumber, absorption = self._apply_lineshape(
                     dg.S.values, line_profile, dg.shiftwav.values
                 )
             abscoeff_bands[band] = absorption
@@ -945,7 +949,7 @@ class BandFactory(BroadenFactory):
         for i, (band, dg) in enumerate(gb):
             if optimization in ("simple", "min-RMS"):
                 line_profile_LDM, wL, wG, wL_dat, wG_dat = self._calc_lineshape_LDM(dg)
-                (wavenumber, absorption) = self._apply_lineshape_LDM(
+                wavenumber, absorption = self._apply_lineshape_LDM(
                     dg.S.values,
                     line_profile_LDM,
                     dg.shiftwav.values,
@@ -955,7 +959,7 @@ class BandFactory(BroadenFactory):
                     wG_dat,
                     optimization,
                 )
-                (_, emission) = self._apply_lineshape_LDM(
+                _, emission = self._apply_lineshape_LDM(
                     dg.Ei.values,
                     line_profile_LDM,
                     dg.shiftwav.values,
@@ -968,10 +972,10 @@ class BandFactory(BroadenFactory):
 
             else:
                 line_profile = self._calc_lineshape(dg)
-                (wavenumber, absorption) = self._apply_lineshape(
+                wavenumber, absorption = self._apply_lineshape(
                     dg.S.values, line_profile, dg.shiftwav.values
                 )
-                (_, emission) = self._apply_lineshape(
+                _, emission = self._apply_lineshape(
                     dg.Ei.values, line_profile, dg.shiftwav.values
                 )
             abscoeff_bands[band] = absorption  #
@@ -1024,7 +1028,7 @@ class BandFactory(BroadenFactory):
                 + " may be inverted"
             )
 
-        (wavenumber, abscoeff_bands) = self._broaden_lines_bands(df)
+        wavenumber, abscoeff_bands = self._broaden_lines_bands(df)
 
         self.profiler.stop("calc_broadening_eq_bands", "Calc Broadening Eq Bands")
 

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -63,7 +63,6 @@ Most methods are written in inherited class with the following inheritance schem
 
 
 """
-
 # TODO: move all CDSD dependant functions _add_Evib123Erot to a specific file for CO2.
 
 import numpy as np

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -63,11 +63,11 @@ Most methods are written in inherited class with the following inheritance schem
 
 
 """
+
 # TODO: move all CDSD dependant functions _add_Evib123Erot to a specific file for CO2.
 
 import numpy as np
 import pandas as pd
-from astropy import units as u
 from numpy import exp, pi
 from psutil import virtual_memory
 
@@ -3979,6 +3979,8 @@ def get_wavenumber_range(
     """
 
     # Checking consistency of all input variables
+    from astropy import units as u
+
     assert medium in ["air", "vacuum"]
 
     w_present = wmin is not None and wmax is not None

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -68,8 +68,6 @@ from numba import float64, jit
 from numpy import arange, exp
 from numpy import log as ln
 from numpy import pi, sin, sqrt, zeros, zeros_like
-from scipy.integrate import trapezoid
-from scipy.signal import oaconvolve
 
 import radis
 from radis.db.references import doi
@@ -803,6 +801,8 @@ def voigt_lineshape(w_centered, hwhm_lorentz, hwhm_voigt, jit=True):
     :py:func:`~radis.lbl.broadening.whiting1968`
     """
 
+    from scipy.integrate import trapezoid
+
     # Note: Whiting and Olivero use FWHM. Here we keep HWHM in all public function
     # arguments for consistency.
     wl = 2 * hwhm_lorentz  # HWHM > FWHM
@@ -1484,6 +1484,8 @@ class BroadenFactory(BaseFactory):
             line profile normalized with area = 1
         """
 
+        from scipy.integrate import trapezoid
+
         # Get collisional broadening HWHM
         gamma_lb = dg.hwhm_lorentz
 
@@ -1546,6 +1548,8 @@ class BroadenFactory(BaseFactory):
 
         # Prepare coefficients, vectorize
         # --------
+
+        from scipy.integrate import trapezoid
 
         # Broadening parameter:
         # ... Doppler broadened half-width:
@@ -1709,6 +1713,8 @@ class BroadenFactory(BaseFactory):
 
         self.profiler.start(key="init_vectors", verbose_level=3)
 
+        from scipy.integrate import trapezoid
+
         # Init variables
         if self.input.Tgas is None:
             raise AttributeError(
@@ -1856,6 +1862,8 @@ class BroadenFactory(BaseFactory):
         # Calculate the Lineshape
         # -----------------------
 
+        from scipy.integrate import trapezoid
+
         line_profile_LDM = {}
         broadening_method = self.params.broadening_method
         if broadening_method == "voigt":
@@ -1965,6 +1973,7 @@ class BroadenFactory(BaseFactory):
         # TODO #clean: make it a standalone function.
 
         import matplotlib.pyplot as plt
+        from scipy.integrate import trapezoid
 
         if pressure_atm is None:
             pressure_atm = self.input.pressure / 1.01325
@@ -2497,6 +2506,8 @@ class BroadenFactory(BaseFactory):
         # corresponding lines with it before summing.
         if broadening_method in ["voigt", "convolve"]:
 
+            from scipy.signal import oaconvolve
+
             # ... Initialize array on which to distribute the lineshapes
             sumoflines_calc = zeros_like(wavenumber_calc)
 
@@ -2627,7 +2638,7 @@ class BroadenFactory(BaseFactory):
                         )
 
                     line_profile = self._calc_lineshape(df)  # usually the bottleneck
-                    (wavenumber, abscoeff) = self._apply_lineshape(
+                    wavenumber, abscoeff = self._apply_lineshape(
                         df.S.values, line_profile, df.shiftwav.values
                     )
                 elif optimization in ("simple", "min-RMS"):
@@ -2647,7 +2658,7 @@ class BroadenFactory(BaseFactory):
                             f"Estimated time for calculating broadening: {estimated_time:.2f}s on 1 CPU"
                         )
 
-                    (wavenumber, abscoeff) = self._apply_lineshape_LDM(
+                    wavenumber, abscoeff = self._apply_lineshape_LDM(
                         df.S.values,
                         line_profile_LDM,
                         df.shiftwav.values,
@@ -2704,7 +2715,7 @@ class BroadenFactory(BaseFactory):
 
                     for i, (_, dg) in enumerate(df):
                         line_profile = self._calc_lineshape(dg)
-                        (wavenumber, absorption) = self._apply_lineshape(
+                        wavenumber, absorption = self._apply_lineshape(
                             dg.S.values, line_profile, dg.shiftwav.values
                         )
                         abscoeff += absorption
@@ -2733,7 +2744,7 @@ class BroadenFactory(BaseFactory):
                             wL_dat_i,
                             wG_dat_i,
                         ) = self._calc_lineshape_LDM(dg)
-                        (wavenumber, absorption) = self._apply_lineshape_LDM(
+                        wavenumber, absorption = self._apply_lineshape_LDM(
                             dg.S.values,
                             line_profile_LDM,
                             dg.shiftwav.values,
@@ -2800,7 +2811,7 @@ class BroadenFactory(BaseFactory):
                     print(
                         f"Estimated time for calculating broadening: {estimated_time:.2f}s on 1 CPU"
                     )
-                (wavenumber, abscoeff) = self._apply_lineshape_LDM(
+                wavenumber, abscoeff = self._apply_lineshape_LDM(
                     df.S.values,
                     line_profile_LDM,
                     df.shiftwav.values,
@@ -2810,7 +2821,7 @@ class BroadenFactory(BaseFactory):
                     wG_dat,
                     optimization,
                 )
-                (_, emisscoeff) = self._apply_lineshape_LDM(
+                _, emisscoeff = self._apply_lineshape_LDM(
                     df.Ei.values,
                     line_profile_LDM,
                     df.shiftwav.values,
@@ -2848,10 +2859,10 @@ class BroadenFactory(BaseFactory):
                 if chunksize is None:
                     # Deal with all lines directly (usually faster)
                     line_profile = self._calc_lineshape(df)  # usually the bottleneck
-                    (wavenumber, abscoeff) = self._apply_lineshape(
+                    wavenumber, abscoeff = self._apply_lineshape(
                         df.S.values, line_profile, df.shiftwav.values
                     )
-                    (_, emisscoeff) = self._apply_lineshape(
+                    _, emisscoeff = self._apply_lineshape(
                         df.Ei.values, line_profile, df.shiftwav.values
                     )
 
@@ -2869,10 +2880,10 @@ class BroadenFactory(BaseFactory):
                     pb = ProgressBar(N, active=self.verbose)
                     for i, (_, dg) in enumerate(df.groupby(arange(len(df)) % N)):
                         line_profile = self._calc_lineshape(dg)
-                        (wavenumber, absorption) = self._apply_lineshape(
+                        wavenumber, absorption = self._apply_lineshape(
                             dg.S.values, line_profile, dg.shiftwav.values
                         )
-                        (_, emission) = self._apply_lineshape(
+                        _, emission = self._apply_lineshape(
                             dg.Ei.values, line_profile, dg.shiftwav.values
                         )
                         abscoeff += absorption  #
@@ -2938,7 +2949,7 @@ class BroadenFactory(BaseFactory):
                 + " may be inverted"
             )
 
-        (wavenumber, abscoeff) = self._broaden_lines(df)
+        wavenumber, abscoeff = self._broaden_lines(df)
         self.profiler.stop("calc_line_broadening", "Calculated line broadening")
 
         return wavenumber, abscoeff
@@ -3120,6 +3131,8 @@ class BroadenFactory(BaseFactory):
             )
 
             # Check inputs
+            from scipy.integrate import trapezoid
+
             wavenumber_calc = self.wavenumber_calc
             pseudo_continuum_threshold = self.params.pseudo_continuum_threshold
             wstep = self.params.wstep

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -77,16 +77,12 @@ for Developers:
 ----------
 """
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING, Union
+from typing import Union
 from warnings import warn
 
 import numpy as np
 from numpy import arange, exp, expm1
-
-if TYPE_CHECKING:
-    from scipy.optimize import OptimizeResult
+from scipy.optimize import OptimizeResult
 
 from radis import version
 from radis.db import MOLECULES_LIST_EQUILIBRIUM, MOLECULES_LIST_NONEQUILIBRIUM

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -76,13 +76,17 @@ for Developers:
 
 ----------
 """
-from typing import Union
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Union
 from warnings import warn
 
-import astropy.units as u
 import numpy as np
 from numpy import arange, exp, expm1
-from scipy.optimize import OptimizeResult
+
+if TYPE_CHECKING:
+    from scipy.optimize import OptimizeResult
 
 from radis import version
 from radis.db import MOLECULES_LIST_EQUILIBRIUM, MOLECULES_LIST_NONEQUILIBRIUM
@@ -593,6 +597,8 @@ class SpectrumFactory(BandFactory):
             )
 
         # Initialize input conditions
+        import astropy.units as u
+
         self.input.wavenum_min = wavenum_min
         self.input.wavenum_max = wavenum_max
         self.input.Tref = convert_and_strip_units(Tref, u.K)
@@ -813,6 +819,8 @@ class SpectrumFactory(BandFactory):
             )
 
         # Convert units
+        import astropy.units as u
+
         Tgas = convert_and_strip_units(Tgas, u.K)
         path_length = convert_and_strip_units(path_length, u.cm)
         pressure = convert_and_strip_units(pressure, u.bar)
@@ -1104,6 +1112,8 @@ class SpectrumFactory(BandFactory):
             )
 
         # Convert units
+        import astropy.units as u
+
         Tgas = convert_and_strip_units(Tgas, u.K)
         path_length = convert_and_strip_units(path_length, u.cm)
         pressure = convert_and_strip_units(pressure, u.bar)
@@ -1634,6 +1644,8 @@ class SpectrumFactory(BandFactory):
         # %% Preprocessing
         # --------------------------------------------------------------------
         # Convert units
+        import astropy.units as u
+
         Tvib = convert_and_strip_units(Tvib, u.K)
         Trot = convert_and_strip_units(Trot, u.K)
         Ttrans = convert_and_strip_units(Ttrans, u.K)

--- a/radis/levels/partfunc_cdsd.py
+++ b/radis/levels/partfunc_cdsd.py
@@ -19,13 +19,11 @@ Which inherit from:
 -------------------------------------------------------------------------------
 """
 
-
 import time
 from os.path import exists, getmtime, join
 from warnings import warn
 
 import pandas as pd
-from scipy.interpolate import splev, splrep
 
 import radis
 from radis.api.cache_files import filter_metadata, load_h5_cache_file, save_to_hdf
@@ -88,6 +86,8 @@ class PartFuncCO2_CDSDtab(RovibParFuncTabulator):
             raise KeyError(f"Missing columns ({'T(K)'}) in {database}")
 
         # Define spline interpolation
+        from scipy.interpolate import splrep
+
         isoname = Itable[isotope]
         tck = splrep(parsum["T(K)"], parsum[isoname])
 
@@ -111,6 +111,8 @@ class PartFuncCO2_CDSDtab(RovibParFuncTabulator):
             raise OutOfBoundError(
                 f"Temperature: {T} is out of bounds {self.Tmin}-{self.Tmax}"
             )
+
+        from scipy.interpolate import splev
 
         return splev(T, self.tck)
 

--- a/radis/misc/arrays.py
+++ b/radis/misc/arrays.py
@@ -35,15 +35,12 @@ Functions to deal with numpy arrays:
 
 """
 
-
 from math import ceil
 
 import numba
 import numpy as np
 from numba import bool_
 from numpy import hstack
-from scipy.integrate import trapezoid
-from scipy.interpolate import interp1d
 
 # Normalize
 
@@ -136,6 +133,8 @@ def array_allclose(a, b, rtol=1e-5, atol=1e-8, equal_nan=True):
 
 def nantrapz(I, w, dx=1.0, axis=-1):
     """Returns :py:func:`~numpy.trapezoid` (I, w) discarding nan."""
+    from scipy.integrate import trapezoid
+
     b = ~np.isnan(I)
     return trapezoid(I[b], w[b], dx=dx, axis=axis)
 
@@ -192,6 +191,8 @@ def calc_diff(t1, v1, t2, v2):
     v2 = v2[b]
 
     # Interpolate the correct values
+    from scipy.interpolate import interp1d
+
     f = interp1d(t1, v1)
     v1 = f(tdiff)
 

--- a/radis/misc/basics.py
+++ b/radis/misc/basics.py
@@ -6,7 +6,6 @@ Small functions used in other procedures
 -------------------------------------------------------------------------------
 """
 
-
 import os
 import sys
 from io import StringIO
@@ -14,7 +13,6 @@ from itertools import filterfalse, tee
 from os.path import abspath, join, normcase, normpath
 
 import numpy as np
-import pandas as pd
 
 verbose = True
 
@@ -361,6 +359,8 @@ def merge_rename_columns(df, columns1, columns2, merged_names):
                                    ['lvl',   'j',  'E',  'n',  'g',  'grot']
                                    )
     """
+
+    import pandas as pd
 
     assert all_in(columns1, list(df.keys()))
     assert all_in(columns2, list(df.keys()))

--- a/radis/misc/curve.py
+++ b/radis/misc/curve.py
@@ -24,8 +24,6 @@ Routine Listing
 import warnings
 
 import numpy as np
-from scipy.interpolate import interp1d
-from scipy.spatial.distance import cdist
 
 
 def curve_distance(w1, I1, w2, I2, discard_out_of_bounds=True):
@@ -78,6 +76,8 @@ def curve_distance(w1, I1, w2, I2, discard_out_of_bounds=True):
     norm_w2 = np.max(w2) - np.min(w2)
     norm_I1 = np.max(I1) - np.min(I1)
     norm_I2 = np.max(I2) - np.min(I2)
+
+    from scipy.spatial.distance import cdist
 
     dist = cdist(
         np.array((w1 / norm_w1, I1 / norm_I1)).T,
@@ -282,6 +282,8 @@ def _curve_interpolate(w1, I1, w2, I2, is_sorted=False, kind="linear"):
 
     # resample if needed
     if not np.array_equal(w1, w2):
+        from scipy.interpolate import interp1d
+
         f = interp1d(w2, I2, kind=kind, bounds_error=False)
         I2 = f(w1)
 

--- a/radis/misc/signal.py
+++ b/radis/misc/signal.py
@@ -17,11 +17,7 @@ Resampling  & smoothing.
 import math
 
 import numpy as np
-import scipy.linalg as LA
 from numpy import abs, isnan, linspace, nan, zeros_like
-from scipy.integrate import trapezoid
-from scipy.interpolate import splev, splrep
-from scipy.linalg import solveh_banded
 
 from radis.misc.arrays import (
     anynan,
@@ -155,6 +151,8 @@ def resample(
         )
 
     # Resample the slit function on the spectrum grid
+    from scipy.interpolate import splev, splrep
+
     try:
         tck = splrep(xspace, vector, k=k)
     except ValueError:
@@ -195,6 +193,8 @@ def resample(
     # Check energy conservation:
 
     # ... calculate energy
+    from scipy.integrate import trapezoid
+
     energy0 = abs(trapezoid(vector[b], x=xspace[b]))
     energy_new = abs(trapezoid(vector_new[b_new], x=xspace_new[b_new]))
     if energy_new == 0:  # deal with particular case of energy = 0
@@ -440,6 +440,8 @@ def baseline(y, deg=None, max_it=None, tol=None):
     x = np.linspace(0.0, cond, y.size)
     base = y.copy()
 
+    import scipy.linalg as LA
+
     vander = np.vander(x, order)
     vander_pinv = LA.pinv(vander)
 
@@ -497,6 +499,8 @@ class WhittakerSmoother(object):
     def smooth(self, w):
         foo = self.upper_bands.copy()
         foo[-1] += w  # last row is the diagonal
+
+        from scipy.linalg import solveh_banded
 
         return solveh_banded(foo, w * self.y, overwrite_ab=True, overwrite_b=True)
 

--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -27,7 +27,6 @@ Routine Listings
 from warnings import warn
 
 import numpy as np
-from scipy.integrate import trapezoid
 
 from radis.misc.arrays import array_allclose
 from radis.misc.basics import compare_dict, compare_lists
@@ -476,6 +475,8 @@ def get_residual_integral(
         wdiff, dI = wdiff[~b], dI[~b]
         b = np.isnan(I1)
         w1, I1 = w1[~b], I1[~b]
+
+    from scipy.integrate import trapezoid
 
     if var in ["transmittance", "transmittance_noslit"]:
         norm = 1 - trapezoid(I1, w1)

--- a/radis/spectrum/operations.py
+++ b/radis/spectrum/operations.py
@@ -53,10 +53,8 @@ Most of these functions are implemented with the standard operators. Ex::
 
 """
 
-
 from warnings import warn
 
-import astropy.units as u
 from numpy import hstack, ones_like
 
 from radis.phys.convert import (
@@ -345,6 +343,8 @@ def crop(s: Spectrum, wmin=None, wmax=None, wunit=None, inplace=False) -> Spectr
 
     stored_waveunit = s.get_waveunit()
 
+    import astropy.units as u
+
     wlunit_list = {
         "km": u.km,
         "m": u.m,
@@ -503,6 +503,8 @@ def multiply(s, coef, unit=None, var=None, inplace=False):
     var = _get_unique_var(s, var, inplace)
 
     # Case where a is dimensioned
+    import astropy.units as u
+
     if isinstance(coef, u.quantity.Quantity):
         if unit is not None:
             raise ValueError(
@@ -634,6 +636,8 @@ def add_array(s, a, unit=None, var=None, inplace=False):
     var = _get_unique_var(s, var, inplace)
 
     # Case where a is dimensioned
+    import astropy.units as u
+
     if isinstance(a, u.quantity.Quantity):
         if unit is not None:
             raise ValueError(
@@ -705,6 +709,8 @@ def sub_baseline(s, left, right, unit=None, var=None, inplace=False):
     var = _get_unique_var(s, var, inplace)
 
     # Case where left, right are dimensioned
+    import astropy.units as u
+
     if isinstance(left, u.quantity.Quantity) or isinstance(right, u.quantity.Quantity):
         if unit is not None:
             raise ValueError(

--- a/radis/spectrum/rescale.py
+++ b/radis/spectrum/rescale.py
@@ -14,7 +14,6 @@ Equations derived from the code using `pytexit <https://pytexit.readthedocs.io/e
 
 from warnings import warn
 
-import astropy.units as u
 import numpy as np
 from numpy import exp, expm1
 from numpy import log as ln
@@ -2376,6 +2375,8 @@ def rescale_path_length(
             "Rescaling to 0 will loose information. Choose force " "= True"
         )
     # Convert units
+    import astropy.units as u
+
     new_path_length = convert_and_strip_units(new_path_length, u.cm)
     old_path_length = convert_and_strip_units(old_path_length, u.cm)
 

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -52,12 +52,9 @@ from copy import deepcopy
 from os.path import basename
 from warnings import warn
 
-import astropy.units as u
 import numpy as np
 import pandas as pd
-import plotly.express as px
 from numpy import abs, diff
-from scipy.integrate import trapezoid
 
 from radis.db.references import doi
 
@@ -2467,6 +2464,8 @@ class Spectrum(object):
         xlabel = format_xlabel(wunit, show_medium)
         ylabel = f"{make_up(var)} ({make_up_unit(Iunit, var)})"
 
+        import plotly.express as px
+
         fig = px.line(x=x, y=y, template=template)
         fig.update_layout(
             xaxis_title=xlabel,
@@ -3946,6 +3945,8 @@ class Spectrum(object):
             else:
                 return cond
         else:
+            import astropy.units as u
+
             if return_unit:
                 if hasattr(cond, "unit"):
                     return cond.to(unit).value, unit
@@ -4849,6 +4850,7 @@ class Spectrum(object):
 
         # Compute area under the curve of models.Voigt1D or models.Gaussian1D or models.Lorentz1D
         from astropy.modeling import models
+        from scipy.integrate import trapezoid
 
         for index, line in enumerate(g_fit_list):
             if isinstance(line, models.Voigt1D):
@@ -6163,6 +6165,8 @@ class Spectrum(object):
           (returns a copy)
         - for 2 Spectra: not defined
         """
+        import astropy.units as u
+
         if (
             isinstance(other, float)
             or isinstance(other, int)
@@ -6186,6 +6190,7 @@ class Spectrum(object):
 
     def __rmul__(self, other):
         r"""Right side multiplication."""
+        import astropy.units as u
 
         if (
             isinstance(other, float)
@@ -6215,6 +6220,8 @@ class Spectrum(object):
           (only if in front, i.e:  s *= 2)  (modifies inplace)
         - for 2 Spectra: not defined
         """
+        import astropy.units as u
+
         if (
             isinstance(other, float)
             or isinstance(other, int)
@@ -6241,6 +6248,8 @@ class Spectrum(object):
 
         - for numeric values: divide algebraically (equivalent to optically thin scaling)
         """
+        import astropy.units as u
+
         if isinstance(other, float) or isinstance(other, int):
             from radis.spectrum.operations import multiply
 
@@ -6273,6 +6282,8 @@ class Spectrum(object):
         - for numeric values: divide quantities algebraically
         (equivalent to optically thin scaling)
         """
+        import astropy.units as u
+
         if isinstance(other, float) or isinstance(other, int):
             from radis.spectrum.operations import multiply
 

--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -68,7 +68,6 @@ import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed
 from numpy import array
-from scipy.interpolate import griddata
 
 from radis.misc.basics import all_in, is_float, list_if_float
 from radis.misc.debug import printdbg
@@ -1736,6 +1735,8 @@ class SpecList(object):
             xarr = np.linspace(min(x), max(x))
             yarr = np.linspace(min(y), max(y))
             mx, my = np.meshgrid(xarr, yarr)
+            from scipy.interpolate import griddata
+
             zgrid = griddata((x, y), z, (mx, my), method="linear", fill_value=np.nan)
             levels = np.linspace(min(z), max(z), 20)
             ax.contourf(

--- a/radis/tools/slit.py
+++ b/radis/tools/slit.py
@@ -40,16 +40,12 @@ recenter_slit, crop_slit):
 
 """
 
-
 from warnings import warn
 
 import numpy as np
 from numpy import exp
 from numpy import log as ln
 from numpy import sqrt
-from scipy.integrate import trapezoid
-from scipy.interpolate import splev, splrep
-from scipy.signal import oaconvolve
 
 from radis.misc.arrays import anynan, evenly_distributed, evenly_distributed_fast
 from radis.misc.basics import is_float
@@ -233,6 +229,9 @@ def get_slit_function(
     # in norm_by=max mode, used to keep units in [Iunit]*return_unit in [Iunit]*unit
     scale_slit = 1
     # not used in norm_by=area mode
+
+    # Lazy import heavy dependencies
+    from scipy.integrate import trapezoid
 
     # Generate Slit
     # -------------
@@ -617,9 +616,10 @@ def convolve_with_slit(
 
     """
 
+    from scipy.interpolate import splev, splrep
+
     # 1. Check input
     # --------------
-
     # Deprecated input:
     if waveunit is not None:
         warn(
@@ -732,6 +732,8 @@ def convolve_with_slit(
 
     # We actually do not use mode valid in np.convolve,
     # instead we use mode=same and remove the same boundaries from I and W in remove_boundary()
+    from scipy.signal import oaconvolve
+
     I_conv = oaconvolve(I, I_slit_interp, mode="same") * wstep
 
     # 5. Remove boundary effects
@@ -839,6 +841,8 @@ def get_effective_FWHM(w, I):
     :py:func:`~radis.tools.slit.crop_slit`
 
     """
+
+    from scipy.integrate import trapezoid
 
     Imax = I.max()
 
@@ -980,6 +984,8 @@ def normalize_slit(w_slit, I_slit, norm_by="area"):
     :py:func:`~radis.tools.slit.crop_slit`
 
     """
+
+    from scipy.integrate import trapezoid
 
     # Renormalize
     # ---------
@@ -1146,6 +1152,7 @@ def plot_slit(
         wunit = waveunit
 
     import matplotlib.pyplot as plt
+    from scipy.integrate import trapezoid
 
     from radis.misc.plot import set_style
 
@@ -1413,6 +1420,8 @@ def import_experimental_slit(
 
     """
 
+    from scipy.integrate import trapezoid
+
     # Deprecated input:
     if waveunit is not None:
         warn(
@@ -1585,6 +1594,8 @@ def triangular_slit(
     w = np.hstack((-w[1:][::-1], w)) + center
 
     # Normalize
+    from scipy.integrate import trapezoid
+
     if norm_by == "area":  # normalize by the area
         I /= trapezoid(I, x=w)
         Iunit = f"1/{wunit}"
@@ -1687,6 +1698,8 @@ def trapezoidal_slit(
     :py:func:`~radis.tools.slit.gaussian_slit`
 
     """
+
+    from scipy.integrate import trapezoid
 
     if top > base:
         top, base = base, top
@@ -1818,6 +1831,8 @@ def gaussian_slit(
 
 
     """
+
+    from scipy.integrate import trapezoid
 
     f = int(footerspacing)  # spacing (footer) on left and right
     sigma = FWHM / 2 / sqrt(2 * ln(2))


### PR DESCRIPTION
### Description

This PR addresses the slow startup time reported in #937 (and previously #629).

Profiling showed that `import radis` was taking about 2.2s because it was eagerly loading heavy dependencies like `scipy`, `astropy`, `plotly`, and the `radis.io` module right at the start.

I have updated these to use lazy loading so they are only imported when actually used.

### Changes

* **Function-Level Deferral:** Moved top-level imports (`scipy`, `astropy`, `plotly`, `bs4`, `requests`) inside the specific functions that need them (mostly in `radis/tools`, `radis/lbl`, and `radis/misc`).
* **Module-Level Lazy Loading:** Updated `radis/io/__init__.py` to use `__getattr__` so fetch functions are only loaded when accessed.

### Benchmarks

I measured the startup time using `python -X importtime` (averaging 5 runs on Linux, Python 3.14).
The mean startup time dropped from **~2.17s to ~1.02s** (~53% faster).
<img width="2400" height="1200" alt="image" src="https://github.com/user-attachments/assets/a7dd5014-6e6d-4a01-9c6f-0a84764930b8" />

**Analysis:**
The chart above breaks down the time spent per module. You can see the heavy bottlenecks in the current version (Red bars):
* `radis.io` (~721ms) and `scipy.signal` (~376ms) were the biggest costs.
* In this PR (Green bars), `scipy.signal`, `astropy`, and `bs4` are completely deferred (0ms).
* `radis.io` is reduced by 98% (down to ~13ms).

**Tuna Profile**
The profile below confirms a clean import tree. The heavy modules are no longer blocking the main thread.

<img width="1875" height="983" alt="image" src="https://github.com/user-attachments/assets/ad7a7fa4-893d-43f5-8445-a32f12844244" />



### How to Verify

```bash
# Quick benchmark 
 for i in 1 2 3 4 5; do python -c "import time; s=time.perf_counter(); import radis; print(f'{time.perf_counter()-s:.3f}s')"; done

# Per-module profiling
python -X importtime -c "import radis" 2>&1 | sort -t'|' -k2 -rn | head -15
```

**Note:** The numbers reported here are the **mean** (average) of my test runs, not the absolute best or worst case. While exact timings may vary slightly on different machines, you should get results very near to these figures.



Fixes #937