### PR TITLE
Add warning for out-of-range wavenumber requests

### DIFF
--- a/radis/api/hdf5.py
+++ b/radis/api/hdf5.py
@@ -6,6 +6,7 @@ Defines the :py:class:`~radis.api.hdf5.DataFileManager` class
 import os
 import pathlib
 import sys
+import warnings
 from os.path import abspath, exists, expanduser, splitext
 from time import time
 
@@ -915,6 +916,24 @@ def hdf2df(
 
     # Read and add metadata in the DataFrame
     metadata = manager.read_metadata(fname)
+
+    # warning when requested wavenumber range lies outside DB metadata
+    md = metadata[0] if isinstance(metadata, list) and len(metadata) > 0 else metadata
+    if isinstance(md, dict):
+        db_min = md.get("wavenumber_min") or None
+        db_max = md.get("wavenumber_max") or None
+
+        req_min = load_wavenum_min
+        req_max = load_wavenum_max
+
+        if db_min is not None and db_max is not None:
+            if (req_min is not None and req_min < db_min) or (
+                req_max is not None and req_max > db_max
+            ):
+                warnings.warn(
+                    f"Requested range [{req_min}, {req_max}] outside database range [{db_min}, {db_max}]",
+                    UserWarning,
+                )
 
     # Sanity Checks if loading the full file
     selection = isotope or load_wavenum_min or load_wavenum_max

--- a/radis/api/hdf5.py
+++ b/radis/api/hdf5.py
@@ -920,8 +920,8 @@ def hdf2df(
     # warning when requested wavenumber range lies outside DB metadata
     md = metadata[0] if isinstance(metadata, list) and len(metadata) > 0 else metadata
     if isinstance(md, dict):
-        db_min = md.get("wavenumber_min") or None
-        db_max = md.get("wavenumber_max") or None
+        db_min = md.get("wavenumber_min", None)
+        db_max = md.get("wavenumber_max", None)
 
         req_min = load_wavenum_min
         req_max = load_wavenum_max
@@ -933,6 +933,7 @@ def hdf2df(
                 warnings.warn(
                     f"Requested range [{req_min}, {req_max}] outside database range [{db_min}, {db_max}]",
                     UserWarning,
+                    stacklevel=2,
                 )
 
     # Sanity Checks if loading the full file


### PR DESCRIPTION
Adds a warning in hdf2df when the requested wavenumber range is outside the database range.
Uses existing metadata and skips cases where range is unavailable.

Implements : add Warning if using a line database outside its min/max range ( #53 )