### PR TITLE
perf: add copy=False to spectrum.get() in compare.py

### DIFF
--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -109,8 +109,8 @@ def get_diff(
 
     # Get data
     # ----
-    w1, I1 = s1.get(var, wunit=wunit, Iunit=Iunit, trim_nan=True)
-    w2, I2 = s2.get(var, wunit=wunit, Iunit=Iunit, trim_nan=True)
+    w1, I1 = s1.get(var, wunit=wunit, Iunit=Iunit, copy=False, trim_nan=True)
+    w2, I2 = s2.get(var, wunit=wunit, Iunit=Iunit, copy=False, trim_nan=True)
 
     if not resample:
         if not array_allclose(w1, w2):
@@ -175,8 +175,8 @@ def get_ratio(
 
     # Get data
     # ----
-    w1, I1 = s1.get(var, wunit=wunit, Iunit=Iunit)
-    w2, I2 = s2.get(var, wunit=wunit, Iunit=Iunit)
+    w1, I1 = s1.get(var, wunit=wunit, Iunit=Iunit, copy=False)
+    w2, I2 = s2.get(var, wunit=wunit, Iunit=Iunit, copy=False)
 
     if not resample:
         if not array_allclose(w1, w2):
@@ -249,8 +249,8 @@ def get_distance(
 
     # Get data
     # ----
-    w1, I1 = s1.get(var, wunit=wunit, Iunit=Iunit)
-    w2, I2 = s2.get(var, wunit=wunit, Iunit=Iunit)
+    w1, I1 = s1.get(var, wunit=wunit, Iunit=Iunit, copy=False)
+    w2, I2 = s2.get(var, wunit=wunit, Iunit=Iunit, copy=False)
 
     if not resample:
         if not array_allclose(w1, w2):
@@ -466,7 +466,7 @@ def get_residual_integral(
 
     # Get data
     # ----
-    w1, I1 = s1.get(var, wunit=wunit, Iunit=Iunit)
+    w1, I1 = s1.get(var, wunit=wunit, Iunit=Iunit, copy=False)
     wdiff, dI = get_diff(s1, s2, var, wunit=wunit, Iunit=Iunit, resample=True)
 
     # mask for 0
@@ -886,14 +886,14 @@ def plot_diff(
     # Plot compared spectra
     # ... note: if 'normalize', s1 & s2 have been edited by _get_wdiff_Idiff
     ax0.plot(
-        *s1.get(var, wunit=wunit, Iunit=Iunit),
+        *s1.get(var, wunit=wunit, Iunit=Iunit, copy=False),
         style,
         color="k",
         lw=3 * lw_multiplier,
         label=label1,
     )
     ax0.plot(
-        *s2.get(var, wunit=wunit, Iunit=Iunit),
+        *s2.get(var, wunit=wunit, Iunit=Iunit, copy=False),
         style,
         color="r",
         lw=1 * lw_multiplier,
@@ -1260,8 +1260,8 @@ def compare_spectra(
         # Compare spectral arrays
         # -----------
         for k in vars:
-            w, q = first.get(k, wunit=wunit, Iunit=first.units[k])
-            w0, q0 = other.get(k, wunit=wunit, Iunit=first.units[k])
+            w, q = first.get(k, wunit=wunit, Iunit=first.units[k], copy=False)
+            w0, q0 = other.get(k, wunit=wunit, Iunit=first.units[k], copy=False)
             if len(w) != len(w0):
                 print(
                     f"Wavespaces have different length (for {k}: {len(w)} vs {len(w0)})"
@@ -1309,8 +1309,8 @@ def compare_spectra(
         # Compare spectral variables
         # -----------
         for k in vars:
-            w, q = first.get(k, wunit=wunit, Iunit=first.units[k])
-            w0, q0 = other.get(k, wunit=wunit, Iunit=first.units[k])
+            w, q = first.get(k, wunit=wunit, Iunit=first.units[k], copy=False)
+            w0, q0 = other.get(k, wunit=wunit, Iunit=first.units[k], copy=False)
             if len(w) != len(w0):
                 print(
                     f"Wavespaces have different length (for {k}: {len(w)} vs {len(w0)})"


### PR DESCRIPTION
### Description 

This PR adds `copy=False` to read-only `.get()` calls in `radis/spectrum/compare.py` to avoid unnecessary numpy array copies during spectrum comparisons. Part of the LONG TERM TODO in #53.
Fixes #974