### PR TITLE
Fix temporary database downloads being written to working directory

### DIFF
--- a/radis/api/dbmanager.py
+++ b/radis/api/dbmanager.py
@@ -456,10 +456,11 @@ class DatabaseManager(object):
                 response.raise_for_status()  # Raise an error if request fails
 
                 # Create a temporary file to store the downloaded content
-                temp_file_path = urlname.split("/")[-1]
-                temp_file_path = re.sub(
-                    r'[<>:"/\\|?*&=]', "_", temp_file_path
+                temp_fname = urlname.split("/")[-1]
+                temp_fname = re.sub(
+                    r'[<>:"/\\|?*&=]', "_", temp_fname
                 )  # Sanitize the filename to remove invalid characters for Windows
+                temp_file_path = join(self.tempdir, temp_fname)
 
                 # Get total file size for progress bar
                 total_size = int(response.headers.get("content-length", 0))


### PR DESCRIPTION
Temporary downloads were written to the current working directory because only the filename was used when constructing the temporary file path in DatabaseManager.download_and_parse(). This change saves temporary downloads in the existing downloads__can_be_deleted directory inside the local RADIS database folder.

Fixes #976