### PR TITLE
refactor: deprecate optically_thin parameter

### DIFF
--- a/radis/los/slabs.py
+++ b/radis/los/slabs.py
@@ -823,9 +823,9 @@ def MergeSlabs(*slabs, **kwargs) -> Spectrum:
                 )
 
         # Add the rest of the spectral quantities afterwards:
+        s.conditions["self_absorption"] = not optically_thin
         s.update(
             [k for k in requested if k not in ["emisscoeff", "abscoeff"]],
-            optically_thin=optically_thin,
             verbose=verbose,
         )
 

--- a/radis/spectrum/rescale.py
+++ b/radis/spectrum/rescale.py
@@ -538,7 +538,7 @@ def get_recompute(spec, wanted, no_change=False, true_path_length=None):
 def update(
     spec,
     quantity="all",
-    optically_thin="default",
+    optically_thin=None,
     assume_equilibrium="default",
     verbose=True,
 ):
@@ -546,8 +546,7 @@ def update(
     quantities and conditions.
 
     e.g: if `path_length` and `emisscoeff` are given, `radiance_noslit` can be recalculated
-    if `abscoeff` is also given, or without `abscoeff` in an optically thin configuration, else
-
+    if `abscoeff` is also given, or without `abscoeff` if the spectrum is optically thin.
 
     Parameters
     ----------
@@ -558,18 +557,29 @@ def update(
         be derived are recomputed. Default ``'all'``. See
         :py:data:`~radis.spectrum.utils.CONVOLUTED_QUANTITIES`
         and :py:data:`~radis.spectrum.utils.NON_CONVOLUTED_QUANTITIES`
-    optically_thin: True, False, or ``'default'``
-        determines whether to calculate radiance with or without self-absorption.
-        If ``'default'``, the value is determined from the ``'self_absorption'`` key
-        in Spectrum.conditions. If not given, ``False`` is taken. Default ``'default'``
-        Also updates the ``'self_absorption'`` key in conditions (creates it if
-        doesnt exist)
     assume_equilibrium: boolean
         if ``True``, only absorption coefficient ``abscoeff`` is recomputed
         and all values are derived from a calculation under equilibrium,
         using Kirchoff's Law. If ``default``, use the value stored in
         Spectrum conditions[``thermal_equilibrium``], else use ``False``.
+
+    Notes
+    -----
+    To compute radiance in the optically thin approximation (without
+    self-absorption), set ``spec.conditions['self_absorption'] = False``
+    before calling this method.
     """
+    import warnings
+
+    if optically_thin is not None:
+        warnings.warn(
+            "The `optically_thin` parameter is deprecated and will be removed in a future version. "
+            "To compute radiance in the optically thin approximation (without self-absorption), "
+            "set `spec.conditions['self_absorption'] = False` before calling this method.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        spec.conditions["self_absorption"] = not optically_thin
 
     # Check inputs
     # ------------
@@ -589,20 +599,9 @@ def update(
         assume_equilibrium = spec.conditions.get("thermal_equilibrium", False)
         assert assume_equilibrium in [True, False]  # prevent 'N/A' for instance
 
-    # Update optically thin
-    if optically_thin not in [True, False, "default"]:
-        raise ValueError("optically_thin must be one of True, False, 'default'")
-    if optically_thin == "default":
-        if "self_absorption" in list(spec.conditions.keys()):
-            optically_thin = not spec.conditions["self_absorption"]
-        else:
-            optically_thin = False
-    assert optically_thin in [True, False]
-    old_self_absorption = spec.conditions.get("self_absorption")
-    if old_self_absorption != (not optically_thin):
-        spec.conditions["self_absorption"] = not optically_thin
-        if verbose:
-            print(("self absorption set to:", spec.conditions["self_absorption"]))
+    # Ensure self_absorption condition exists (default: True, i.e. not optically thin)
+    if "self_absorption" not in spec.conditions:
+        spec.conditions["self_absorption"] = True
 
     initial = spec.get_vars()
 

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -1649,24 +1649,16 @@ class Spectrum(object):
             header=header,
         )
 
-    def update(self, quantity="all", optically_thin="default", verbose=True):
+    def update(self, quantity="all", optically_thin=None, verbose=True):
         r"""Calculate missing quantities: ex: if path_length and emisscoeff are
         given, recalculate radiance_noslit.
 
         Parameters
         ----------
-
-        spec: Spectrum
         quantity: str
             name of the spectral quantity to recompute. If 'same', only the quantities
             in the Spectrum are recomputed. If 'all', then all quantities that can
             be derived are recomputed. Default 'all'.
-        optically_thin: True, False, or 'default'
-            determines whether to calculate radiance with or without self absorption.
-            If 'default', the value is determined from the self_absorption key
-            in Spectrum.conditions. If not given, False is taken. Default 'default'
-            Also updates the self_absorption value in conditions (creates it if
-            doesnt exist
 
         Examples
         --------
@@ -1693,6 +1685,12 @@ class Spectrum(object):
         --------
 
         :ref:`the Spectrum page <label_spectrum>`
+
+        Notes
+        -----
+        To compute radiance in the optically thin approximation (without
+        self-absorption), set ``self.conditions['self_absorption'] = False``
+        before calling this method.
         """
 
         return update(

--- a/radis/test/spectrum/test_spectrum.py
+++ b/radis/test/spectrum/test_spectrum.py
@@ -354,7 +354,8 @@ def test_rescaling_function(verbose=True, *args, **kwargs):
         populations={"molecules": {"N2C": 1e13}},  # arbitrary
         # (just an example)
     )
-    s.update(optically_thin=True)
+    s.conditions["self_absorption"] = False
+    s.update()
     s.rescale_path_length(10)
 
     assert np.isclose(s.get_radiance_noslit(Iunit="mW/cm2/sr/nm")[0], 352.57305783248)


### PR DESCRIPTION
### Description
This pull request is to address the clean-up task for the `optically_thin` parameter while ensuring full backward compatibility for existing users in the LONG TERM TODO #53 

**Key changes:**

* **Graceful Deprecation:** The `optically_thin` parameter in `Spectrum.update()` (`spectrum.py`) and `rescale.py` now defaults to `None` and raises a `DeprecationWarning` if used. Legacy code will still run perfectly under the hood!
* **API Simplification:** Users are now guided to use the single source of truth (`conditions['self_absorption'] = False`) instead of relying on a hidden side-effect parameter.
* **Internal Updates:** Updated internal logic (like `MergeSlabs` in `slabs.py`) and test suites (`test_spectrum.py`) to natively use the condition-based approach.


Fixes #972
