### PR TITLE
refactor: extract envelope logic from gpu to standalone module

### DIFF
--- a/radis/api/hitranapi.py
+++ b/radis/api/hitranapi.py
@@ -20,7 +20,6 @@ Routine Listing
 
 """
 
-
 import os
 import sys
 
@@ -157,6 +156,58 @@ def extract_columns(df, extracted_values, columns):
 
     for column in columns:
         df[column] = df.evaluate(df[column])
+
+
+def _compute_envelope_metadata(df, molecule):
+    """Compute Gaussian/Lorentzian broadening envelopes and return as
+    metadata dict suitable for HDF5 cache storage.
+
+    Returns an empty dict if the required columns are missing.
+    """
+    import numpy as np
+    from scipy.constants import N_A, c, k
+
+    from radis.db.molparam import MolParams
+    from radis.lbl.envelope import (
+        compute_gaussian_envelope,
+        compute_lorentzian_envelope,
+        envelope_to_metadata,
+    )
+
+    required = {"wav", "Tdpair", "selbrd", "airbrd"}
+    if not required.issubset(df.columns):
+        return {}
+
+    from radis.db.classes import get_molecule_identifier
+
+    mol_id = get_molecule_identifier(molecule)
+    molparam = MolParams()
+
+    iso_set = df.iso.unique() if "iso" in df.columns else [1]
+    molar_mass = {}
+    for iso in iso_set:
+        try:
+            molar_mass[iso] = molparam.get(mol_id, iso, "mol_mass")
+        except Exception:
+            return {}
+
+    if "iso" in df.columns:
+        Mm = df["iso"].map(molar_mass).values
+    else:
+        Mm = molar_mass[iso_set[0]] * np.ones(len(df))
+
+    log_2vMm = np.log(df.wav.values) + 0.5 * np.log(
+        8 * k * np.log(2) / (c**2 * Mm * 1e-3 / N_A)
+    )
+    g_envelope = compute_gaussian_envelope(log_2vMm.astype(np.float32))
+
+    na = df.Tdpair.values.astype(np.float32)
+    gamma_arr = np.zeros((2, len(df)), dtype=np.float32)
+    gamma_arr[0] = df.selbrd.values.astype(np.float32)
+    gamma_arr[1] = df.airbrd.values.astype(np.float32)
+    l_envelope = compute_lorentzian_envelope(na, gamma_arr)
+
+    return envelope_to_metadata(g_envelope, l_envelope)
 
 
 def hit2df(
@@ -319,6 +370,7 @@ def hit2df(
             "wavenum_min": df.wav.min(),
             "wavenum_max": df.wav.max(),
         }
+        new_metadata.update(_compute_envelope_metadata(df, mol))
         if verbose:
             print(f"Generating cache file {fcache} with metadata :\n{new_metadata}")
         from radis import __version__
@@ -1959,7 +2011,9 @@ class HITRANDatabaseManager(DatabaseManager):
                         warnings.warn(warning_msg, UserWarning, stacklevel=2)
                         time.sleep(retry_delay)
                         retry_delay *= 2  # exponential
-                except KeyError as err:  # check for missing isotopes. If the isotope is missing, skip to next up to isotope 9
+                except (
+                    KeyError
+                ) as err:  # check for missing isotopes. If the isotope is missing, skip to next up to isotope 9
                     list_pattern = ["(", ",", ")"]
                     import re
 

--- a/radis/gpu/gpu.py
+++ b/radis/gpu/gpu.py
@@ -51,6 +51,8 @@ class gpuApp(GPUApplication):
         Q_intp_list,
         verbose=0,
         device_id=0,
+        gaussian_envelope=None,
+        lorentzian_envelope=None,
     ):
         """
         Initialize gpuApp object required for GPU calculations
