### PR TITLE
Move profiler out of conditions

### DIFF
--- a/docs/lbl/lbl.rst
+++ b/docs/lbl/lbl.rst
@@ -729,7 +729,7 @@ calculation steps at runtime. Example with ``verbose=3``::
                       verbose=3,
                       )
 
-Performance profiles are kept in the output spectrum ``conditions['profiler']`` dictionary.
+Performance profiles are kept in the output spectrum ``Spectrum.profiler`` dictionary.
 You can also use the :py:meth:`~radis.lbl.factory.SpectrumFactory.print_perf_profile`
 method in the SpectrumFactory object or the :py:meth:`~radis.spectrum.spectrum.Spectrum.print_perf_profile`
 method in the Spectrum object to print them in the console :

--- a/radis/lbl/factory.py
+++ b/radis/lbl/factory.py
@@ -953,7 +953,6 @@ class SpectrumFactory(BandFactory):
                 "diluents": self._diluent,
                 "radis_version": version,
                 "spectral_points": len(self.wavenumber),
-                "profiler": dict(self.profiler.final),
             }
         )
         if self.params.optimization != None:
@@ -1002,6 +1001,7 @@ class SpectrumFactory(BandFactory):
             name=name,
             references=dict(self.reftracker),
         )
+        s.profiler = dict(self.profiler.final)
         # OPTION 2.  Change a posteriori using a Spectrum.method. More universal. Can it be slower?
 
         # update database if asked so
@@ -1329,7 +1329,6 @@ class SpectrumFactory(BandFactory):
                 "gpu_backend": backend,
                 "spectral_points": len(self.wavenumber),
                 "add_at_used": "gpu-backend",
-                "profiler": dict(self.profiler.final),
                 "NwL": iter_N_L,
                 "NwG": iter_N_G,
             }
@@ -1862,7 +1861,6 @@ class SpectrumFactory(BandFactory):
                 "diluents": self._diluent,
                 "radis_version": version,
                 "spectral_points": len(self.wavenumber),
-                "profiler": dict(self.profiler.final),
             }
         )
         if self.params.optimization != None:
@@ -1914,6 +1912,7 @@ class SpectrumFactory(BandFactory):
             name=name,
             references=dict(self.reftracker),
         )
+        s.profiler = dict(self.profiler.final)
 
         # update database if asked so
         if self.autoupdatedatabase:

--- a/radis/spectrum/spectrum.py
+++ b/radis/spectrum/spectrum.py
@@ -356,6 +356,7 @@ class Spectrum(object):
         "name",
         "_slit",
         "file",
+        "profiler",
     ]
 
     def __init__(
@@ -557,6 +558,7 @@ class Spectrum(object):
         self.cond_units = cond_units
         self.name = name
         self.file = None  # used to store filename when loaded from a file
+        self.profiler = None
 
         # Add references
         self.references = RefTracker(**references)
@@ -5966,7 +5968,10 @@ class Spectrum(object):
 
         from radis.spectrum.utils import print_perf_profile
 
-        profiler = self.conditions["profiler"]
+        profiler = getattr(self, "profiler", None)
+        if profiler is None:
+            warn("No profiler attached to this Spectrum instance.")
+            return None
         total_time = profiler["spectrum_calculation"]["value"]
 
         return print_perf_profile(
@@ -5981,7 +5986,7 @@ class Spectrum(object):
         r"""Generate a visual/interactive performance profile diagram using ``tuna``
 
         .. note::
-            requires a `profiler` key with in Spectrum.conditions
+            requires a profiler attached to ``Spectrum.profiler``
 
         .. warning::
             deprecated in favor of :py:meth:`~radis.spectrum.spectrum.Spectrum.print_perf_profile`
@@ -6013,9 +6018,13 @@ class Spectrum(object):
         """
         from radis.spectrum.utils import generate_perf_profile
 
-        profiler = self.conditions["profiler"]["spectrum_calculation"].copy()
+        profiler_all = getattr(self, "profiler", None)
+        if profiler_all is None:
+            warn("No profiler attached to this Spectrum instance.")
+            return None
+        profiler = profiler_all.get("spectrum_calculation", {}).copy()
         # Add total calculation time:
-        profiler.update({"value": self.conditions["calculation_time"]})
+        profiler.update({"value": self.conditions.get("calculation_time")})
 
         return generate_perf_profile(profiler)
 

--- a/radis/tools/fitting.py
+++ b/radis/tools/fitting.py
@@ -228,7 +228,7 @@ def fit_legacy(
     s0 = compute_los_model(fit_parameters)  # New run to get performance profile of fit
     sys.stderr.flush()
     s0.name = "Fit (in progress)"
-    if "profiler" in s0.conditions and verbose > 0:
+    if getattr(s0, "profiler", None) is not None and verbose > 0:
         print("-" * 30)
         print("TYPICAL FIT CALCULATION TIME:")
         s0.print_perf_profile()


### PR DESCRIPTION
- Move profiler out of Spectrum.conditions into a standalone Spectrum.profiler attribute.
- Update factories and accessors to use it.

Fixes : move profiler as a standalone dictionary outside of Spectrum.conditions ( #53 )
