### PR TITLE
feat: Store HITRAN isotopes separately to improve download and parsing performance

### DIFF
--- a/radis/api/hitranapi.py
+++ b/radis/api/hitranapi.py
@@ -1824,22 +1824,69 @@ class HITRANDatabaseManager(DatabaseManager):
         self.actual_file = None
 
     def get_filenames(self):
+        """Return list of per-isotope filenames for this molecule."""
+        from radis.db.hitran_isotopes import get_hitran_isotopes
+
+        isotopes = get_hitran_isotopes(self.molecule)
         if self.engine == "vaex":
-            return [join(self.local_databases, f"{self.molecule}.hdf5")]
+            ext = ".hdf5"
         elif self.engine == "pytables":
-            return [join(self.local_databases, f"{self.molecule}.h5")]
+            ext = ".h5"
         else:
             raise NotImplementedError()
+        return [
+            join(self.local_databases, f"{self.molecule}_iso{iso}{ext}")
+            for iso in isotopes
+        ]
+
+    def get_filenames_for_isotopes(self, isotopes):
+        """Return filenames for specific isotope numbers.
+
+        Parameters
+        ----------
+        isotopes : list of int
+            e.g. [1, 2, 3]
+        """
+        if self.engine == "vaex":
+            ext = ".hdf5"
+        elif self.engine == "pytables":
+            ext = ".h5"
+        else:
+            raise NotImplementedError()
+        return [
+            join(self.local_databases, f"{self.molecule}_iso{iso}{ext}")
+            for iso in isotopes
+        ]
+
+    def check_old_format_files(self):
+        """Detect and auto-remove old single-file databases (e.g. CO.hdf5).
+
+        Follows the established ``check_deprecated_files`` pattern.
+        """
+        for ext in [".hdf5", ".h5"]:
+            old_file = join(self.local_databases, f"{self.molecule}{ext}")
+            if exists(old_file):
+                if self.verbose:
+                    from radis.misc.printer import printr
+
+                    printr(
+                        f"Found old-format database file {old_file}. "
+                        "RADIS now stores isotopes separately. "
+                        "Removing it to regenerate per-isotope files."
+                    )
+                os.remove(old_file)
 
     def download_and_parse(
         self,
-        local_file,
+        local_files,
         cache=True,
         parse_quanta=True,
         add_HITRAN_uncertainty_code=False,
     ):
-        """Download from HITRAN and parse into ``local_file``.
-        Also add metadata
+        """Download from HITRAN and parse into per-isotope ``local_files``.
+
+        Each file in ``local_files`` corresponds to a single isotope,
+        named like ``CO_iso1.hdf5``.
 
         Overwrites :py:meth:`radis.api.dbmanager.DatabaseManager.download_and_parse`
         which downloads from a list of URL, because here we use [HAPI]_ to
@@ -1847,161 +1894,110 @@ class HITRANDatabaseManager(DatabaseManager):
 
         Parameters
         ----------
-        opener: an opener with an .open() command
-        gfile : file handler. Filename: for info"""
+        local_files : list of str
+            Target per-isotope HDF5 file paths.
+        """
+
+        import io
+        import re as re_module
+        import sys
 
         from hapi import LOCAL_TABLE_CACHE, db_begin, fetch
 
         from radis.db.classes import get_molecule_identifier
 
-        if isinstance(local_file, list):
-            assert (
-                len(local_file) == 1
-            )  # fetch_hitran stores all lines of a given molecule in one file
-            local_file = local_file[0]
-
+        molecule = self.molecule
+        extra_params = self.extra_params
         wmin = 0
         wmax = 1e10
+        max_fetch_retries = 3
 
-        def download_all_hitran_isotopes(molecule, directory, extra_params):
-            """Blindly try to download all isotopes 1 - 9 for the given molecule
+        # create database in a subfolder to isolate molecules
+        tempdir = join(self.tempdir, molecule)
+        from radis.misc.basics import make_folders
 
-            .. warning::
-                this won't be able to download higher isotopes (ex : isotope 10-11-12 for CO2)
-                Neglected for the moment, they're irrelevant for most calculations anyway
-            .. Isotope Missing:
-                When an isotope is missing for a particular molecule then a key error `(molecule_id, isotope_id)
-                is raised.
+        make_folders(*split(abspath(expanduser(tempdir))))
 
-            """
-            directory = abspath(expanduser(directory))
-            max_fetch_retries = 3
-            retry_delay = 1
-            # create temp folder :
-            from radis.misc.basics import make_folders
+        # Suppress HAPI's verbose output
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            db_begin(tempdir)
+        finally:
+            sys.stdout = old_stdout
 
