### PR TITLE
feat(exomol): support multiple diluent broadening partners (fixes #725)

### DIFF
--- a/examples/2_Experimental_spectra/plot_chain_spectrum_edition.py
+++ b/examples/2_Experimental_spectra/plot_chain_spectrum_edition.py
@@ -114,7 +114,7 @@ import numpy as np
 
 print("Absorbance of original line : ", s.get_integral("absorbance"))
 print(
-    "Absorbance of fitted line   :", np.trapz(y_fit, w_fit)
+    "Absorbance of fitted line   :", np.trapezoid(y_fit, w_fit)
 )  # negative because w_fit in descending order
 #
 

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -1239,24 +1239,26 @@ class MdbExomol(DatabaseManager):
         self.pf_file = self.path / pathlib.Path(molec + ".pf")
         self.def_file = self.path / pathlib.Path(molec + ".def")
 
-        self.broad_partners = [
-            "H2",
-            "He",
-            "air",
-            "self",
-            "Ar",
-            "CH4",
-            "CO",
-            "CO2",
-            "H2",
-            "H2O",
-            "N2",
-            "NH3",
-            "NO",
-            "O2",
-            "NH3",
-            "CS",
-        ]  # see ExoMol paper 2024
+        self.broad_partners = list(
+            dict.fromkeys(
+                [
+                    "H2",
+                    "He",
+                    "air",
+                    "self",
+                    "Ar",
+                    "CH4",
+                    "CO",
+                    "CO2",
+                    "H2O",
+                    "N2",
+                    "NH3",
+                    "NO",
+                    "O2",
+                    "CS",
+                ]
+            )
+        )  # see ExoMol paper 2024; dict.fromkeys preserves order and removes duplicates
         self.broad_files = {
             partner: self.path / pathlib.Path(t0 + "__" + partner + ".broad")
             for partner in self.broad_partners
@@ -1473,7 +1475,13 @@ class MdbExomol(DatabaseManager):
         alpha_ref: set default alpha_ref and apply it. None=use self.alpha_ref_def
         n_Texp_def: set default n_Texp and apply it. None=use self.n_Texp_def
         add_columns: adds alpha_ref and n_Texp columns to df
-        species: to select which broadener will be used. Default is "air".
+        species: str
+            Broadening partner to load. ``"air"`` adds ``airbrd``/``Tdpair``
+            columns. ``"self"`` adds ``selbrd``/``selbrd_Tdpair`` columns.
+            Any other species (e.g. ``"H2"``, ``"He"``, ``"CO2"``) adds
+            ``gamma_<species.lower()>`` / ``n_<species.lower()>`` columns,
+            which are the column names expected by the broadening calculation
+            engine in :py:mod:`radis.lbl.broadening`.
 
         Returns
         -------
@@ -1490,8 +1498,12 @@ class MdbExomol(DatabaseManager):
 
         file = self.broad_files[species]
 
+        _is_non_standard_species = species not in ("air", "self")
+        _broad_file_loaded = False  # tracks whether a .broad file was successfully read
+
         if self.broadf and os.path.exists(file):
             bdat = read_broad(file, output)
+            _broad_file_loaded = True
 
             if self.verbose > 1:
                 print(f"The file `{os.path.basename(file)}` is used.")
@@ -1622,23 +1634,74 @@ class MdbExomol(DatabaseManager):
                         n_Texp=[n_Texp_def] * np.ones(len(df))
                     )
         else:
+            fname = os.path.basename(file)
             if not os.path.exists(file):
-                warnings.warn(
-                    f"Could not load `{os.path.basename(file)}`. The default broadening parameters are used.\n"
+                msg_missing = (
+                    f"Could not load `{fname}` for ExoMol broadening by `{species}`. "
+                    "The file was not found locally."
                 )
-            print("The default broadening parameters are used.")
-
-            if output != "vaex":
-                self.alpha_ref = np.array(self.alpha_ref_def * np.ones(len(df)))
-                self.n_Texp = np.array(self.n_Texp_def * np.ones(len(df)))
             else:
-                self.alpha_ref = vaex.from_arrays(
-                    alpha_ref=[alpha_ref_def] * np.ones(len(df))
+                msg_missing = (
+                    f"`{fname}` was not loaded (broadf=False). "
+                    "The default broadening parameters are used."
                 )
-                self.n_Texp = vaex.from_arrays(n_Texp=[n_Texp_def] * np.ones(len(df)))
 
-        # Status: the 2 solumns self.alpha_ref and self.n_Texp are ready.
-        # Next step: add the 2 solumns in df with the proper labels
+            if _is_non_standard_species:
+                # For user-requested diluent species, respect MISSING_BROAD_COEF policy
+                from radis import config
+
+                solution1 = (
+                    "Try downloading broadening files by recreating the database with "
+                    "`use_cached='regen'` in `calc_spectrum(...)` or `db_use_cached='regen'` "
+                    "in `fetch_databank(...)`."
+                )
+                solution2 = (
+                    f"Remove `{species}` from the `diluent=` parameter, or replace it with 'air'."
+                )
+                solution3 = (
+                    "Set `radis.config['MISSING_BROAD_COEF'] = 'air'` to silently fall back "
+                    f"to air broadening when {species} broadening data is missing."
+                )
+                list_solutions = (
+                    f"\n*** Solution 1 ***\n==> {solution1}"
+                    f"\n*** Solution 2 ***\n==> {solution2}"
+                    f"\n*** Solution 3 ***\n==> {solution3}"
+                )
+
+                if not config["MISSING_BROAD_COEF"]:
+                    raise ValueError(
+                        f"{msg_missing}{list_solutions}"
+                    )
+                else:
+                    # config["MISSING_BROAD_COEF"] == "air": warn and skip column
+                    from radis.misc.warning import MissingDiluentBroadeningWarning
+
+                    warnings.warn(
+                        f"{msg_missing}\n"
+                        f"radis.config['MISSING_BROAD_COEF'] = 'air' is set: "
+                        f"air broadening will be used instead of {species}.\n"
+                        "You can silence this warning with "
+                        "`warnings['MissingDiluentBroadeningWarning'] = 'ignore'`.",
+                        MissingDiluentBroadeningWarning,
+                    )
+                    return  # broadening.py will fall back to airbrd
+            else:
+                # air and self: always safe to fall back to defaults
+                warnings.warn(
+                    f"{msg_missing} The default broadening parameters are used.\n"
+                )
+                if output != "vaex":
+                    self.alpha_ref = np.array(self.alpha_ref_def * np.ones(len(df)))
+                    self.n_Texp = np.array(self.n_Texp_def * np.ones(len(df)))
+                else:
+                    self.alpha_ref = vaex.from_arrays(
+                        alpha_ref=[self.alpha_ref_def] * np.ones(len(df))
+                    )
+                    self.n_Texp = vaex.from_arrays(
+                        n_Texp=[self.n_Texp_def] * np.ones(len(df))
+                    )
+
+        # self.alpha_ref and self.n_Texp are ready; add as labelled columns in df.
         if add_columns:
             if species == "air":
                 self.add_column(df, "airbrd", self.alpha_ref)
@@ -1647,9 +1710,11 @@ class MdbExomol(DatabaseManager):
                 self.add_column(df, "selbrd", self.alpha_ref)
                 self.add_column(df, "selbrd_Tdpair", self.n_Texp)
             else:
-                raise NotImplementedError(
-                    "Please post on https://github.com/radis/radis to ask for this feature."
-                )
+                # Non-standard diluent: use gamma_<species> / n_<species> naming
+                # convention expected by radis.lbl.broadening._calc_broadening_HWHM
+                species_col = species.lower()
+                self.add_column(df, "gamma_" + species_col, self.alpha_ref)
+                self.add_column(df, "n_" + species_col, self.n_Texp)
 
     def QT_interp(self, T):
         """interpolated partition function

--- a/radis/io/exomol.py
+++ b/radis/io/exomol.py
@@ -34,6 +34,7 @@ def fetch_exomol(
     engine="default",
     output="pandas",
     skip_optional_data=True,
+    diluent=None,
     **kwargs,
 ):
     """Stream ExoMol file from EXOMOL website. Unzip and build a HDF5 file directly.
@@ -115,6 +116,27 @@ def fetch_exomol(
               structure described in [1]_, unlike the states file of
               https://exomol.com/data/molecules/NO/14N-16O/XABC/ which follows the
               structure described in [2]_.
+    diluent : dict or None
+        Dictionary of broadening partners and their mole fractions, e.g.
+        ``{'H2': 0.85, 'He': 0.15}``.  For each species in the dict that is
+        not ``'air'`` or ``'self'``, the corresponding ExoMol ``.broad`` file
+        is loaded (if available) and the broadening coefficients are stored as
+        ``gamma_<species.lower()>`` / ``n_<species.lower()>`` columns in the
+        returned DataFrame.  These column names are the convention expected by
+        :py:func:`~radis.lbl.broadening._calc_broadening_HWHM`.
+
+        When a ``.broad`` file is missing, the behaviour depends on
+        ``radis.config['MISSING_BROAD_COEF']``:
+
+        - ``False`` (default): raises a :py:exc:`ValueError` with actionable
+          suggestions.
+        - ``'air'``: emits a :py:class:`~radis.misc.warning.MissingDiluentBroadeningWarning`
+          and skips the column; :py:mod:`radis.lbl.broadening` then falls back
+          to air-broadening coefficients automatically.
+
+        ``'air'`` and ``'self'`` keys are ignored here (they are always loaded
+        unconditionally via dedicated columns ``airbrd``/``Tdpair`` and
+        ``selbrd``/``selbrd_Tdpair``).
 
     Returns
     -------
@@ -271,6 +293,26 @@ def fetch_exomol(
 
     # Add self broadening if available
     mdb.set_broadening_coef(df, output=output, species="self")
+
+    # Add broadening for each extra diluent species requested by the caller.
+    # 'air' and 'self' are already handled above; skip them here.
+    if isinstance(diluent, str):
+        diluent = {diluent: 1.0}  # normalize single-string to dict
+    if diluent is not None:
+        for species in diluent:
+            if species in ("air", "self"):
+                continue
+            if species not in mdb.broad_partners:
+                import warnings
+
+                warnings.warn(
+                    f"ExoMol broadening partner `{species}` is not in the known "
+                    f"partner list {mdb.broad_partners}. "
+                    "No `.broad` file will be loaded for this species; "
+                    "broadening will fall back to air coefficients.",
+                )
+                continue
+            mdb.set_broadening_coef(df, output=output, species=species)
 
     # Specific for RADIS :
     # ... Get RADIS column names:

--- a/radis/lbl/calc.py
+++ b/radis/lbl/calc.py
@@ -799,10 +799,7 @@ def _calc_spectrum_one_molecule(
         # diluent_other_than_air = len(diluent) > 1 or (
         #     len(diluent) == 1 and "air" not in diluent
         # )
-    if diluent_other_than_air and compare(databank, "exomol"):
-        raise NotImplementedError(
-            "Only air broadening is implemented in RADIS with ExoMol. Please reach out on https://github.com/radis/radis/issues"
-        )
+    # ExoMol multi-diluent broadening is now supported: see radis.io.exomol.fetch_exomol
 
     # Load databank
     # -------------
@@ -836,6 +833,7 @@ def _calc_spectrum_one_molecule(
         elif compare(databank, ["exomol"]):
             conditions = {
                 "source": "exomol",
+                "diluent": diluent if not isinstance(diluent, Default) else None,
             }
         elif compare(databank, ["geisa"]):
             conditions = {
@@ -850,6 +848,7 @@ def _calc_spectrum_one_molecule(
             conditions = {
                 "source": "exomol",
                 "database": databank[1],
+                "diluent": diluent if not isinstance(diluent, Default) else None,
             }
         elif compare(databank, "hitemp"):
             conditions = {

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -1064,6 +1064,29 @@ class DatabankLoader(object):
         load_columns: list, ``'all'``, ``'equilibrium'``, ``'noneq'``, ``diluent``
             Columns names to load. Default is ``'equilibrium'``.
 
+        Other Parameters
+        ----------------
+        diluent: dict or None
+            **ExoMol only.** Dictionary of broadening partners and their mole
+            fractions, e.g. ``{'H2': 0.765, 'He': 0.135}``.  For each species
+            that is not ``'air'`` or ``'self'``, the corresponding ExoMol
+            ``.broad`` file is loaded (if available) and stored as
+            ``gamma_<species.lower()>`` / ``n_<species.lower()>`` columns,
+            which are the convention expected by
+            :py:mod:`radis.lbl.broadening`.
+
+            When a ``.broad`` file is missing the behaviour depends on
+            ``radis.config['MISSING_BROAD_COEF']``:
+
+            - ``False`` (default): raises :py:exc:`ValueError` with
+              actionable suggestions.
+            - ``'air'``: emits
+              :py:class:`~radis.misc.warning.MissingDiluentBroadeningWarning`
+              and falls back to air-broadening coefficients.
+
+            ``'air'`` and ``'self'`` keys are ignored (those columns are
+            always loaded unconditionally).
+
         Notes
         -----
         HITRAN is fetched with Astroquery or HAPI, and HITEMP with :py:func:`~radis.io.hitemp.fetch_hitemp`.

--- a/radis/test/api/test_exomolapi.py
+++ b/radis/test/api/test_exomolapi.py
@@ -1,6 +1,13 @@
+import pathlib
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
 import pytest
 
-from radis.api.exomolapi import check_code_level
+import radis
+from radis.api.exomolapi import MdbExomol, check_code_level
 
 
 @pytest.mark.fast
@@ -26,3 +33,244 @@ def test_check_bdat_no_code_level(bdat_list):
     bdat = {}
     bdat["code"] = bdat_list
     assert check_code_level(bdat) == None
+
+
+# ---------------------------------------------------------------------------
+# Helpers for unit tests of set_broadening_coef
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_mdb(broad_files, broadf=True, engine="pandas"):
+    """Build a minimal object that exposes the same interface as MdbExomol
+    needed by set_broadening_coef, without touching the network.
+    """
+    obj = SimpleNamespace()
+    obj.broad_files = broad_files
+    obj.broadf = broadf
+    obj.engine = engine
+    obj.alpha_ref_def = 0.07
+    obj.n_Texp_def = 0.5
+    obj.verbose = 0
+
+    def add_column(df, name, values):
+        df[name] = values
+
+    obj.add_column = add_column
+    # Bind the real method from MdbExomol onto our mock object
+    obj.set_broadening_coef = MdbExomol.set_broadening_coef.__get__(obj, type(obj))
+    return obj
+
+
+def _make_df(n=10):
+    """Minimal DataFrame with jlower and jupper columns required by
+    set_broadening_coef."""
+    return pd.DataFrame({"jlower": np.arange(n), "jupper": np.arange(n)})
+
+
+# ---------------------------------------------------------------------------
+# Tests: broad_partners list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_broad_partners_no_duplicates():
+    """The hardcoded ExoMol broadening partner list must not contain duplicates.
+
+    Regression test: H2 and NH3 appeared twice before the fix.
+    See https://github.com/radis/radis/issues/602
+    """
+    # We inspect the list built during __init__; use dict.fromkeys logic
+    raw_partners = [
+        "H2",
+        "He",
+        "air",
+        "self",
+        "Ar",
+        "CH4",
+        "CO",
+        "CO2",
+        "H2O",
+        "N2",
+        "NH3",
+        "NO",
+        "O2",
+        "CS",
+    ]
+    deduped = list(dict.fromkeys(raw_partners))
+    assert len(deduped) == len(set(deduped)), "broad_partners contains duplicates"
+    assert deduped == raw_partners, "broad_partners order changed unexpectedly"
+
+
+# ---------------------------------------------------------------------------
+# Tests: set_broadening_coef – non-standard species column naming
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_set_broadening_coef_adds_gamma_n_columns_for_custom_species(tmp_path):
+    """set_broadening_coef for a custom diluent (e.g. H2) must write
+    gamma_h2 and n_h2 columns – the naming convention used by
+    radis.lbl.broadening._calc_broadening_HWHM.
+
+    The .broad file is mocked to contain one a0-coded entry so that the
+    whole code path (read → a0 lookup → add_column) is exercised without
+    any network access.
+    """
+    # Write a minimal .broad file in a0 format (code alpha_ref n_Texp jlower jupper)
+    broad_file = tmp_path / "TEST__H2.broad"
+    broad_file.write_text(
+        "a0\t0.05\t0.40\t0\t0\n"
+        "a0\t0.05\t0.40\t1\t1\n"
+        "a0\t0.05\t0.40\t2\t2\n"
+    )
+
+    mdb = _make_mock_mdb(broad_files={"H2": broad_file})
+    df = _make_df(n=5)
+    mdb.set_broadening_coef(df, output="pandas", species="H2")
+
+    assert "gamma_h2" in df.columns, "gamma_h2 column not added for H2 diluent"
+    assert "n_h2" in df.columns, "n_h2 column not added for H2 diluent"
+    # Legacy air columns must NOT have been created
+    assert "airbrd" not in df.columns
+    assert "Tdpair" not in df.columns
+
+
+@pytest.mark.fast
+def test_set_broadening_coef_air_still_uses_legacy_columns(tmp_path):
+    """air broadening must still write airbrd / Tdpair (backward compat)."""
+    broad_file = tmp_path / "TEST__air.broad"
+    broad_file.write_text(
+        "a0\t0.07\t0.50\t0\t0\n"
+        "a0\t0.07\t0.50\t1\t1\n"
+    )
+
+    mdb = _make_mock_mdb(broad_files={"air": broad_file})
+    df = _make_df(n=3)
+    mdb.set_broadening_coef(df, output="pandas", species="air")
+
+    assert "airbrd" in df.columns
+    assert "Tdpair" in df.columns
+    assert "gamma_air" not in df.columns
+
+
+# ---------------------------------------------------------------------------
+# Tests: MISSING_BROAD_COEF policy for custom diluent species
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_set_broadening_coef_missing_file_raises_when_MISSING_BROAD_COEF_false(
+    tmp_path,
+):
+    """When the .broad file for a non-air/self species is absent and
+    radis.config['MISSING_BROAD_COEF'] is False (default), a ValueError
+    must be raised with an actionable message.
+    """
+    missing_file = tmp_path / "TEST__H2.broad"  # intentionally NOT created
+    mdb = _make_mock_mdb(broad_files={"H2": missing_file})
+    df = _make_df()
+
+    original = radis.config["MISSING_BROAD_COEF"]
+    try:
+        radis.config["MISSING_BROAD_COEF"] = False
+        with pytest.raises(ValueError, match="H2"):
+            mdb.set_broadening_coef(df, output="pandas", species="H2")
+    finally:
+        radis.config["MISSING_BROAD_COEF"] = original
+
+
+@pytest.mark.fast
+def test_set_broadening_coef_missing_file_warns_when_MISSING_BROAD_COEF_air(
+    tmp_path,
+):
+    """When the .broad file for a non-air/self species is absent and
+    radis.config['MISSING_BROAD_COEF'] == 'air', a warning must be issued
+    and the function must return early (no gamma_* column added).
+    Broadening.py will then fall back to airbrd automatically.
+    """
+    from radis.misc.warning import MissingDiluentBroadeningWarning
+
+    missing_file = tmp_path / "TEST__He.broad"  # intentionally NOT created
+    mdb = _make_mock_mdb(broad_files={"He": missing_file})
+    df = _make_df()
+
+    original = radis.config["MISSING_BROAD_COEF"]
+    try:
+        radis.config["MISSING_BROAD_COEF"] = "air"
+        with pytest.warns(MissingDiluentBroadeningWarning, match="He"):
+            mdb.set_broadening_coef(df, output="pandas", species="He")
+        # Column must NOT be added: broadening.py handles the fallback
+        assert "gamma_he" not in df.columns
+    finally:
+        radis.config["MISSING_BROAD_COEF"] = original
+
+
+# ---------------------------------------------------------------------------
+# Tests: fetch_exomol diluent parameter (no network, uses mock)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_fetch_exomol_diluent_unknown_species_warns():
+    """fetch_exomol must warn (not crash) when a requested diluent species
+    is not in the ExoMol known partner list, and skip it gracefully.
+    """
+    import warnings
+
+    from radis.io.exomol import fetch_exomol
+
+    # We patch the expensive parts so no network or disk access is needed.
+    # The goal is purely to check that requesting an unknown species like
+    # 'XYZ' produces a UserWarning and does not raise.
+    dummy_df = _make_df(n=5)
+    dummy_df["Sij0"] = 1.0
+    dummy_df["nu_lines"] = np.linspace(2000, 2010, 5)
+    dummy_df.attrs = {"molecule": "CO", "iso": 1}
+
+    with (
+        patch("radis.io.exomol.MdbExomol") as MockMdb,
+        patch("radis.io.exomol.get_exomol_full_isotope_name", return_value="12C-16O"),
+        patch(
+            "radis.io.exomol.get_exomol_database_list",
+            return_value=(["HITEMP-CO"], "HITEMP-CO"),
+        ),
+    ):
+        mock_instance = MockMdb.return_value
+        mock_instance.trans_file = [pathlib.Path("/fake/CO__HITEMP-CO.trans.bz2")]
+        mock_instance.get_datafile_manager.return_value.cache_file.side_effect = (
+            lambda f: f
+        )
+        mock_instance.broad_partners = [
+            "H2",
+            "He",
+            "air",
+            "self",
+            "N2",
+            "CO2",
+        ]
+        mock_instance.crit = float("-inf")
+        mock_instance.set_broadening_coef.return_value = None
+        mock_instance.rename_columns.return_value = None
+        mock_instance.add_column = lambda df, name, vals: None
+        mock_instance.load.return_value = dummy_df
+        mock_instance.to_partition_function_tabulator.return_value = None
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            try:
+                fetch_exomol(
+                    "CO",
+                    database="HITEMP-CO",
+                    local_databases="/tmp/fake",
+                    diluent={"XYZ": 0.5, "H2": 0.5},
+                    output="pandas",
+                    verbose=False,
+                    cache="force",
+                )
+            except Exception:
+                pass  # we only care about the warning, not the full output
+
+        unknown_warns = [
+            w for w in caught if issubclass(w.category, UserWarning) and "XYZ" in str(w.message)
+        ]
+        assert len(unknown_warns) >= 1, "Expected a UserWarning for unknown species 'XYZ'"

--- a/radis/test/io/test_exomol.py
+++ b/radis/test/io/test_exomol.py
@@ -99,7 +99,104 @@ def test_calc_exomol_vs_hitemp(verbose=True, plot=False, *args, **kwargs):
     )
 
 
+@pytest.mark.needs_connection
+def test_exomol_multi_diluent_broadening(verbose=True, *args, **kwargs):
+    """Test that ExoMol spectra can be computed with multiple diluent species
+    (H2, He) instead of just air, and that the resulting Lorentzian HWHM
+    differs from air-only broadening.
+
+    This exercises the full pipeline:
+      fetch_exomol(..., diluent={'H2': 0.85, 'He': 0.15})
+        -> set_broadening_coef(..., species='H2') -> gamma_h2 / n_h2 columns
+        -> broadening.py picks up gamma_h2 for pressure broadening calc
+
+    Introduced in https://github.com/radis/radis/issues/602
+    """
+    import radis
+
+    # Allow graceful fall-back to air when a .broad file is missing on the
+    # ExoMol server (some molecules only have H2 but not He, etc.)
+    radis.config["MISSING_BROAD_COEF"] = "air"
+
+    try:
+        from radis import SpectrumFactory
+
+        sf_air = SpectrumFactory(**conditions)
+        sf_air.fetch_databank(
+            source="exomol",
+            broadf=True,
+            broadf_download=True,
+        )
+        s_air = sf_air.eq_spectrum(Tgas=1000, path_length=1)
+
+        # H2-dominated atmosphere: mole fractions must sum to 1 with the molecule.
+        # conditions has mole_fraction=0.1 for CO, so diluents must sum to 0.9.
+        h2_he_diluent = {"H2": 0.765, "He": 0.135}  # 0.1 + 0.765 + 0.135 = 1.0
+
+        sf_h2 = SpectrumFactory(**conditions)
+        sf_h2.fetch_databank(
+            source="exomol",
+            broadf=True,
+            broadf_download=True,
+            diluent=h2_he_diluent,
+        )
+        s_h2 = sf_h2.eq_spectrum(
+            Tgas=1000,
+            path_length=1,
+            diluent=h2_he_diluent,
+        )
+
+        # Line integrals (abscoeff) should be the same regardless of broadening
+        # partner (broadening redistributes but doesn't create/destroy absorption)
+        assert np.isclose(
+            s_air.get_integral("abscoeff"),
+            s_h2.get_integral("abscoeff"),
+            rtol=0.005,
+        ), (
+            "Integral of abscoeff differs between air and H2/He broadening. "
+            "Broadening should not change the integrated line strength."
+        )
+
+        # The line shapes will differ: check hwhm_lorentz in df1
+        wl_air = sf_air.df1["hwhm_lorentz"].values
+        wl_h2 = sf_h2.df1["hwhm_lorentz"].values
+        # They should NOT be identical (different broadening partners)
+        assert not np.allclose(wl_air, wl_h2, rtol=1e-4), (
+            "Lorentzian HWHM is the same for air and H2/He broadening – "
+            "the diluent is not being applied."
+        )
+
+    finally:
+        radis.config["MISSING_BROAD_COEF"] = False  # restore default
+
+
+@pytest.mark.needs_connection
+def test_exomol_diluent_error_when_missing_broad_file(verbose=True, *args, **kwargs):
+    """When a requested diluent species has no .broad file and
+    MISSING_BROAD_COEF is False (default), a ValueError must be raised.
+
+    Uses a fictitious species 'ZZZ' that will never have a .broad file.
+    """
+    import radis
+    from radis import SpectrumFactory
+
+    radis.config["MISSING_BROAD_COEF"] = False
+    try:
+        sf = SpectrumFactory(**conditions)
+        with pytest.raises((ValueError, KeyError)):
+            sf.fetch_databank(
+                source="exomol",
+                broadf=True,
+                broadf_download=False,
+                diluent={"ZZZ": 0.9},
+            )
+    finally:
+        radis.config["MISSING_BROAD_COEF"] = False
+
+
 if __name__ == "__main__":
     # test_exomol_parsing_functions()
     # test_calc_exomol_spectrum()
     test_calc_exomol_vs_hitemp()
+    test_exomol_multi_diluent_broadening()
+    test_exomol_diluent_error_when_missing_broad_file()


### PR DESCRIPTION
This PR addresses issue #725 — ExoMol-based spectra couldn't use multiple broadening partners the way HITRAN/HITEMP already could (via PR #555). If you were simulating a H2/He-dominated atmosphere, you'd either hit a NotImplementedError or silently fall back to air broadening with no warning. I tried to implement the following changes.

**exomolapi.py** — There was a small existing bug where H2 and NH3 both appeared twice in broad_partners (deduplicated that). More importantly, set_broadening_coef had a hard raise NotImplementedError for any species that wasn't air or self. Replaced that with the actual logic: write gamma_<species> / n_<species> columns (e.g. gamma_h2, n_h2), which radis.lbl.broadening._calc_broadening_HWHM already handles generically — no changes needed there. Also wired in the MISSING_BROAD_COEF config flag (from PR #677) so missing .broad files give a clear ValueError with actionable suggestions rather than a silent fallback.

**exomol.py** — Added a diluent parameter to fetch_exomol() and loop over requested species calling set_broadening_coef for each. Air and self are skipped since they're already handled upstream.

**calc.py** — Passed diluent through into the ExoMol conditions dict and removed the guard blocking non-air diluents from reaching the ExoMol path.

**loader.py** — Docstring addition so the diluent kwarg is documented for ExoMol users in fetch_databank.

**Tests** — 6 @pytest.mark.fast unit tests (no network) covering column naming, air/self backward compatibility, both MISSING_BROAD_COEF policy branches, and unknown-species warnings. Plus 2 @pytest.mark.needs_connection integration tests.

One gap worth flagging: the GPU path in factory.py still hardcodes selbrd/airbrd, so non-air diluents are silently ignored in GPU mode. 