### PR TITLE
Add normalize support to get_distance()

### DIFF
--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -187,9 +187,16 @@ def get_ratio(
 
 
 def get_distance(
-    s1: Spectrum, s2: Spectrum, var, wunit="default", Iunit="default", resample=True
+    s1: Spectrum,
+    s2: Spectrum,
+    var,
+    wunit="default",
+    Iunit="default",
+    resample=True,
+    normalize=False,
+    normalize_how="max",
 ):
-    # type: (Spectrum, Spectrum, str, str, str, str, bool) -> np.array, np.array
+    # type: (Spectrum, Spectrum, str, str, str, str, bool, bool, str) -> np.array, np.array
     r"""Get a regularized Euclidian distance between two spectra ``s1`` and
     ``s2``
 
@@ -230,6 +237,21 @@ def get_distance(
     medium: 'air', 'vacuum', default'
         propagating medium to compare in (if in wavelength)
 
+    Other Parameters
+    ----------------
+    normalize: bool, or tuple
+        if ``True``, normalize the two spectra before computing distance.
+        If a tuple (ex: ``(4168, 4180)``), normalize on this range only. The unit
+        is that of the first Spectrum by default (use ``wunit`` to change). Ex::
+
+            get_distance(s_exp, s_calc, var, normalize=(4178, 4180))
+
+        Default ``False``
+    normalize_how: ``'max'``, ``'area'``, ``'mean'``
+        how to normalize. ``'max'`` is the default but may not be suited for very
+        noisy experimental spectra. ``'area'`` will normalize the integral to 1.
+        ``'mean'`` will normalize by the mean amplitude value
+
     Notes
     -----
     Uses :func:`~radis.misc.curve.curve_distance` internally
@@ -243,7 +265,21 @@ def get_distance(
     :func:`~radis.spectrum.compare.plot_diff`,
     :meth:`~radis.spectrum.spectrum.compare_with`
     """
-    # TODO: normalize with Imax, wmax
+
+    if normalize:
+        if isinstance(normalize, tuple):
+            wrange = normalize
+        else:
+            wrange = ()
+        var, wunit, Iunit = get_default_units(s1, s2, var=var, wunit=wunit, Iunit=Iunit)
+        s1 = s1.take(var).normalize(
+            wrange=wrange, normalize_how=normalize_how, wunit=wunit
+        )
+        s2 = s2.take(var).normalize(
+            wrange=wrange, normalize_how=normalize_how, wunit=wunit
+        )
+        Iunit = s1.units[var]
+        assert Iunit == s2.units[var]
 
     var, wunit, Iunit = get_default_units(s1, s2, var=var, wunit=wunit, Iunit=Iunit)
 

--- a/radis/test/spectrum/test_compare.py
+++ b/radis/test/spectrum/test_compare.py
@@ -172,6 +172,56 @@ def test_get_residual():
         assert residual3 < criterion[index]
 
 
+def test_get_distance_normalize():
+    """Test that get_distance supports normalize parameter.
+
+    Two spectra with the same shape but different scales should yield
+    ~0 distance when normalized (since shape is identical)."""
+    from radis import Spectrum
+
+    w = np.linspace(2000, 2300, 100)
+    I1 = np.exp(-((w - 2150) ** 2) / 500)  # peak = 1.0
+    I2 = I1 * 1000  # same shape, 1000x larger
+
+    s1 = Spectrum.from_array(
+        w, I1, "radiance_noslit", wunit="cm-1", Iunit="mW/cm2/sr/nm"
+    )
+    s2 = Spectrum.from_array(
+        w, I2, "radiance_noslit", wunit="cm-1", Iunit="mW/cm2/sr/nm"
+    )
+
+    var = "radiance_noslit"
+
+    # Identical spectra after normalization: distance should be ~0
+    _, d_norm = get_distance(s1, s2, var, normalize=True)
+    assert (
+        np.nanmean(d_norm) < 1e-10
+    ), f"Same-shape spectra should have ~0 normalized distance, got {np.nanmean(d_norm)}"
+
+    # Self-distance should be ~0
+    _, d_self = get_distance(s1, s1, var, normalize=True)
+    assert np.nanmean(d_self) < 1e-10
+
+    # Different shapes should have non-zero normalized distance
+    I3 = np.exp(-((w - 2180) ** 2) / 500)  # shifted peak
+    s3 = Spectrum.from_array(
+        w, I3, "radiance_noslit", wunit="cm-1", Iunit="mW/cm2/sr/nm"
+    )
+    _, d_diff = get_distance(s1, s3, var, normalize=True)
+    assert (
+        np.nanmean(d_diff) > 1e-3
+    ), "Different-shape spectra should have non-zero normalized distance"
+
+    # Test all normalize_how options work without error
+    for how in ["max", "area", "mean"]:
+        _, d = get_distance(s1, s2, var, normalize=True, normalize_how=how)
+        assert not np.all(np.isnan(d)), f"normalize_how='{how}' returned all NaNs"
+
+    # Test normalize with wrange tuple
+    _, d_range = get_distance(s1, s2, var, normalize=(2100, 2200))
+    assert not np.all(np.isnan(d_range))
+
+
 def _run_testcases(plot=True, verbose=True, warnings=True, *args, **kwargs):
     """Test procedures"""
 
@@ -180,8 +230,9 @@ def _run_testcases(plot=True, verbose=True, warnings=True, *args, **kwargs):
     test_compare_methods(verbose=verbose, plot=plot, *args, **kwargs)
     test_plot_compare_with_nan(verbose=verbose, plot=True, *args, **kwargs)
     test_get_residual()
+    test_get_distance_normalize()
 
 
 if __name__ == "__main__":
     # print("Test_compare.py: ", _run_testcases())
-    test_get_residual()
+    test_get_distance_normalize()


### PR DESCRIPTION
<!-- Please be sure to check out our developer guide,
https://radis.readthedocs.io/en/latest/dev/developer.html -->

### Description
<!-- Provide a general description of what your pull request does. -->
- Add normalization support to `get_distance()`
- Enables shape-based spectrum comparison 
- Matches the interface of `get_residual()`
- Adds tests for normalization behavior 

edit(added issue details):

In [compare.py:247](https://github.com/radis/radis/blob/develop/radis/spectrum/compare.py#L247), there was this TODO:


`# TODO: normalize with Imax, wmax`

The problem: get_distance() compares two spectra by computing Euclidean distance, but it had no way to normalize spectra before comparing.

So if you had:

Spectrum A: simulated, intensity 0 → 1000
Spectrum B: experimental, intensity 0 → 0.5
Even though they have the same shape, get_distance() couldn't ignore the scale difference. Meanwhile, the sister function get_residual() already had normalize and normalize_how parameters for exactly this purpose.

How i Fixed It
Added two parameters to get_distance(), matching get_residual()'s interface:


BEFORE:
get_distance(s1, s2, var)  
`# normalize=True → TypeError!`

AFTER:  
get_distance(s1, s2, var, normalize=True, normalize_how='max')
`# Works! Normalizes both spectra before computing`

code to recreate issue:
```
import numpy as np
from radis import Spectrum
from radis.spectrum.compare import get_distance

w = np.linspace(2000, 2300, 100)
I1 = np.exp(-((w - 2150) ** 2) / 500)
I2 = I1 * 1000

s1 = Spectrum.from_array(w, I1, "radiance_noslit", wunit="cm-1", Iunit="mW/cm2/sr/nm")
s2 = Spectrum.from_array(w, I2, "radiance_noslit", wunit="cm-1", Iunit="mW/cm2/sr/nm")

get_distance(s1, s2, "radiance_noslit", normalize=True)
```