-            make_folders(*split(directory))
-
-            # Use tqdm for isotope progress
-            import io
-            import sys
-
-            from tqdm import tqdm
-
-            # Suppress HAPI's verbose output (version banner, directory messages, etc.)
-            old_stdout = sys.stdout
-            sys.stdout = io.StringIO()
-            try:
-                db_begin(directory)
-            finally:
-                sys.stdout = old_stdout
-
-            isotope_list = []
-            data_file_list = []
-            header_file_list = []
-
-            for iso in tqdm(
-                range(1, 10), desc="Downloading isotopes", disable=not self.verbose
-            ):
-                file = f"{molecule}_{iso}"
-                if exists(join(directory, file + ".data")):
-                    if cache == "regen":
-                        # remove without printing message
-                        os.remove(join(directory, file + ".data"))
-                    else:
-                        from radis.misc.printer import printr
-
-                        printr(
-                            f"File already exist: {join(directory, file + '.data')}. Deleting it.`"
-                        )
-                        os.remove(join(directory, file + ".data"))
-                try:
-                    for attempt in range(max_fetch_retries):
-                        # Suppress HAPI's verbose output (65536 bytes written...)
-                        old_stdout = sys.stdout
-                        sys.stdout = io.StringIO()
-                        try:
-                            if extra_params == "all":
-                                fetch(
-                                    file,
-                                    get_molecule_identifier(molecule),
-                                    iso,
-                                    wmin,
-                                    wmax,
-                                    ParameterGroups=[*PARAMETER_GROUPS_HITRAN],
-                                )
-                            elif extra_params is None:
-                                fetch(
-                                    file,
-                                    get_molecule_identifier(molecule),
-                                    iso,
-                                    wmin,
-                                    wmax,
-                                )
-                            else:
-                                raise ValueError(
-                                    "extra_params can only be 'all' or None "
-                                )
-                        finally:
-                            sys.stdout = old_stdout
-
-                        ### We test if the download went well ###
-                        df = pd.DataFrame(LOCAL_TABLE_CACHE[file]["data"])
-                        if len(df["molec_id"]) != 0:
-                            break  # everything worked well
-                        else:
-                            warning_msg = (
-                                "HITRAN fetch failed. The database looks empty. "
-                                f"Waiting {retry_delay} seconds and trying again (attempt {attempt + 1}/{max_fetch_retries})."
-                            )
-                        if attempt == max_fetch_retries - 1:
-                            warning_msg += "\nLAST ATTEMPT"
-                        warnings.warn(warning_msg, UserWarning, stacklevel=2)
-                        time.sleep(retry_delay)
-                        retry_delay *= 2  # exponential
-                except KeyError as err:  # check for missing isotopes. If the isotope is missing, skip to next up to isotope 9
-                    list_pattern = ["(", ",", ")"]
-                    import re
-
-                    if (
-                        set(list_pattern).issubset(set(str(err)))
-                        and len(re.findall(r"\d", str(err))) >= 2
-                        and get_molecule_identifier(molecule)
-                        == int(
-                            re.findall(r"[\w']+", str(err))[0]
-                        )  # The regex are cryptic
-                    ):
-                        # Isotope not defined, go to next isotope
-                        continue
-                    else:
-                        raise KeyError(f"Error: {str(err)}")
-                else:
-                    isotope_list.append(iso)
-                    data_file_list.append(file + ".data")
-                    header_file_list.append(file + ".header")
-            return isotope_list, data_file_list, header_file_list
-
-        molecule = self.molecule
+        writer = self.get_datafile_manager()
         wmin_final = 100000
         wmax_final = -1
 
-        # create database in a subfolder to isolate molecules from one-another
-        # (HAPI doesn't check and may mix molecules --> see failure at https://app.travis-ci.com/github/radis/radis/jobs/548126303#L2676)
-        tempdir = join(self.tempdir, molecule)
-        extra_params = self.extra_params
+        for local_file in local_files:
+            # Extract isotope number from filename like CO_iso3.hdf5
+            match = re_module.search(r"_iso(\d+)\.", local_file)
+            if not match:
+                raise ValueError(
+                    f"Cannot extract isotope number from filename: {local_file}"
+                )
+            iso = int(match.group(1))
 