@@ -93,6 +95,13 @@ class gpuApp(GPUApplication):
             Select the GPU device. If ``int``, specifies the device index, which is printed for convenience during GPU initialization with backend='vulkan' (default).
             If ``str``, return the first device that includes the specified string (case in-sesitive). If not found, return the device at index 0.
             default = 0
+        gaussian_envelope: tuple, optional
+            Pre-computed Gaussian envelope ``(log_2vMm_min, log_2vMm_max)``.
+            If provided, ``init_G_params`` is skipped.
+        lorentzian_envelope: tuple, optional
+            Pre-computed Lorentzian envelope as returned by
+            :func:`~radis.lbl.envelope.compute_lorentzian_envelope`.
+            If provided, ``init_L_params`` is skipped.
 
         """
 
@@ -153,8 +162,19 @@ class gpuApp(GPUApplication):
         init_Q(Q_intp_list)
         log_2vMm = np.log(v0) + log_c2Mm_arr.take(iso)
 
-        init_G_params(log_2vMm.astype(np.float32), verbose)
-        init_L_params(na, gamma_arr, verbose)  # TODO: do this on GPU?
+        if gaussian_envelope is not None:
+            from radis.gpu import params as _params_mod
+
+            _params_mod._G_param_data = gaussian_envelope
+        else:
+            init_G_params(log_2vMm.astype(np.float32), verbose)
+
+        if lorentzian_envelope is not None:
+            from radis.gpu import params as _params_mod
+
+            _params_mod._L_param_data = lorentzian_envelope
+        else:
+            init_L_params(na, gamma_arr, verbose)  # TODO: do this on GPU?
 
         # Parameters that *do* change are stored in iter_h.
         # We only assign values to them in the iterate() method,

--- a/radis/gpu/params.py
+++ b/radis/gpu/params.py
@@ -1,6 +1,8 @@
 import numpy as np
 from scipy.constants import c, h, k
 
+from radis.lbl.envelope import compute_gaussian_envelope, compute_lorentzian_envelope
+
 c_cm = 100 * c
 c2 = h * c_cm / k
 
@@ -10,61 +12,11 @@ def init_L_params(na, gamma_arr, verbose=False):
     if verbose >= 2:
         print("Initializing Lorentzian parameters ")
 
-    # The entire list of widths is first checked for minima, then for maxima.
-    result = []
-    for minmax in (np.min, np.max):
-
-        # Remove duplicates
-        na_gamma_arr = np.zeros((na.size, 2), dtype=np.float32)
-        na_gamma_arr[:, 0] = na
-        na_gamma_arr[:, 1] = minmax(gamma_arr, axis=0)
-
-        unique_lines = np.unique(na_gamma_arr.reshape(2 * na.size).view(np.int64))
-        unique_lines = unique_lines.view(np.float32).reshape(unique_lines.size, 2)
-
-        # Only keep extremes
-        test_dict = {}
-        for na_i, gamma_i in unique_lines:
-            try:
-                test_dict[na_i] = minmax((gamma_i, test_dict[na_i]))
-
-            except KeyError:
-                test_dict[na_i] = gamma_i
-
-        # Check which ones are really at the top:
-
-        keys = sorted(test_dict.keys(), reverse=(minmax == np.min))
-        A = [keys[0]]
-        B = [np.log(test_dict[keys[0]])]
-        X = [-np.inf]
-
-        for key in keys[1:]:
-            for i in range(len(X)):
-                xi = (np.log(test_dict[key]) - B[i]) / (A[i] - key)
-                if xi >= X[i]:
-                    if i < len(X) - 1:
-                        if xi < X[i + 1]:
-                            break
-                    else:
-                        break
-
-            while X[i] == xi:
-                i -= 1
-
-            A = A[: i + 1] + [key]
-            B = B[: i + 1] + [np.log(test_dict[key])]
-            X = X[: i + 1] + [xi]
-
-        X = X[1:] + [np.inf]
-        result.append((A, B, X))
-
-    param_data = tuple(result)
+    global _L_param_data
+    _L_param_data = compute_lorentzian_envelope(na, gamma_arr)
 
     if verbose >= 2:
         print("done!")
-
-    global _L_param_data
-    _L_param_data = param_data
 
 
 def init_G_params(log_2vMm, verbose=False):
@@ -72,13 +24,11 @@ def init_G_params(log_2vMm, verbose=False):
     if verbose >= 2:
         print("Initializing Gaussian parameters")
 
-    param_data = (np.min(log_2vMm), np.max(log_2vMm))
+    global _G_param_data
+    _G_param_data = compute_gaussian_envelope(log_2vMm)
 
     if verbose >= 2:
         print("done!")
-
-    global _G_param_data
-    _G_param_data = param_data
 
 
 def init_Q(Q_intp_list):

--- a/radis/lbl/broadening.py
+++ b/radis/lbl/broadening.py
@@ -1216,6 +1216,61 @@ class BroadenFactory(BaseFactory):
 
         self.profiler.stop("calc_hwhm", "Calculate broadening HWHM")
 
+    def _compute_broadening_envelopes(self, df=None):
+        """Compute Gaussian and Lorentzian broadening envelopes from line database.
+
+        Results are stored in ``self._gaussian_envelope`` and
+        ``self._lorentzian_envelope`` for later use in the GPU code path.
+
+        Parameters
+        ----------
+        df : DataFrame, optional
+            Line database.  Defaults to ``self.df0``, then ``self.df1``.
+        """
+        from scipy.constants import N_A, c, k
+
+        from radis.lbl.envelope import (
+            compute_gaussian_envelope,
+            compute_lorentzian_envelope,
+        )
+
+        if df is None:
+            df = getattr(self, "df0", None)
+            if df is None:
+                df = self.df1
+
+        molar_mass = self.get_molar_mass(df)
+        if hasattr(molar_mass, "values"):
+            Mm = molar_mass.values
+        else:
+            Mm = np.full(len(df), float(molar_mass))
+
+        log_2vMm = np.log(df.wav.values) + 0.5 * np.log(
+            8 * k * np.log(2) / (c**2 * Mm * 1e-3 / N_A)
+        )
+        self._gaussian_envelope = compute_gaussian_envelope(log_2vMm.astype(np.float32))
+
+        if "Tdpair" in df.columns:
+            na = df.Tdpair.values.astype(np.float32)
+        elif "n_air" in df.columns:
+            na = df.n_air.values.astype(np.float32)
+        else:
+            self._lorentzian_envelope = None
+            return
+
+        gamma_cols = []
+        if "selbrd" in df.columns:
+            gamma_cols.append(df.selbrd.values.astype(np.float32))
+        if "airbrd" in df.columns:
+            gamma_cols.append(df.airbrd.values.astype(np.float32))
+
+        if not gamma_cols:
+            self._lorentzian_envelope = None
+            return
+
+        gamma_arr = np.array(gamma_cols, dtype=np.float32)
+        self._lorentzian_envelope = compute_lorentzian_envelope(na, gamma_arr)
+
     def _calc_min_width(self, df):
         """Calculates the minimum FWHM of the lines
         and stores in self.min_width
