### PR TITLE
ci: cache HITRAN databases to fix rate-limiting and mark network tests

### DIFF
--- a/.github/workflows/test-fetch-databases.yml
+++ b/.github/workflows/test-fetch-databases.yml
@@ -1,0 +1,35 @@
+# Separate workflow to test actual database fetching from HITRAN, HITEMP, ExoMol, GEISA.
+# No cache - every run downloads fresh from the servers.
+# Known to fail intermittently due to server-side rate-limiting - this is NOT
+# a required check, but gives visibility into fetch regressions before merge.
+
+name: Test fetch from databases
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest specutils
+          pip install -e .
+      - name: Test database fetching
+        env:
+          HITRAN_EMAIL: ${{ secrets.HITRAN_EMAIL }}
+          HITRAN_PASSWORD: ${{ secrets.HITRAN_PASSWORD }}
+        run: |
+          pytest -m "needs_connection and not download_large_databases" --durations=10 --tb=short

--- a/.github/workflows/tests-develop.yml
+++ b/.github/workflows/tests-develop.yml
@@ -38,6 +38,13 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache downloaded databases
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.radisdb
+            ~/radis.json
+          key: radisdb-v1-${{ matrix.os }}-py${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/tests-master.yml
+++ b/.github/workflows/tests-master.yml
@@ -49,6 +49,13 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache downloaded databases
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.radisdb
+            ~/radis.json
+          key: radisdb-v1-${{ matrix.os }}-py${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/uncached-fetch-tests.yml
+++ b/.github/workflows/uncached-fetch-tests.yml
@@ -1,7 +1,5 @@
-# Separate workflow to test actual database fetching from HITRAN, HITEMP, ExoMol, GEISA.
-# No cache - every run downloads fresh from the servers.
-# Known to fail intermittently due to server-side rate-limiting - this is NOT
-# a required check, but gives visibility into fetch regressions before merge.
+# Verifies live database fetching without cache (HITRAN, HITEMP, ExoMol, GEISA).
+# Non-blocking workflow: Expect occasional rate-limit failures from remote servers.before merge.
 
 name: Test fetch from databases
 

--- a/radis/test/lbl/test_broadening.py
+++ b/radis/test/lbl/test_broadening.py
@@ -926,6 +926,7 @@ def test_noneq_continuum(plot=False, verbose=2, warnings=True, *args, **kwargs):
     assert res < 5.2e-6
 
 
+@pytest.mark.needs_connection
 def test_broadening_chunksize_eq(verbose=True, plot=False, *args, **kwargs):
     """
     Test equilibrium spectra with and without chunksize,
@@ -990,6 +991,7 @@ def test_broadening_chunksize_eq(verbose=True, plot=False, *args, **kwargs):
 
 
 # @pytest.mark.fast #not fast due to connection, Nicolas Minesi 08/04/2024
+@pytest.mark.needs_connection
 def test_non_air_diluent(verbose=True, plot=False, *args, **kwargs):
     """Test collisional broadening by other species than air and self (resonant)
 
@@ -1055,6 +1057,7 @@ def test_non_air_diluent(verbose=True, plot=False, *args, **kwargs):
 
 
 # @pytest.mark.fast #not fast due to connection, Nicolas Minesi 08/04/2024
+@pytest.mark.needs_connection
 def test_diluents_molefraction(verbose=True, plot=False, *args, **kwargs):
     """
     Assert an error is raised when Molefraction (molecule + diluent) < 1 or > 1

--- a/radis/test/lbl/test_calc.py
+++ b/radis/test/lbl/test_calc.py
@@ -866,6 +866,7 @@ def test_check_wavelength_range(verbose=True, warnings=True, *args, **kwargs):
     assert np.isclose(w.max(), 5000, atol=wstep)
 
 
+@pytest.mark.needs_connection
 def test_non_air_diluent_calc(verbose=True, plot=False, warnings=True, *args, **kwargs):
     from radis import plot_diff
 
@@ -927,6 +928,7 @@ def test_non_air_diluent_calc(verbose=True, plot=False, warnings=True, *args, **
         )
 
 
+@pytest.mark.needs_connection
 def test_diluent_invalid(verbose=True, plot=False, *args, **kwargs):
 
     with pytest.raises(KeyError) as err:

--- a/radis/test/lbl/test_factory.py
+++ b/radis/test/lbl/test_factory.py
@@ -641,6 +641,7 @@ def test_all_spectrum_using_wstep_auto(verbose=True, plot=False, *args, **kwargs
     assert sf._wstep == "auto"
 
 
+@pytest.mark.needs_connection
 @pytest.mark.skipif(isinstance(vaex, NotInstalled), reason="Vaex not available")
 def test_vaex_and_pandas_spectrum():
     """Compares spectrum calculated using vaex and pandas are same.
@@ -724,6 +725,7 @@ def test_vaex_and_pandas_spectrum():
 
 
 # %%
+@pytest.mark.needs_connection
 @pytest.mark.skipif(isinstance(vaex, NotInstalled), reason="Vaex not available")
 def test_vaex_and_pandas_spectrum_noneq():
     """Compares the Spectrum calculated under non-equilibrium conditions .

--- a/radis/test/tools/test_database.py
+++ b/radis/test/tools/test_database.py
@@ -167,6 +167,7 @@ def test_save_compressed2(verbose=True, *args, **kwargs):
         assert s.compare_with(s_bis, spectra_only=var, plot=False, verbose=verbose)
 
 
+@pytest.mark.needs_connection
 def test_lazy_loading(verbose=True, *args, **kwargs):
     """Test lazy loading"""
 


### PR DESCRIPTION
### Description

This PR implements database caching in GitHub Actions to reduce HITRAN API calls and prevent rate-limiting, addressing the remaining fetching optimization mentioned in the closed issue #785.

**The Problem:**
RADIS CI tests intermittently fail when downloading databases from HITRAN servers. Because CI runners start fresh on every run and execute five jobs in parallel, they simultaneously spam HITRAN with download requests, triggering rate limiting. Since HITRAN doesn't return a standard HTTP error code when blocking us, adding retry logic isn't a practical fix.

**The Solution:**
1. **GitHub Actions Cache:** Added `actions/cache@v4` to the CI workflows to persist the downloaded databases (`~/.radisdb` and `~/radis.json`) between runs. The cache key includes the OS and Python version to avoid cross-platform HDF5 incompatibility. After the initial cache is built, future CI runs will reuse the databases instead of re-downloading them, fixing the rate-limiting at its root.
2. **Missing Network Markers:** I tracked down 8 test functions that make network calls to HITRAN but were missing the `@pytest.mark.needs_connection` marker, and added them for correctness.

Fixes #785 

[Related Slack discussion](https://radis-radiation.slack.com/archives/C9F7X0ZAT/p1772135413531809?thread_ts=1772135413.531809&cid=C9F7X0ZAT)