-        # Use HAPI only to download the files, then we'll parse them with RADIS's
-        # parsers, and convert to RADIS's fast HDF5 file formats.
-        isotope_list, data_file_list, header_file_list = download_all_hitran_isotopes(
-            molecule, tempdir, extra_params
-        )
+            hapi_table = f"{molecule}_{iso}"
+            data_file_path = join(tempdir, hapi_table + ".data")
+            if exists(data_file_path):
+                os.remove(data_file_path)
 
-        writer = self.get_datafile_manager()
+            # Download this isotope via HAPI
+            retry_delay = 1
+            downloaded = False
+            for attempt in range(max_fetch_retries):
+                old_stdout = sys.stdout
+                sys.stdout = io.StringIO()
+                try:
+                    if extra_params == "all":
+                        fetch(
+                            hapi_table,
+                            get_molecule_identifier(molecule),
+                            iso,
+                            wmin,
+                            wmax,
+                            ParameterGroups=[*PARAMETER_GROUPS_HITRAN],
+                        )
+                    elif extra_params is None:
+                        fetch(
+                            hapi_table,
+                            get_molecule_identifier(molecule),
+                            iso,
+                            wmin,
+                            wmax,
+                        )
+                    else:
+                        raise ValueError("extra_params can only be 'all' or None")
+                finally:
+                    sys.stdout = old_stdout
 