@@ -2997,7 +3052,7 @@ class BroadenFactory(BaseFactory):
                 + " may be inverted"
             )
 
-        (wavenumber, abscoeff, emisscoeff) = self._broaden_lines_noneq(df)
+        wavenumber, abscoeff, emisscoeff = self._broaden_lines_noneq(df)
 
         self.profiler.stop("calc_line_broadening", "Calculated line broadening")
         return wavenumber, abscoeff, emisscoeff

--- a/radis/lbl/envelope.py
+++ b/radis/lbl/envelope.py
@@ -1,0 +1,160 @@
+"""
+Gaussian and Lorentzian Width Envelope Pre-computation
+======================================================
+
+Compute tight min/max bounds of Gaussian and Lorentzian half-widths
+across all spectral lines, so that LDM grid dimensions can be determined
+*before* per-line broadening widths are evaluated.
+
+Algorithms moved from :py:mod:`radis.gpu.params` so both GPU and CPU
+code paths can reuse them.
+"""
+
+import json
+
+import numpy as np
+
+#  Serialization helpers for HDF5 metadata
+
+
+def envelope_to_metadata(g_envelope, l_envelope):
+    """Serialize envelopes to a flat dict storable in HDF5 metadata.
+
+    Gaussian bounds are stored as plain floats.  Lorentzian piecewise-linear
+    segments are stored as JSON strings (arrays are not HDF5-attribute-safe).
+
+    Parameters
+    ----------
+    g_envelope : tuple (float, float)
+    l_envelope : tuple of two tuples ``((A, B, X), (A, B, X))``
+
+    Returns
+    -------
+    dict
+    """
+    meta = {
+        "envelope_g_min": g_envelope[0],
+        "envelope_g_max": g_envelope[1],
+    }
+    l_min, l_max = l_envelope
+    meta["envelope_l_min"] = json.dumps(
+        {
+            "A": l_min[0].tolist(),
+            "B": l_min[1].tolist(),
+            "X": l_min[2].tolist(),
+        }
+    )
+    meta["envelope_l_max"] = json.dumps(
+        {
+            "A": l_max[0].tolist(),
+            "B": l_max[1].tolist(),
+            "X": l_max[2].tolist(),
+        }
+    )
+    return meta
+
+
+#  Gaussian envelope
+
+
+def compute_gaussian_envelope(log_2vMm):
+    """Compute the Gaussian width envelope from per-line ``log_2vMm`` values.
+
+    Parameters
+    ----------
+    log_2vMm : array_like, shape (N_lines,)
+        ``log(v0) + 0.5 * log(8 k ln2 / (c² Mm))`` for each line.
+
+    Returns
+    -------
+    tuple (float, float)
+        ``(log_2vMm_min, log_2vMm_max)``
+    """
+    return (float(np.min(log_2vMm)), float(np.max(log_2vMm)))
+
+
+#  Lorentzian envelope
+
+
+def compute_lorentzian_envelope(na, gamma_arr):
+    """Compute piecewise-linear min/max envelopes for the Lorentzian width.
+
+    The Lorentzian half-width in log-space is a piecewise-linear function
+    of ``log(T_ref / T)`` (denoted ``log_rT`` elsewhere).  This function
+    determines the piecewise segments via a convex-hull sweep over the
+    ``(na, log(gamma))`` parameter space.
+
+    Parameters
+    ----------
+    na : array_like, shape (N_lines,)
+        Temperature-dependence exponent for each line.
+    gamma_arr : array_like, shape (N_broadeners, N_lines)
+        Broadening half-widths at reference conditions for each broadener
+        (e.g. row 0 = self-broadening, row 1 = air-broadening).
+
+    Returns
+    -------
+    tuple of two tuples
+        ``((A_min, B_min, X_min), (A_max, B_max, X_max))`` where each
+        inner tuple represents the piecewise-linear envelope segments.
+
+        * ``A`` – slopes  (the ``na`` values at each breakpoint)
+        * ``B`` – offsets  (``log(gamma)`` at each breakpoint)
+        * ``X`` – breakpoints in ``log_rT`` space (first is ``-inf``,
+          last is ``+inf``)
+
+        To evaluate at a given ``log_rT``::
+
+            # find segment i such that X[i-1] <= log_rT < X[i]
+            log_wL = log_rT * A[i] + B[i] + log(2 * p)
+    """
+    result = []
+    for minmax in (np.min, np.max):
+
+        # Combine (na, gamma) per line, taking min or max across broadeners
+        na_gamma_arr = np.zeros((na.size, 2), dtype=np.float32)
+        na_gamma_arr[:, 0] = na
+        na_gamma_arr[:, 1] = minmax(gamma_arr, axis=0)
+
+        # Deduplicate lines with identical (na, gamma) pairs
+        unique_lines = np.unique(na_gamma_arr.reshape(2 * na.size).view(np.int64))
+        unique_lines = unique_lines.view(np.float32).reshape(unique_lines.size, 2)
+
+        # For lines sharing the same na, keep only the extreme gamma
+        test_dict = {}
+        for na_i, gamma_i in unique_lines:
+            try:
+                test_dict[na_i] = minmax((gamma_i, test_dict[na_i]))
+            except KeyError:
+                test_dict[na_i] = gamma_i
+
+        # Build the piecewise-linear envelope via a convex-hull sweep
+        keys = sorted(test_dict.keys(), reverse=(minmax == np.min))
+        A = [keys[0]]
+        B = [np.log(test_dict[keys[0]])]
+        X = [-np.inf]
+
+        for key in keys[1:]:
+            if key == A[-1]:
+                # Same slope as the last segment — dominated, skip
+                continue
+            for i in range(len(X)):
+                xi = (np.log(test_dict[key]) - B[i]) / (A[i] - key)
+                if xi >= X[i]:
+                    if i < len(X) - 1:
+                        if xi < X[i + 1]:
+                            break
+                    else:
+                        break
+
+            while X[i] == xi:
+                i -= 1
+
+            A = A[: i + 1] + [key]
+            B = B[: i + 1] + [np.log(test_dict[key])]
+            X = X[: i + 1] + [xi]
+
+        X = X[1:] + [np.inf]
+        result.append((np.array(A), np.array(B), np.array(X)))
+
+    return tuple(result)

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -1198,6 +1198,9 @@ class SpectrumFactory(BandFactory):
         self.profiler.start("spectrum_calculation", 1)
         self.profiler.start("spectrum_calc_before_obj", 2)
 
