### PR TITLE
Fix TODOs: add error/warning messages and fix bare except

### DIFF
--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -448,7 +448,7 @@ def read_states(
             dat = pd.read_csv(
                 statesf, compression="bz2", sep=r"\s+", usecols=usecol, names=names
             )
-        except:  #!!!TODO What was the expected error?
+        except (OSError, pd.errors.ParserError):  # File not compressed or parse error
             dat = pd.read_csv(statesf, sep=r"\s+", usecols=usecol, names=names)
     else:
         raise NotImplementedError(engine)

--- a/radis/api/nistapi.py
+++ b/radis/api/nistapi.py
@@ -88,6 +88,14 @@ class NISTDatabaseManager(DatabaseManager):
         # Use the opener's open method which should be available in all implementations
         with opener.open() as file:
             file_content = file.read().decode("utf-8")
+
+        # Check if NIST returned no data
+        if "No lines are available in ASD with the parameters selected" in file_content:
+            raise ValueError(
+                f"No spectral lines available for {self.molecule} in NIST database "
+                "with the selected parameters"
+            )
+
         file = StringIO(file_content)
 
         df = nist2df(file, self.molecule)

--- a/radis/lbl/overp.py
+++ b/radis/lbl/overp.py
@@ -677,7 +677,19 @@ def rescale_updown_levels(
     when inferring emission quantities from absorption quantities this may
     ends up in error in overpopulation rescaling.
     """
-    # TODO: Add warning when too large rescaling
+    # Warn if rescaling is too large (>30% change)
+    if old_nu != 0 and old_nl != 0 and not ignore_warnings:
+        rescale_nu = abs(new_nu / old_nu - 1)
+        rescale_nl = abs(new_nl / old_nl - 1)
+        if rescale_nu > 0.3 or rescale_nl > 0.3:
+            from warnings import warn
+
+            warn(
+                f"Large rescaling detected: nu factor={new_nu/old_nu:.2f}, "
+                f"nl factor={new_nl/old_nl:.2f}. For large changes, "
+                "calculate a new spectrum instead.",
+                UserWarning,
+            )
 
     # Check inputs
     # ---------

--- a/radis/lbl/overp.py
+++ b/radis/lbl/overp.py
@@ -682,8 +682,6 @@ def rescale_updown_levels(
         rescale_nu = abs(new_nu / old_nu - 1)
         rescale_nl = abs(new_nl / old_nl - 1)
         if rescale_nu > 0.3 or rescale_nl > 0.3:
-            from warnings import warn
-
             warn(
                 f"Large rescaling detected: nu factor={new_nu/old_nu:.2f}, "
                 f"nl factor={new_nl/old_nl:.2f}. For large changes, "


### PR DESCRIPTION
## Summary

Implements 4 TODO items from the codebase:

1. **nistapi.py**: Add `ValueError` when NIST database returns no spectral lines
2. **spectrum.py**: Add warning when slit FWHM >= wstep/5 (may cause inaccurate convolution)
3. **overp.py**: Add warning when rescaling factor > 30% (large rescaling may be inaccurate)
4. **exomolapi.py**: Replace bare `except:` with specific `(OSError, pd.errors.ParserError)`