-        # Create HDF5 cache file for all isotopes
-        Nlines = 0
-        for iso, data_file in zip(isotope_list, data_file_list):
-            df = pd.DataFrame(LOCAL_TABLE_CACHE[data_file.split(".")[0]]["data"])
+                df = pd.DataFrame(LOCAL_TABLE_CACHE[hapi_table]["data"])
+                if len(df["molec_id"]) != 0:
+                    downloaded = True
+                    break
+                else:
+                    warning_msg = (
+                        "HITRAN fetch failed. The database looks empty. "
+                        f"Waiting {retry_delay}s and trying again "
+                        f"(attempt {attempt + 1}/{max_fetch_retries})."
+                    )
+                    if attempt == max_fetch_retries - 1:
+                        warning_msg += "\nLAST ATTEMPT"
+                    warnings.warn(warning_msg, UserWarning, stacklevel=2)
+                    time.sleep(retry_delay)
+                    retry_delay *= 2
+
+            if not downloaded:
+                warnings.warn(
+                    f"Could not download isotope {iso} of {molecule}.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                continue
+
+            # Parse and write to per-isotope HDF5 file
             df.rename(
                 columns={
                     "molec_id": "id",
@@ -2032,60 +2028,55 @@ class HITRANDatabaseManager(DatabaseManager):
 
             wmin_final = min(wmin_final, df.wav.min())
             wmax_final = max(wmax_final, df.wav.max())
-            Nlines += len(df)
 
-            writer.write(
-                local_file, df, append=True
-            )  # create temporary files if required
+            writer.write(local_file, df, append=False)
+            writer.combine_temp_batch_files(local_file, sort_values="wav")
 
-        # Open all HDF5 cache files and export in a single file with Vaex
-        writer.combine_temp_batch_files(
-            local_file, sort_values="wav"
-        )  # used for vaex mode only
-        # Note: by construction, in Pytables mode the database is not sorted
-        # by 'wav' but by isotope
+            # Add metadata per file
+            from radis import __version__
+
+            writer.add_metadata(
+                local_file,
+                {
+                    "wavenumber_min": float(df.wav.min()),
+                    "wavenumber_max": float(df.wav.max()),
+                    "download_date": self.get_today(),
+                    "download_url": "downloaded by HAPI, parsed & stored with RADIS",
+                    "total_lines": len(df),
+                    "version": __version__,
+                    "isotope": iso,
+                },
+            )
 
         self.wmin = wmin_final
         self.wmax = wmax_final
 
-        # Add metadata
-        from radis import __version__
+    def register(self, download_files, local_files=None):
+        """Register per-isotope files in ~/radis.json.
 
-        writer.add_metadata(
-            local_file,
-            {
-                "wavenumber_min": self.wmin,
-                "wavenumber_max": self.wmax,
-                "download_date": self.get_today(),
-                "download_url": "downloaded by HAPI, parsed & store with RADIS",
-                "total_lines": Nlines,
-                "version": __version__,
-            },
-        )
-
-        # # clean downloaded files  TODO
-        # for file in data_file_list + header_file_list:
-        #     os.remove(join(self.local_databases, "downloads", file))
-
-    def register(self, download_files):
-        """register in ~/radis.json"""
+        Parameters
+        ----------
+        download_files : bool
+            Whether files were downloaded in this session.
+        local_files : list of str, optional
+            Paths to per-isotope files to register.
+        """
 
         if self.is_registered():
             dict_entries = getDatabankEntries(
                 self.name
             )  # just update previous register details
         else:
-
             dict_entries = {}
 
         if download_files:
-            files = [self.actual_file]
+            files = local_files if local_files else self.get_filenames()
+            # Filter to only existing files
+            files = [f for f in files if exists(f)]
             if self.wmin is None or self.wmax is None:
                 print(
                     "Somehow wmin and wmax was not given for this database. Reading from the files"
                 )
-                ##  fix:
-                # (can happen if database was downloaded & parsed, but registration failed a first time)
                 df_full = self.load(
                     local_files=files,
                     columns=["wav"],

--- a/radis/db/hitran_isotopes.py
+++ b/radis/db/hitran_isotopes.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""Registry of all HITRAN isotopes per molecule.
+
+Derived from HITRAN 2020 [1]_ and ``isotope_name_dict`` in
+:py:mod:`radis.db.molparam`.
+
+Used to know which per-isotope database files to expect when
+``isotope='all'`` is requested, without querying the HITRAN server
+each time.
+
+References
+----------
+.. [1] `HITRAN molecule metadata <https://hitran.org/docs/molec-meta/>`__
+
+See Also
+--------
+:py:data:`radis.db.molparam.isotope_name_dict`
+"""
+
+from collections import defaultdict
+
+from radis.db.molparam import isotope_name_dict
+
+
+def _build_hitran_isotopes():
+    """Build HITRAN_ISOTOPES from isotope_name_dict.
+
+    Returns a dict  ``{molecule_name: [iso1, iso2, ...]}``
+    sorted by isotope number.
+    """
+    from radis.db.classes import get_molecule
+
+    mol_isos = defaultdict(list)
+    for mol_id, iso_num in isotope_name_dict:
+        mol_name = get_molecule(mol_id)
+        mol_isos[mol_name].append(iso_num)
+    # Sort isotope lists
+    return {mol: sorted(isos) for mol, isos in mol_isos.items()}
+
+
+HITRAN_ISOTOPES = _build_hitran_isotopes()
+"""dict: Mapping of HITRAN molecule name -> list of valid isotope numbers.
+
+Example::
+
+    >>> from radis.db.hitran_isotopes import HITRAN_ISOTOPES
+    >>> HITRAN_ISOTOPES["CO"]
+    [1, 2, 3, 4, 5, 6]
+    >>> HITRAN_ISOTOPES["CO2"]
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+"""
+
+
+def get_hitran_isotopes(molecule):
+    """Return the list of valid HITRAN isotope numbers for *molecule*.
+
+    Parameters
+    ----------
+    molecule : str
+        HITRAN molecule name, e.g. ``"CO"``, ``"CO2"``.
+
+    Returns
+    -------
+    list of int
+
+    Raises
+    ------
+    KeyError
+        If *molecule* is not found in the HITRAN registry.
+    """
+    try:
+        return HITRAN_ISOTOPES[molecule]
+    except KeyError:
+        raise KeyError(
+            f"Molecule '{molecule}' not found in HITRAN isotope registry. "
+            f"Available molecules: {sorted(HITRAN_ISOTOPES.keys())}"
+        )

--- a/radis/io/hitran.py
+++ b/radis/io/hitran.py
@@ -139,7 +139,6 @@ def fetch_hitran(
         databank_name = databank_name.format(**{"molecule": molecule})
 
     if local_databases is None:
-
         local_databases = join(config["DEFAULT_DOWNLOAD_PATH"], "hitran")
     local_databases = abspath(local_databases.replace("~", expanduser("~")))
 
@@ -153,35 +152,53 @@ def fetch_hitran(
         parallel=parallel,
     )
 
+    # Auto-remove old single-file format (e.g. CO.hdf5 -> CO_iso*.hdf5)
+    ldb.check_old_format_files()
+
+    # Determine which isotopes are needed
+    from radis.db.hitran_isotopes import get_hitran_isotopes
+
+    all_isotopes = get_hitran_isotopes(molecule)
+    if isotope is not None:
+        needed_isotopes = [int(i) for i in str(isotope).split(",")]
+    else:
+        needed_isotopes = all_isotopes
+
+    # Get per-isotope file paths
+    needed_files = ldb.get_filenames_for_isotopes(needed_isotopes)
+    all_files = ldb.get_filenames()  # all possible files for registration
+
     # Check if the database is registered in radis.json
-    local_files = []
+    registered_files = []
     if ldb.is_registered():
         entries = getDatabankEntries(ldb.name)
-        local_files = entries["path"]
+        registered_files = entries["path"]
 
     if ldb.is_registered() and not config["ALLOW_OVERWRITE"]:
         error = False
-        if cache == "regen" or not local_files:
+        if cache == "regen" or not registered_files:
             error = True
-        files_to_check = local_files
-        if ldb.get_missing_files(files_to_check):
+        if ldb.get_missing_files(needed_files):
             error = True
         if error:
             raise Exception(
-                'Changes are required to the local database, and hence updating the registered entry, but "ALLOW_OVERWRITE" is False. Set `radis.config["ALLOW_OVERWRITE"]=True` to allow the changes to be made and config file to be automatically updated accordingly.'
+                "Changes are required to the local database, and hence updating "
+                'the registered entry, but "ALLOW_OVERWRITE" is False. Set '
+                '`radis.config["ALLOW_OVERWRITE"]=True` to allow the changes.'
             )
 
     # Delete files if needed:
     if cache == "regen":
-        ldb.remove_local_files(local_files)
+        ldb.remove_local_files(needed_files)
     else:
-        # Raising AccuracyWarning if local_file exists and doesn't have extra columns in it
-        if ldb.get_existing_files(local_files) and extra_params == "all":
-            columns = ldb.get_columns(local_files[0])
+        # Raising AccuracyWarning if local_file exists and doesn't have extra columns
+        existing = ldb.get_existing_files(needed_files)
+        if existing and extra_params == "all":
+            cols = ldb.get_columns(existing[0])
             extra_columns = ["y_", "gamma_", "n_"]
             found = False
             for key in extra_columns:
-                for column_name in columns:
+                for column_name in cols:
                     if key in column_name:
                         found = True
                         break
@@ -191,22 +208,19 @@ def fetch_hitran(
 
                 warnings.warn(
                     AccuracyWarning(
-                        "All columns are not downloaded currently, please use cache = 'regen' and extra_params='all' to download all columns."
+                        "All columns are not downloaded currently, please use "
+                        "cache = 'regen' and extra_params='all' to download all columns."
                     )
                 )
     ldb.check_deprecated_files(
-        ldb.get_existing_files(local_files),
+        ldb.get_existing_files(needed_files),
         auto_remove=True if cache != "force" else False,
     )
 
-    # Check if local files are available so we don't have to download
-    download_files = True
-    if local_files and not ldb.get_missing_files(local_files):
-        download_files = False
-        ldb.actual_file = local_files[0]
+    # Determine which per-isotope files need to be downloaded
+    missing_files = ldb.get_missing_files(needed_files)
+    do_download = len(missing_files) > 0
 
-    # Download files
-    # Download files
     # Initialize progress printer for consistent output
     printer = DatabaseProgressPrinter(
         database_name="HITRAN",
@@ -215,46 +229,46 @@ def fetch_hitran(
     )
     printer.header("Downloading database")
 
-    if download_files:
+    if do_download:
         printer.section("Download")
-        main_files = ldb.get_filenames()
-        printer.info(f"Downloading all isotopes for {molecule}", indent=1)
-        if main_files:
-            try:
-                ldb.download_and_parse(
-                    main_files, cache=cache, parse_quanta=parse_quanta
-                )
-            except OSError as err:
-                printer.warning(f"Error downloading: {err}")
-                raise
-            else:
-                printer.success("HITRAN database download complete")
-                ldb.actual_file = main_files[0]
+        printer.info(
+            f"Downloading {len(missing_files)} isotope file(s) for {molecule}", indent=1
+        )
+        try:
+            ldb.download_and_parse(
+                missing_files, cache=cache, parse_quanta=parse_quanta
+            )
+        except OSError as err:
+            printer.warning(f"Error downloading: {err}")
+            raise
+        else:
+            printer.success("HITRAN database download complete")
     else:
         printer.section("Download")
-        printer.info("All files already downloaded.", indent=1)
+        printer.info("All needed isotope files already downloaded.", indent=1)
         printer.section("Caching to HDF5/H5 format")
-        printer.info("All files already cached.", indent=1)
+        printer.info("All needed isotope files already cached.", indent=1)
 
-    # Register
-    if download_files or not ldb.is_registered():
-        ldb.register(download_files)
+    # Register all existing per-isotope files
+    existing_all = ldb.get_existing_files(all_files)
+    if do_download or not ldb.is_registered():
+        ldb.register(do_download, local_files=existing_all)
 
-    if download_files and clean_cache_files:
+    if do_download and clean_cache_files:
         ldb.clean_download_files()
 
-    # Load and return
+    # Load from per-isotope files (only the needed ones)
+    files_to_load = ldb.get_existing_files(needed_files)
     df = ldb.load(
-        [ldb.actual_file],
+        files_to_load,
         columns=columns,
-        within=[("iso", isotope)] if isotope is not None else [],
-        # for relevant files, get only the right range :
+        within=[],  # isotope filtering is implicit (separate files)
         lower_bound=[("wav", load_wavenum_min)] if load_wavenum_min is not None else [],
         upper_bound=[("wav", load_wavenum_max)] if load_wavenum_max is not None else [],
         output=output,
     )
 
-    return (df, local_files) if return_local_path else df
+    return (df, files_to_load) if return_local_path else df
 
 
 # ======================================================

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -1234,10 +1234,12 @@ class DatabankLoader(object):
 
                 df.attrs = {}
 
-                # ... explicitely write all isotopes based on isotopes found in the database
+                # ... explicitly write all isotopes based on the HITRAN registry
                 if isotope == "all":
+                    from radis.db.hitran_isotopes import get_hitran_isotopes
+
                     self.input.isotope = ",".join(
-                        [str(k) for k in self._get_isotope_list(df=df)]
+                        [str(k) for k in get_hitran_isotopes(molecule)]
                     )
 
             elif database == "range":

--- a/radis/test/db/test_hitran_isotopes.py
+++ b/radis/test/db/test_hitran_isotopes.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""Tests for :py:mod:`radis.db.hitran_isotopes`."""
+
+import pytest
+
+
+def test_hitran_isotopes_vs_molparam():
+    """Ensure HITRAN_ISOTOPES is consistent with isotope_name_dict.
+
+    Every (mol_id, iso_num) pair in ``isotope_name_dict`` must appear
+    in ``HITRAN_ISOTOPES`` under the correct molecule name.
+    """
+    from radis.db.classes import get_molecule
+    from radis.db.hitran_isotopes import HITRAN_ISOTOPES
+    from radis.db.molparam import isotope_name_dict
+
+    for mol_id, iso_num in isotope_name_dict:
+        mol_name = get_molecule(mol_id)
+        assert (
+            mol_name in HITRAN_ISOTOPES
+        ), f"Molecule '{mol_name}' (id={mol_id}) missing from HITRAN_ISOTOPES"
+        assert (
+            iso_num in HITRAN_ISOTOPES[mol_name]
+        ), f"Isotope {iso_num} of '{mol_name}' missing from HITRAN_ISOTOPES"
+
+
+def test_hitran_isotopes_known_molecules():
+    """Spot-check well-known molecules."""
+    from radis.db.hitran_isotopes import HITRAN_ISOTOPES
+
+    assert HITRAN_ISOTOPES["CO"] == [1, 2, 3, 4, 5, 6]
+    assert HITRAN_ISOTOPES["CO2"] == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    assert HITRAN_ISOTOPES["H2O"] == [1, 2, 3, 4, 5, 6, 7]
+    assert HITRAN_ISOTOPES["O2"] == [1, 2, 3]
+
+
+def test_get_hitran_isotopes():
+    """Test the helper function."""
+    from radis.db.hitran_isotopes import get_hitran_isotopes
+
+    assert get_hitran_isotopes("CO") == [1, 2, 3, 4, 5, 6]
+
+    with pytest.raises(KeyError):
+        get_hitran_isotopes("NOT_A_MOLECULE")
+
+
+if __name__ == "__main__":
+    test_hitran_isotopes_vs_molparam()
+    test_hitran_isotopes_known_molecules()
+    test_get_hitran_isotopes()
+    print("All hitran_isotopes tests passed!")

--- a/radis/test/io/test_hdf5.py
+++ b/radis/test/io/test_hdf5.py
@@ -99,20 +99,23 @@ def test_local_hdf5_lines_loading(*args, **kwargs):
 
     # Initialize the database
     fetch_hitran("OH")
-    path = getDatabankEntries("HITRAN-OH")["path"][0]
+    paths = getDatabankEntries("HITRAN-OH")["path"]
+    assert len(paths) >= 1  # Should have multiple per-isotope files
+    path = paths[0]
     df = hdf2df(path)
     wmin, wmax = df.wav.min(), df.wav.max()
     assert wmin < 2300  # needed for next test to be valid
     assert wmax > 2500  # needed for next test to be valid
     assert len(df.columns) > 5  # many columns loaded by default
-    assert len(df.iso.unique()) > 1
+    assert len(df.iso.unique()) == 1  # Each file now contains exactly 1 isotope
 
     # Test loading only certain columns
     df = hdf2df(path, columns=["wav", "int"])
     assert len(df.columns) == 2 and "wav" in df.columns and "int" in df.columns
 
     # Test loading only certain isotopes
-    df = hdf2df(path, isotope="2")
+    path_iso2 = next(p for p in paths if "iso2" in p)
+    df = hdf2df(path_iso2, isotope="2")
     assert df.iso.unique() == 2
 
     # Test partial loading of wavenumbers

--- a/radis/test/io/test_query.py
+++ b/radis/test/io/test_query.py
@@ -147,6 +147,9 @@ def test_fetch_hitran_CO_vaex(*args, **kwargs):
         cache="regen",
     )
 
+    print("Loaded completely!", len(df))
+    print(df.iso.value_counts())
+
     assert len(df) == 5381
     assert df.wav.min() == 3.40191
     assert df.wav.max() == 14477.377153

--- a/radis/test/io/test_query.py
+++ b/radis/test/io/test_query.py
@@ -147,8 +147,9 @@ def test_fetch_hitran_CO_vaex(*args, **kwargs):
         cache="regen",
     )
 
-    print("Loaded completely!", len(df))
-    print(df.iso.value_counts())
+
+    # Debug statements removed
+    
 
     assert len(df) == 5381
     assert df.wav.min() == 3.40191

--- a/radis/test/io/test_query.py
+++ b/radis/test/io/test_query.py
@@ -147,9 +147,7 @@ def test_fetch_hitran_CO_vaex(*args, **kwargs):
         cache="regen",
     )
 
-
     # Debug statements removed
-    
 
     assert len(df) == 5381
     assert df.wav.min() == 3.40191

--- a/radis/test/io/test_query.py
+++ b/radis/test/io/test_query.py
@@ -6,6 +6,7 @@ Test query functions
 
 """
 
+from glob import glob
 from os.path import exists, join
 
 import pytest
@@ -108,16 +109,22 @@ def test_fetch_hitran_CO_pytables(*args, **kwargs):
     from radis.io.hitran import fetch_hitran
     from radis.test.utils import getTestFile
 
+    local_db = join(getTestFile("."), "hitran_iso")
     df = fetch_hitran(
         "CO",
-        local_databases=join(getTestFile("."), "hitran"),
-        databank_name="HITRAN-CO-TEST-ENGINE-PYTABLES",
+        local_databases=local_db,
+        databank_name="HITRAN-CO-TEST-ISO-PYTABLES",
         engine="pytables",
+        cache="regen",
     )
 
     assert len(df) == 5381
     assert df.wav.min() == 3.40191
     assert df.wav.max() == 14477.377153
+
+    # Verify per-isotope files were created
+    iso_files = glob(join(local_db, "CO_iso*.h5"))
+    assert len(iso_files) == 6  # CO has 6 isotopes
 
 
 # TODO : clean database on each new pytest run ?
@@ -131,16 +138,22 @@ def test_fetch_hitran_CO_vaex(*args, **kwargs):
     from radis.io.hitran import fetch_hitran
     from radis.test.utils import getTestFile
 
+    local_db = join(getTestFile("."), "hitran_iso")
     df = fetch_hitran(
         "CO",
-        local_databases=join(getTestFile("."), "hitran"),
-        databank_name="HITRAN-CO-TEST-ENGINE-VAEX",
+        local_databases=local_db,
+        databank_name="HITRAN-CO-TEST-ISO-VAEX",
         engine="vaex",
+        cache="regen",
     )
 
     assert len(df) == 5381
     assert df.wav.min() == 3.40191
     assert df.wav.max() == 14477.377153
+
+    # Verify per-isotope files were created
+    iso_files = glob(join(local_db, "CO_iso*.hdf5"))
+    assert len(iso_files) == 6  # CO has 6 isotopes
 
 
 # ignored by pytest with argument -m "not needs_connection"
@@ -149,12 +162,41 @@ def test_fetch_hitran(*args, **kwargs):
 
     from radis.io.hitran import fetch_hitran
 
-    df = fetch_hitran("CO")
+    df = fetch_hitran("CO", cache="regen")
 
     assert set(df["iso"]) == {1, 2, 3, 4, 5, 6}
     assert len(df) == 5381
     assert df.wav.min() == 3.40191
     assert df.wav.max() == 14477.377153
+
+
+# ignored by pytest with argument -m "not needs_connection"
+@pytest.mark.needs_connection
+def test_fetch_hitran_specific_isotope(*args, **kwargs):
+    """Test that fetching a specific isotope only downloads that isotope's file."""
+
+    from radis.io.hitran import fetch_hitran
+    from radis.test.utils import getTestFile
+
+    local_db = join(getTestFile("."), "hitran_iso_single")
+    df = fetch_hitran(
+        "CO",
+        isotope="1",
+        local_databases=local_db,
+        databank_name="HITRAN-CO-TEST-ISO1-ONLY",
+        engine="pytables",
+        cache="regen",
+    )
+
+    # Only isotope 1 should be present
+    assert set(df["iso"]) == {1}
+    assert len(df) < 5381  # Fewer lines than all isotopes
+    assert len(df) > 0
+
+    # Verify only the requested isotope file was created
+    assert exists(join(local_db, "CO_iso1.h5"))
+    # Other isotope files should NOT exist
+    assert not exists(join(local_db, "CO_iso2.h5"))
 
 
 @pytest.mark.needs_connection

--- a/radis/test/spectrum/test_spectrum.py
+++ b/radis/test/spectrum/test_spectrum.py
@@ -483,7 +483,10 @@ def test_plot_by_parts(plot=False, *args, **kwargs):
     and plot_by_parts=True in :py:meth:`~radis.spectrum.spectrum.Spectrum.plot`
     """
 
+
     import matplotlib.pyplot as plt
+    if not plot:
+        plt.switch_backend("Agg")
 
     plt.ion()
 

--- a/radis/test/spectrum/test_spectrum.py
+++ b/radis/test/spectrum/test_spectrum.py
@@ -483,8 +483,8 @@ def test_plot_by_parts(plot=False, *args, **kwargs):
     and plot_by_parts=True in :py:meth:`~radis.spectrum.spectrum.Spectrum.plot`
     """
 
-
     import matplotlib.pyplot as plt
+
     if not plot:
         plt.switch_backend("Agg")
 


### PR DESCRIPTION
<!-- Please be sure to check out our developer guide,
https://radis.readthedocs.io/en/latest/dev/developer.html -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address the inefficiency in HITRAN database downloads by refactoring the mechanism to store each isotope in its own separate HDF5 file (e.g., `CO_iso1.hdf5`) instead of merging all isotopes into a single database file.

**Key Changes:**
- **Isotope Registry**: Added a hardcoded `HITRAN_ISOTOPES` registry ([hitran_isotopes.py](cci:7://file:///Users/zenx/Radis-Gsoc/radis-Opensource/radis/db/hitran_isotopes.py:0:0-0:0)) so RADIS knows which isotopes exist without querying the server.
- **[HITRANDatabaseManager](cci:2://file:///Users/zenx/Radis-Gsoc/radis-Opensource/radis/api/hitranapi.py:1792:0-2127:20) Refactor**: Modified [download_and_parse()](cci:1://file:///Users/zenx/Radis-Gsoc/radis-Opensource/radis/api/dbmanager.py:383:4-528:84) to write each isotope to a separate file.
- **Selective Downloads**: [fetch_hitran()](cci:1://file:///Users/zenx/Radis-Gsoc/radis-Opensource/radis/io/hitran.py:14:0-256:59) now determines which isotopes are needed and only downloads the missing per-isotope caches.
- **Cache Auto-Migration**: Added detection to automatically remove old single-file databases (like `CO.hdf5`), forcing a seamless re-download in the new per-isotope format.
- **Loader Update**: Updated [loader.py](cci:7://file:///Users/zenx/Radis-Gsoc/radis-Opensource/radis/lbl/loader.py:0:0-0:0) to use the offline registry when `isotope="all"` is requested.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Related to Issue #513 
