### PR TITLE
fix: Spectrum.plot(wunit='nm') respects medium for correct wavelength range

### DIFF
--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -3963,6 +3963,8 @@ def get_wavenumber_range(
         If unitless, wunit is assumed as the accompanying unit.
     wunit: string
         The unit accompanying wmin and wmax. Cannot be passed without passing values for wmin and wmax.
+        Accepted values: ``'cm-1'``, ``'nm'``, ``'nm_air'``, ``'nm_vac'``.
+        ``'nm_air'`` and ``'nm_vac'`` override the ``medium`` parameter.
         Default: cm-1
     wavenum_min, wavenum_max: float, or `~astropy.units.quantity.Quantity` or ``None``
         wavenumbers
@@ -4005,6 +4007,15 @@ def get_wavenumber_range(
             "or `wavelength_min=..., wavelength_max=...` (in nm)"
             "We recommend to use units. Example: \n\n  import astropy.units as u\n  calc_spectrum(wmin=2000 / u.cm, wmax=2300 / u.cm, ..."
         )
+
+    # Allow medium-specific wavelength units
+    if not isinstance(wunit, Default) and isinstance(wunit, str):
+        if wunit in ["nm_vac", "nm_vacuum"]:
+            medium = "vacuum"
+            wunit = "nm"
+        elif wunit in ["nm_air"]:
+            medium = "air"
+            wunit = "nm"
 
     if not isinstance(wunit, Default):
         if not u.Unit(wunit).is_equivalent(u.m) and not u.Unit(wunit).is_equivalent(

--- a/radis/lbl/calc.py
+++ b/radis/lbl/calc.py
@@ -93,8 +93,11 @@ def calc_spectrum(
 
             import astropy.units as u
             calc_spectrum(2.5*u.um, 3.0*u.um, ...)
-    wunit: ``'nm'``, ``'cm-1'``
-        unit for ``wmin`` and ``wmax``. Default is ``"cm-1"``.
+    wunit: ``'nm'``, ``'cm-1'``, ``'nm_air'``, ``'nm_vac'``
+        unit for ``wmin`` and ``wmax``. ``'nm'`` uses the ``medium`` parameter
+        to determine air or vacuum conversion. ``'nm_air'`` and ``'nm_vac'``
+        are explicit and override the ``medium`` parameter.
+        Default is ``"cm-1"``.
     Tgas: float [:math:`K`]
         Gas temperature. If non equilibrium, is used for :math:`T_{translational}`.
         Default ``300`` K​

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -616,6 +616,7 @@ class SpectrumFactory(BandFactory):
         )
         self.input.self_absorption = self_absorption
         self.input.potential_lowering = potential_lowering
+        self.input.medium = medium
         self.input.pfsource = pfsource
 
         # Initialize computation variables

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -1291,11 +1291,16 @@ class Spectrum(object):
                 wunit = self.c["default_output_unit"]
             else:
                 wunit = self.get_waveunit()
+        # Handle explicit nm_air before cast_waveunit collapses it to "nm"
+        force_air = wunit in ("nm_air",)
         wunit = cast_waveunit(wunit)
         if wunit == "cm-1":
             w = self.get_wavenumber(copy=copy)
         elif wunit == "nm":
-            medium = self.conditions.get("medium", "air")
+            if force_air:
+                medium = "air"
+            else:
+                medium = self.conditions.get("medium", "air")
             w = self.get_wavelength(medium=medium, copy=copy)
         elif wunit == "nm_vac":
             w = self.get_wavelength(medium="vacuum", copy=copy)

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -1295,7 +1295,8 @@ class Spectrum(object):
         if wunit == "cm-1":
             w = self.get_wavenumber(copy=copy)
         elif wunit == "nm":
-            w = self.get_wavelength(medium="air", copy=copy)
+            medium = self.conditions.get("medium", "air")
+            w = self.get_wavelength(medium=medium, copy=copy)
         elif wunit == "nm_vac":
             w = self.get_wavelength(medium="vacuum", copy=copy)
         else:
@@ -2298,26 +2299,35 @@ class Spectrum(object):
             ax.legend()
         fix_style()
 
-        from radis.phys.convert import cm2nm, div_safe, nm2cm
+        from radis.phys.convert import cm2nm, cm2nm_air, div_safe, nm2cm, nm_air2cm
 
         if ax.child_axes != []:
             pass
-        elif "cm⁻¹" in ylabel:
+        elif wunit == "cm-1":
             secx = ax.secondary_xaxis(
                 "top", functions=(div_safe(cm2nm), div_safe(nm2cm))
             )
             secx.set_xlabel("Wavelength (nm)")
-        elif "nm" in ylabel:
-            if wunit == "nm" or wunit == "nm_air":
+        elif wunit == "nm":
+            medium = self.conditions.get("medium", "air")
+            if medium == "vacuum":
                 secx = ax.secondary_xaxis(
                     "top", functions=(div_safe(nm2cm), div_safe(cm2nm))
                 )
             else:
-                from radis.phys.convert import cm2nm_air, nm_air2cm
-
                 secx = ax.secondary_xaxis(
                     "top", functions=(div_safe(nm_air2cm), div_safe(cm2nm_air))
                 )
+            secx.set_xlabel("wavenumber (cm⁻¹)")
+        elif wunit == "nm_air":
+            secx = ax.secondary_xaxis(
+                "top", functions=(div_safe(nm_air2cm), div_safe(cm2nm_air))
+            )
+            secx.set_xlabel("wavenumber (cm⁻¹)")
+        elif wunit == "nm_vac":
+            secx = ax.secondary_xaxis(
+                "top", functions=(div_safe(nm2cm), div_safe(cm2nm))
+            )
             secx.set_xlabel("wavenumber (cm⁻¹)")
 
         # Add plotting tools

--- a/radis/test/lbl/test_calc.py
+++ b/radis/test/lbl/test_calc.py
@@ -176,27 +176,31 @@ def test_calc_spectrum(verbose=True, plot=False, warnings=True, *args, **kwargs)
     # Update on 14/11/21: after switching from HITRAN fetched by astroquery (partial range)
     # to HITRAN fetched by HAPI (full database) > atol=1e-6 fails, because of
     # numerical errors in how the two databases are stored. Switched to rtol=1e-3
+    # Update after PR #982 (issue #707): Spectrum.plot/get(wunit='nm') now
+    # respects the medium from conditions. Since this spectrum is calculated
+    # with medium='vacuum', get(wunit='nm') now returns vacuum wavelengths
+    # (previously it always returned air wavelengths).
     w_ref = np.array(
         [
-            4197.60321744,
-            4195.84148905,
-            4194.08123884,
-            4192.32246493,
-            4190.56516548,
-            4188.80933862,
-            4187.05498252,
-            4185.30209532,
-            4183.55067518,
-            4181.80072025,
-            4180.05222871,
-            4178.30519870,
-            4176.55962842,
-            4174.81551601,
-            4173.07285967,
-            4171.33165756,
-            4169.59190786,
-            4167.85360877,
-            4166.11675846,
+            4198.74793337,
+            4196.98572485,
+            4195.22499491,
+            4193.46574168,
+            4191.70796331,
+            4189.95165793,
+            4188.19682371,
+            4186.44345879,
+            4184.69156133,
+            4182.94112949,
+            4181.19216142,
+            4179.44465530,
+            4177.69860928,
+            4175.95402155,
+            4174.21089028,
+            4172.46921363,
+            4170.72898980,
+            4168.99021697,
+            4167.25289331,
         ]
     )
 

--- a/radis/test/lbl/test_factory.py
+++ b/radis/test/lbl/test_factory.py
@@ -379,7 +379,7 @@ def test_media_line_shift(plot=False, verbose=True, warnings=True, *args, **kwar
         plt.title("CO spectrum (2000 K)")
         s.plot(
             "radiance_noslit",
-            wunit="nm",
+            wunit="nm_air",
             nfig=fig.number,
             lw=2,
             color="r",
@@ -389,7 +389,7 @@ def test_media_line_shift(plot=False, verbose=True, warnings=True, *args, **kwar
     # ... there should be about ~1.25 nm shift at 4.5 µm:
     assert np.isclose(
         s.get("radiance_noslit", wunit="nm_vac")[0][0]
-        - s.get("radiance_noslit", wunit="nm")[0][0],
+        - s.get("radiance_noslit", wunit="nm_air")[0][0],
         1.2540436086346745,
     )
 

--- a/radis/test/lbl/test_spec.py
+++ b/radis/test/lbl/test_spec.py
@@ -262,6 +262,86 @@ def test_medium(plot=False, verbose=True, debug=False, warnings=True, *args, **k
     assert all(s.get_wavelength(medium="vacuum") > s.get_wavelength(medium="air"))
 
 
+@pytest.mark.fast
+def test_plot_wunit_nm_medium_consistency(verbose=True, *args, **kwargs):
+    """Test that plot(wunit='nm') respects the medium from calculation
+    and that get_wavenumber_range accepts 'nm_vac'/'nm_air'.
+
+    Regression test for https://github.com/radis/radis/issues/707
+    """
+    from radis import Spectrum
+    from radis.lbl.base import get_wavenumber_range
+
+    # --- Test 1: get_wavenumber_range accepts 'nm_vac' and 'nm_air' ---
+    wmin_nm = 3403.0
+    wmax_nm = 3405.0
+
+    wn_min_vac, wn_max_vac = get_wavenumber_range(
+        wmin=wmin_nm, wmax=wmax_nm, wunit="nm_vac"
+    )
+    wn_min_vac2, wn_max_vac2 = get_wavenumber_range(
+        wmin=wmin_nm, wmax=wmax_nm, wunit="nm", medium="vacuum"
+    )
+    assert np.isclose(wn_min_vac, wn_min_vac2)
+    assert np.isclose(wn_max_vac, wn_max_vac2)
+
+    wn_min_air, wn_max_air = get_wavenumber_range(
+        wmin=wmin_nm, wmax=wmax_nm, wunit="nm_air"
+    )
+    wn_min_air2, wn_max_air2 = get_wavenumber_range(
+        wmin=wmin_nm, wmax=wmax_nm, wunit="nm", medium="air"
+    )
+    assert np.isclose(wn_min_air, wn_min_air2)
+    assert np.isclose(wn_max_air, wn_max_air2)
+
+    assert not np.isclose(
+        wn_min_vac, wn_min_air
+    ), "nm_vac and nm_air should produce different wavenumber conversions"
+
+    # --- Test 2: get(wunit='nm') respects medium from conditions ---
+    w_cm = np.linspace(2937.0, 2938.0, 100)
+    I = np.random.uniform(0.8, 1.0, len(w_cm))
+
+    s_vac = Spectrum.from_array(
+        w_cm,
+        I,
+        "transmittance_noslit",
+        wunit="cm-1",
+        Iunit="",
+        conditions={"medium": "vacuum"},
+    )
+    s_air = Spectrum.from_array(
+        w_cm,
+        I,
+        "transmittance_noslit",
+        wunit="cm-1",
+        Iunit="",
+        conditions={"medium": "air"},
+    )
+
+    w_nm_from_vac, _ = s_vac.get("transmittance_noslit", wunit="nm")
+    w_nm_from_air, _ = s_air.get("transmittance_noslit", wunit="nm")
+    w_nm_vac_explicit, _ = s_vac.get("transmittance_noslit", wunit="nm_vac")
+
+    # wunit='nm' on a vacuum spectrum should return vacuum wavelengths
+    assert np.allclose(
+        w_nm_from_vac, w_nm_vac_explicit
+    ), "get(wunit='nm') on a vacuum spectrum should return vacuum wavelengths"
+
+    # wunit='nm' on air vs vacuum spectrum should give different values
+    assert not np.allclose(
+        w_nm_from_vac, w_nm_from_air
+    ), "get(wunit='nm') should give different results for air vs vacuum spectra"
+
+    # Vacuum wavelengths > air wavelengths
+    assert all(
+        w_nm_from_vac > w_nm_from_air
+    ), "Vacuum wavelengths should be larger than air wavelengths"
+
+    if verbose:
+        printm("test_plot_wunit_nm_medium_consistency: OK")
+
+
 def _run_testcases(
     plot=False, verbose=True, debug=False, warnings=True, *args, **kwargs
 ):

--- a/radis/tools/database.py
+++ b/radis/tools/database.py
@@ -661,25 +661,20 @@ def _fix_format(file, sload):
                 f"Spectrum 'conditions' dict should at least have a 'waveunit' key. Got: {list(sload['conditions'].keys())}"
             ) from err
 
-    # propagation medium removed in 0.9.22, replaced with 'nm' and 'nm_vac' in
-    # waveunit directly
-    if "medium" in sload["conditions"]:
+    # propagation medium was removed in 0.9.22 (replaced with 'nm' and 'nm_vac'
+    # in waveunit) but reintroduced in PR #982 (issue #707) as a computation
+    # medium stored in conditions. Only treat as the pre-0.9.22 deprecated
+    # structure when waveunit == 'nm' (old files encoded the medium there).
+    if "medium" in sload["conditions"] and sload["conditions"].get("waveunit") == "nm":
         printr(
             f"File {basename(file)} has a deprecated structure (key medium removed in 0.9.22). Fixing this time, but regenerate database ASAP."
         )  # , DeprecationWarning)
-        # Fix: rewrite waveunit
-        assert "waveunit" in sload["conditions"]
-        if sload["conditions"]["waveunit"] == "cm-1":
-            pass  # does not change anything, no need to report
-        else:  # wavelength is in air or vacuum.
-            assert sload["conditions"]["waveunit"] == "nm"
-            if sload["conditions"]["medium"] == "air":
-                sload["conditions"]["waveunit"] = "nm"
-            elif sload["conditions"]["medium"] == "vacuum":
-                sload["conditions"]["waveunit"] = "nm_vac"
-            else:
-                raise ValueError(sload["conditions"]["medium"])
-        # fix: delete medium key
+        if sload["conditions"]["medium"] == "air":
+            sload["conditions"]["waveunit"] = "nm"
+        elif sload["conditions"]["medium"] == "vacuum":
+            sload["conditions"]["waveunit"] = "nm_vac"
+        else:
+            raise ValueError(sload["conditions"]["medium"])
         del sload["conditions"]["medium"]
         fixed = True
 


### PR DESCRIPTION


### Description
<!-- Provide a general description of what your pull request does. -->

The issue was that `medium` wasn’t stored in `SpectrumFactory.input`, so it never reached `Spectrum.conditions`. As a result, `get(wunit='nm')` always assumed `"air"`, leading to incorrect conversions and plot axes.

This PR fixes it by propagating `medium` correctly and using it in conversions. It:

* Stores `medium` in `SpectrumFactory.input`
* Uses `conditions["medium"]` in `get(wunit='nm')`
* Applies correct air/vacuum conversions in plots
* Adds support for `'nm_vac'` and `'nm_air'`

Also added a regression test and verified across cm⁻¹, nm (air), nm (vacuum), and `nm_vac`.

Fixes #707

<img width="695" height="288" alt="image" src="https://github.com/user-attachments/assets/7a07f40e-0adf-4783-8034-70f49dd99c8c" />