### PR TITLE
fix: replace raise DeprecationWarning with warnings.warn and NotImple…

### DIFF
--- a/radis/api/cache_files.py
+++ b/radis/api/cache_files.py
@@ -663,7 +663,7 @@ def filter_metadata(arguments, discard_variables=["self", "verbose"]):
 
 
 def cache_file_name(fname, engine="pytables"):
-    raise DeprecationWarning("Use DataFileManager.cache_file() instead")
+    raise NotImplementedError("Use DataFileManager.cache_file() instead")
 
 
 if __name__ == "__main__":

--- a/radis/api/cache_files.py
+++ b/radis/api/cache_files.py
@@ -662,10 +662,6 @@ def filter_metadata(arguments, discard_variables=["self", "verbose"]):
     return metadata
 
 
-def cache_file_name(fname, engine="pytables"):
-    raise NotImplementedError("Use DataFileManager.cache_file() instead")
-
-
 if __name__ == "__main__":
     import pytest
 

--- a/radis/api/hdf5.py
+++ b/radis/api/hdf5.py
@@ -70,7 +70,7 @@ def update_pytables_to_vaex(fname, remove_initial=False, verbose=True, key="df")
 
 class HDF5Manager(object):
     def __init__(*args, **kwargs):
-        raise DeprecationWarning("HDF5Manager replaced with DataFileManager")
+        raise NotImplementedError("HDF5Manager replaced with DataFileManager")
 
 
 class DataFileManager(object):

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -1439,10 +1439,11 @@ class Spectrum(object):
         :ref:`the Spectrum page <label_spectrum>`
         """
         if which is not None:
-            raise DeprecationWarning(
-                "`which` parameter was deleted in Radis 0.9.30. Just use Spectrum.get_wavelength()"
+            warn(
+                "`which` parameter was deleted in Radis 0.9.30. Just use Spectrum.get_wavelength()",
+                DeprecationWarning,
+                stacklevel=2,
             )
-            # TODO: remove after 0.9.31
 
         # Check input
         if not medium in ["air", "vacuum"]:
@@ -1492,10 +1493,11 @@ class Spectrum(object):
             quantities
         """
         if which is not None:
-            raise DeprecationWarning(
-                "`which` parameter was deleted in Radis 0.9.30. Just use Spectrum.get_wavenumber()"
+            warn(
+                "`which` parameter was deleted in Radis 0.9.30. Just use Spectrum.get_wavenumber()",
+                DeprecationWarning,
+                stacklevel=2,
             )
-            # TODO: remove after 0.9.31
 
         w = self._get_wavespace(copy=copy)
 
@@ -2109,10 +2111,11 @@ class Spectrum(object):
 
         """
         if which is not None:
-            raise DeprecationWarning(
-                "`which` parameter was deleted in Radis 0.9.30. Just use Spectrum.get_vars()"
+            warn(
+                "`which` parameter was deleted in Radis 0.9.30. Just use Spectrum.get_vars()",
+                DeprecationWarning,
+                stacklevel=2,
             )
-            # TODO: remove after 0.9.31
 
         # remove wavespace
         varlist = [k for k in self._q.keys() if k != "wavespace"]
@@ -2125,10 +2128,11 @@ class Spectrum(object):
 
         """
         if which is not None:
-            raise DeprecationWarning(
-                "`which` parameter was deleted in Radis 0.9.30. Just use Spectrum.get_quantities()"
+            warn(
+                "`which` parameter was deleted in Radis 0.9.30. Just use Spectrum.get_quantities()",
+                DeprecationWarning,
+                stacklevel=2,
             )
-            # TODO: remove after 0.9.31
 
         return self.get_vars()
 
@@ -4482,10 +4486,13 @@ class Spectrum(object):
         """
         # Check inputs (check for deprecated)
         if if_conflict_drop is not None:
-            raise DeprecationWarning(
-                "`if_conflict_drop` parameter was deleted in Radis 0.9.30"
+            import warnings
+
+            warnings.warn(
+                "`if_conflict_drop` parameter was deleted in Radis 0.9.30",
+                DeprecationWarning,
+                stacklevel=2,
             )
-            # TODO: remove after 0.9.31
 
         if inplace:
             s = self

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -1413,7 +1413,7 @@ class Spectrum(object):
 
         return w
 
-    def get_wavelength(self, medium="air", which=None, copy=True):
+    def get_wavelength(self, medium="air", copy=True):
         r"""Return wavelength in defined medium.
 
         Parameters
@@ -1438,13 +1438,6 @@ class Spectrum(object):
         --------
         :ref:`the Spectrum page <label_spectrum>`
         """
-        if which is not None:
-            warn(
-                "`which` parameter was deleted in Radis 0.9.30. Just use Spectrum.get_wavelength()",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
         # Check input
         if not medium in ["air", "vacuum"]:
             raise NotImplementedError(f"Unknown propagating medium: {medium}")
@@ -4408,7 +4401,6 @@ class Spectrum(object):
         energy_threshold="default",
         print_conservation=False,
         inplace=True,
-        if_conflict_drop=None,
         **kwargs,
     ):
         r"""Resample spectrum over a new wavelength/wavenumber range.
@@ -4484,16 +4476,6 @@ class Spectrum(object):
         --------
         :func:`radis.misc.signal.resample`, :py:meth:`radis.spectrum.spectrum.Spectrum.resample_even`
         """
-        # Check inputs (check for deprecated)
-        if if_conflict_drop is not None:
-            import warnings
-
-            warnings.warn(
-                "`if_conflict_drop` parameter was deleted in Radis 0.9.30",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
         if inplace:
             s = self
         else:

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -1470,7 +1470,7 @@ class Spectrum(object):
 
         return w
 
-    def get_wavenumber(self, which=None, copy=True):
+    def get_wavenumber(self, copy=True):
         r"""Return wavenumber (if the same for all quantities)
 
         Other Parameters
@@ -1485,13 +1485,6 @@ class Spectrum(object):
             (a copy of) spectrum wavenumber for convoluted or non convoluted
             quantities
         """
-        if which is not None:
-            warn(
-                "`which` parameter was deleted in Radis 0.9.30. Just use Spectrum.get_wavenumber()",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
         w = self._get_wavespace(copy=copy)
 
         if self.get_waveunit() == "cm-1":  #
@@ -2098,35 +2091,21 @@ class Spectrum(object):
 
     # %% Plotting routines
 
-    def get_vars(self, which=None):
+    def get_vars(self):
         r"""Returns all spectral quantities stored in this object (convoluted or
         non convoluted)
 
         """
-        if which is not None:
-            warn(
-                "`which` parameter was deleted in Radis 0.9.30. Just use Spectrum.get_vars()",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
         # remove wavespace
         varlist = [k for k in self._q.keys() if k != "wavespace"]
         return varlist
 
-    def get_quantities(self, which=None):
+    def get_quantities(self):
         r"""Returns all spectral quantities stored in this object (convoluted or
         non convoluted). Wrapper to
         :py:meth:`~radis.spectrum.spectrum.get_vars`
 
         """
-        if which is not None:
-            warn(
-                "`which` parameter was deleted in Radis 0.9.30. Just use Spectrum.get_quantities()",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
         return self.get_vars()
 
     def _get_items(self) -> dict:


### PR DESCRIPTION
### Description
This PR implements the changes discussed in #963 to fix the incorrect `raise DeprecationWarning` usage.

**Summary of changes:**
- **`spectrum.py`**: Replaced `raise DeprecationWarning` with `warnings.warn(..., DeprecationWarning, stacklevel=2)` for `get_wavelength`, `get_wavenumber`, `get_vars`, `get_quantities`, and `resample`. 
 - **`cache_files.py` and `hdf5.py`**: Replaced `raise DeprecationWarning` with `raise NotImplementedError` for the fully removed `cache_file_name()` function and `HDF5Manager` class.

Fixes #963