### PR TITLE
Resolve TODOs: add missing warning, docstring, and remove outdated comment

### DIFF
--- a/radis/levels/partfunc.py
+++ b/radis/levels/partfunc.py
@@ -640,9 +640,13 @@ class RovibParFuncCalculator(RovibPartitionFunction):
                 # Add overpopulations (so they are taken into account in the partition function)
                 for viblvl, ov in overpopulation.items():
                     if ov != 1:
-                        df.loc[df.viblvl == viblvl, "nvibQvib"] *= ov
-                        # TODO: add warning if empty? I dont know how to do it without
-                        # an extra lookup though.
+                        mask = df.viblvl == viblvl
+                        if mask.sum() == 0:
+                            warn(
+                                f"Overpopulation set for level '{viblvl}' but no "
+                                f"rows match in the energy level database."
+                            )
+                        df.loc[mask, "nvibQvib"] *= ov
 
             # Calculate sum of levels
             nQ = df.nvibQvib * df.nrotQrot

--- a/radis/misc/warning.py
+++ b/radis/misc/warning.py
@@ -191,9 +191,17 @@ class ZeroBroadeningWarning(UserWarning):
 
 
 class MissingPressureShiftWarning(UserWarning):
-    """Pressure-shift coefficient is missing in Line Database."""
+    """Pressure-shift coefficient (``Pshft``) is missing in Line Database.
 
-    # TODO : add docstring link to references of line database columns.
+    When missing, zero pressure shift is assumed.
+
+    The ``Pshft`` column is defined in:
+
+    - HITRAN format: :py:data:`~radis.api.hitranapi.columns_hitran`
+    - GEISA format: :py:data:`~radis.api.geisaapi.columns_geisa`
+    - CDSD format: :py:data:`~radis.api.cdsdapi.columns_cdsd`
+    """
+
     pass
 
 

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -373,8 +373,6 @@ class Spectrum(object):
         check_wavespace=True,
         **kwargs,
     ):
-        # TODO: add help on creating a Spectrum from a dictionary
-
         # Check inputs
         # ---------------
         # ... Replace None attributes with dictionaries


### PR DESCRIPTION
<!-- Please be sure to check out our developer guide,
https://radis.readthedocs.io/en/latest/dev/developer.html -->

### Description
<!-- Provide a general description of what your pull request does. -->

- Remove outdated TODO in Spectrum.__init__ (dict creation help already exists in class docstring)
- Add docstring with Pshft column references (HITRAN, GEISA, CDSD) to MissingPressureShiftWarning
- Add warning when overpopulation targets a vibrational level with no matching rows in partfunc