+        if not hasattr(self, "_gaussian_envelope") or self._gaussian_envelope is None:
+            self._compute_broadening_envelopes()
+
         self._generate_wavenumber_arrays(checks=False)
         _Nlines_calculated = len(self.df0["wav"])
 
@@ -1250,6 +1253,8 @@ class SpectrumFactory(BandFactory):
             Q_interp_list,
             verbose=verbose,
             device_id=device_id,
+            gaussian_envelope=getattr(self, "_gaussian_envelope", None),
+            lorentzian_envelope=getattr(self, "_lorentzian_envelope", None),
         )
         if verbose >= 2:
             print("Initialization complete!")

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -43,6 +43,7 @@ to force regenerating them after a given version. See ``"OLDEST_COMPATIBLE_VERSI
 key in :py:attr:`radis.config`
 -------------------------------------------------------------------------------
 """
+
 # TODO: on use_cache functions, make a 'clean' / 'reset' option to delete / regenerate
 # cache files
 
@@ -675,7 +676,9 @@ class DatabankLoader(object):
         "_databank_kwargs",
         "_diluent",
         "_export_continuum",
+        "_gaussian_envelope",
         "_id",
+        "_lorentzian_envelope",
         "_neighbour_lines",
         "_sparse_ldm",
         "_wstep",

--- a/radis/test/lbl/test_envelope.py
+++ b/radis/test/lbl/test_envelope.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+"""
+Test :py:mod:`radis.lbl.envelope` — Gaussian and Lorentzian width envelope
+pre-computation.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+
+@pytest.mark.fast
+def test_gaussian_envelope_basic():
+    """compute_gaussian_envelope returns correct min/max."""
+    from radis.lbl.envelope import compute_gaussian_envelope
+
+    log_2vMm = np.array([-3.0, -2.5, -1.0, -2.0, -1.5], dtype=np.float32)
+    g_min, g_max = compute_gaussian_envelope(log_2vMm)
+    assert np.isclose(g_min, -3.0, atol=1e-6)
+    assert np.isclose(g_max, -1.0, atol=1e-6)
+
+
+@pytest.mark.fast
+def test_gaussian_envelope_single_line():
+    """Edge case: single line."""
+    from radis.lbl.envelope import compute_gaussian_envelope
+
+    log_2vMm = np.array([-2.0], dtype=np.float32)
+    g_min, g_max = compute_gaussian_envelope(log_2vMm)
+    assert np.isclose(g_min, -2.0, atol=1e-6)
+    assert np.isclose(g_max, -2.0, atol=1e-6)
+
+
+@pytest.mark.fast
+def test_lorentzian_envelope_single_na():
+    """When all lines have the same na, the envelope is trivial."""
+    from radis.lbl.envelope import compute_lorentzian_envelope
+
+    np.random.seed(99)
+    N = 100
+    na = np.full(N, 0.7, dtype=np.float32)
+    gamma_arr = np.random.uniform(0.01, 0.1, size=(2, N)).astype(np.float32)
+
+    envelope = compute_lorentzian_envelope(na, gamma_arr)
+    assert len(envelope) == 2  # (min_params, max_params)
+
+    for params in envelope:
+        A, B, X = params
+        assert len(A) == len(B)
+        assert len(A) == len(X)
+        assert isinstance(A, np.ndarray)
+
+
+@pytest.mark.fast
+def test_lorentzian_envelope_bounds():
+    """Envelope must bound the actual per-line Lorentzian widths."""
+    from radis.lbl.envelope import compute_lorentzian_envelope
+
+    np.random.seed(42)
+    N = 500
+    na = np.random.uniform(0.3, 0.9, size=N).astype(np.float32)
+    gamma_arr = np.random.uniform(0.01, 0.15, size=(2, N)).astype(np.float32)
+
+    envelope = compute_lorentzian_envelope(na, gamma_arr)
+
+    for T in [300, 1000, 3000, 5000]:
+        for p in [0.01, 1.0, 10.0]:
+            log_rT = np.log(296.0 / T)
+            log_2p = np.log(2 * p)
+
+            # Evaluate envelope (same logic as params.set_L_params)
+            env_vals = []
+            for params in envelope:
+                A, B, X = params
+                i = 0
+                while X[i] < log_rT:
+                    i += 1
+                env_vals.append(log_rT * A[i] + B[i] + log_2p)
+            log_wL_min_env, log_wL_max_env = env_vals
+
+            # Compute actual per-line widths
+            gamma_min = np.min(gamma_arr, axis=0)
+            gamma_max = np.max(gamma_arr, axis=0)
+            actual_min = (na * log_rT + np.log(gamma_min) + log_2p).min()
+            actual_max = (na * log_rT + np.log(gamma_max) + log_2p).max()
+
+            assert log_wL_min_env <= actual_min + 1e-4, (
+                f"Envelope min {log_wL_min_env} > actual min {actual_min} "
+                f"at T={T}, p={p}"
+            )
+            assert log_wL_max_env >= actual_max - 1e-4, (
+                f"Envelope max {log_wL_max_env} < actual max {actual_max} "
+                f"at T={T}, p={p}"
+            )
+
+
+@pytest.mark.fast
+def test_gpu_params_uses_shared_envelope():
+    """radis.gpu.params delegates to radis.lbl.envelope."""
+    import radis.gpu.params as params_mod
+    from radis.gpu.params import init_G_params, init_L_params
+    from radis.lbl.envelope import (
+        compute_gaussian_envelope,
+        compute_lorentzian_envelope,
+    )
+
+    np.random.seed(123)
+    N = 50
+    log_2vMm = np.random.uniform(-3, -1, size=N).astype(np.float32)
+    na = np.random.uniform(0.4, 0.8, size=N).astype(np.float32)
+    gamma_arr = np.random.uniform(0.02, 0.1, size=(2, N)).astype(np.float32)
+
+    g_direct = compute_gaussian_envelope(log_2vMm)
+    l_direct = compute_lorentzian_envelope(na, gamma_arr)
+
+    init_G_params(log_2vMm)
+    init_L_params(na, gamma_arr)
+
+    assert np.isclose(g_direct[0], params_mod._G_param_data[0], atol=1e-6)
+    assert np.isclose(g_direct[1], params_mod._G_param_data[1], atol=1e-6)
+
+    for i in range(2):
+        np.testing.assert_allclose(
+            l_direct[i][0], params_mod._L_param_data[i][0], atol=1e-6
+        )
+        np.testing.assert_allclose(
+            l_direct[i][1], params_mod._L_param_data[i][1], atol=1e-6
+        )
+        np.testing.assert_allclose(
+            l_direct[i][2], params_mod._L_param_data[i][2], atol=1e-6
+        )
+
+
+@pytest.mark.fast
+def test_envelope_to_metadata():
+    """envelope_to_metadata produces correct HDF5-storable dict."""
+    from radis.lbl.envelope import (
+        compute_gaussian_envelope,
+        compute_lorentzian_envelope,
+        envelope_to_metadata,
+    )
+
+    np.random.seed(77)
+    N = 80
+    log_2vMm = np.random.uniform(-3, -1, size=N).astype(np.float32)
+    na = np.random.uniform(0.3, 0.9, size=N).astype(np.float32)
+    gamma_arr = np.random.uniform(0.02, 0.12, size=(2, N)).astype(np.float32)
+
+    g_env = compute_gaussian_envelope(log_2vMm)
+    l_env = compute_lorentzian_envelope(na, gamma_arr)
+
+    meta = envelope_to_metadata(g_env, l_env)
+
+    assert np.isclose(meta["envelope_g_min"], g_env[0])
+    assert np.isclose(meta["envelope_g_max"], g_env[1])
+
+    l_min_d = json.loads(meta["envelope_l_min"])
+    np.testing.assert_allclose(l_min_d["A"], l_env[0][0].tolist(), atol=1e-6)
+    np.testing.assert_allclose(l_min_d["B"], l_env[0][1].tolist(), atol=1e-6)
+
+    l_max_d = json.loads(meta["envelope_l_max"])
+    np.testing.assert_allclose(l_max_d["A"], l_env[1][0].tolist(), atol=1e-6)
+    np.testing.assert_allclose(l_max_d["B"], l_env[1][1].tolist(), atol=1e-6)
+
+
+if __name__ == "__main__":
+    test_gaussian_envelope_basic()
+    test_gaussian_envelope_single_line()
+    test_lorentzian_envelope_single_na()
+    test_lorentzian_envelope_bounds()
+    test_gpu_params_uses_shared_envelope()
+    test_envelope_to_metadata()
+    print("All envelope tests passed!")


### PR DESCRIPTION
<!-- Please be sure to check out our developer guide,
https://radis.readthedocs.io/en/latest/dev/developer.html -->

### Description

This pull request addresses the performance bottleneck in calculating Gaussian and Lorentzian envelopes by decoupling them from the GPU logic and calculating them at the caching stage.

**Key changes:**
* **Shared Math Module:** Extracted envelope calculations into a new pure module (`radis/lbl/envelope.py`), making the logic clean, isolated, and much easier to test.
* **Smarter Caching:** Envelopes are now calculated only *once* when the database is fetched (`hitranapi.py`) and saved directly as metadata inside the main HDF5 cache. No more separate cache files!
* **Optimized GPU Loading:** The GPU initialization now checks for these pre-calculated envelopes and fetches them directly from the cache instead of recalculating them from scratch every time.
* **Bug Fixes:** Fixed a division-by-zero error (for lines with the same `na`), handled `save_memory` mode correctly, and updated `__slots__`.

Fixes #269