### PR TITLE
Compatibility with Python 3.13 + install vaex-hdf5 from pip

### DIFF
--- a/.github/workflows/tests-develop.yml
+++ b/.github/workflows/tests-develop.yml
@@ -16,20 +16,18 @@ jobs:
       max-parallel: 3
       matrix:
         include:
-          # - os: ubuntu-latest
-          #   python-version: "3.14"
-          #   continue-on-error: true #this is allowed to fail, as some dependencies may not yet be available
+          # Try only the oldest and latest supported versions of Python on develop, to speed up the tests. We test more versions on master (see python-package-master.yml)
           - os: ubuntu-latest
             python-version: "3.10"
-          - os: ubuntu-latest
-            python-version: "3.11"
           - os: ubuntu-latest
             python-version: "3.12"
-          #Issue with Windows and Mac OS, see https://github.com/radis/radis/issues/864
+          - os: ubuntu-latest
+            python-version: "3.13" #added to test the behavior without vaex (compatible up to 3.12)
+          #For windows and macOS, we test only the Python 3.12, to speed up the tests.
           - os: windows-latest
-            python-version: "3.10"
+            python-version: "3.12"
           - os: macos-latest
-            python-version: "3.10"
+            python-version: "3.12"
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/tests-master.yml
+++ b/.github/workflows/tests-master.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       fail-fast: false
-      max-parallel: 3
+      max-parallel: 5
       matrix:
         include:
           - os: ubuntu-latest
@@ -24,7 +24,6 @@ jobs:
             python-version: "3.12"
           - os: ubuntu-latest
             python-version: "3.13"
-          #Issue with Windows and Mac OS, see https://github.com/radis/radis/issues/864
           - os: windows-latest
             python-version: "3.10"
           - os: windows-latest
@@ -37,6 +36,9 @@ jobs:
             python-version: "3.11"
           - os: macos-latest
             python-version: "3.12"
+          - os: ubuntu-latest
+            python-version: "3.14"
+            continue-on-error: true #this is allowed to fail, as some dependencies may not yet be available
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
 - joblib  # for parallel loading of SpecDatabase
 - lmfit  # for new fitting modules
 - matplotlib
-- numpy~=2.0  # Warning: numpy 2.0 is not compatible with vaex-hdf5<=0.14.1, see #869. We directly install the latest vaex-hdf5 via pip below as a workaround.
+- numpy~=2.0
 - numba  # just-in-time compiler
 - pandas
 - plotly>=2.5.1  # for line survey HTML output
@@ -50,8 +50,8 @@ dependencies:
   - ruamel.yaml
   - toml
   - tqdm
-  - vaex-core; python_version < '3.13' #latest version 4.19 is not on conda-forge yet and install not compatible with python 3.13
-  - git+https://github.com/vaexio/vaex.git#subdirectory=packages/vaex-hdf5; python_version < '3.13' #vaex-hdf5 latest version
+  - vaex-core; python_version < '3.13' #latest version 4.19 is not on conda-forge yet
+  - vaex-hdf5; python_version < '3.13' #latest version 4.19 is not on conda-forge yet
   - vaex-viz; python_version < '3.13'
   - vulkan
 

--- a/examples/2_Experimental_spectra/plot_chain_spectrum_edition.py
+++ b/examples/2_Experimental_spectra/plot_chain_spectrum_edition.py
@@ -114,7 +114,7 @@ import numpy as np
 
 print("Absorbance of original line : ", s.get_integral("absorbance"))
 print(
-    "Absorbance of fitted line   :", np.trapz(y_fit, w_fit)
+    "Absorbance of fitted line   :", np.trapezoid(y_fit, w_fit)
 )  # negative because w_fit in descending order
 #
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ dependencies = [
     "tqdm",  # for progress bars
     "numpy~=2.0", #Warning, numpy 2.0 is not compatible with vaex-hdf5<=0.14.1, but we install vaex-hdf5 from the github repo see #869 and https://github.com/vaexio/vaex/issues/2468
     'vaex-core; python_version < "3.13"',
-    'vaex-hdf5 @ git+https://github.com/vaexio/vaex.git#subdirectory=packages/vaex-hdf5 ; python_version < "3.13"',  # vaex-hdf5 latest version
+    'vaex-hdf5; python_version < "3.13"',  # vaex-hdf5 latest version
     'vaex-viz; python_version < "3.13"',
     "vulkan",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,8 @@ dependencies = [
     "toml",
     "tqdm",  # for progress bars
     "numpy~=2.0", #Warning, numpy 2.0 is not compatible with vaex-hdf5<=0.14.1, but we install vaex-hdf5 from the github repo see #869 and https://github.com/vaexio/vaex/issues/2468
-    'vaex-core; python_version < "3.13"',
-    'vaex-hdf5; python_version < "3.13"',  # vaex-hdf5 latest version
+    'vaex-core; python_version < "3.13"', #to-do, check latest release of vaex (last compatible with 3.12 in january 2026)
+    'vaex-hdf5; python_version < "3.13"',
     'vaex-viz; python_version < "3.13"',
     "vulkan",
 ]

--- a/radis/api/hdf5.py
+++ b/radis/api/hdf5.py
@@ -186,7 +186,14 @@ class DataFileManager(object):
         elif self.engine == "pytables-fixed":
             assert not append
             # export dataframe
-            df.to_hdf(file, key, format="fixed", mode="w", complevel=9, complib="blosc")
+            df.to_hdf(
+                path_or_buf=file,
+                key=key,
+                format="fixed",
+                mode="w",
+                complevel=9,
+                complib="blosc",
+            )
         elif self.engine == "vaex":
             if isinstance(df, pd.DataFrame):
                 df = vaex.from_pandas(df)

--- a/radis/api/hitranapi.py
+++ b/radis/api/hitranapi.py
@@ -1992,9 +1992,31 @@ class HITRANDatabaseManager(DatabaseManager):
 
         # Use HAPI only to download the files, then we'll parse them with RADIS's
         # parsers, and convert to RADIS's fast HDF5 file formats.
-        isotope_list, data_file_list, header_file_list = download_all_hitran_isotopes(
-            molecule, tempdir, extra_params
-        )
+
+        max_retries = 2
+        retry_count = 0
+
+        while retry_count < max_retries:
+            try:
+                (
+                    isotope_list,
+                    data_file_list,
+                    header_file_list,
+                ) = download_all_hitran_isotopes(molecule, tempdir, extra_params)
+                break  # Success, exit retry loop
+            except ValueError as e:
+                if "invalid literal for int() with base 10: '\\x00\\x00'" in str(e):
+                    retry_count += 1
+                    if retry_count < max_retries:
+                        warnings.warn(
+                            f"ValueError encountered during download. Retrying (attempt {retry_count}/{max_retries})...",
+                            UserWarning,
+                            stacklevel=2,
+                        )
+                    else:
+                        raise  # Re-raise on final attempt
+                else:
+                    raise  # Re-raise if it's a different ValueError
 
         writer = self.get_datafile_manager()
 

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -700,10 +700,15 @@ class BaseFactory(DatabankLoader):
             # only keep vibrational energies
             # see text for how we define vibrational energy
             index = ["p", "c", "N"]
-            # energies = energies.drop_duplicates(index, inplace=False) #fails in Python 3.13
-            energies = energies.reset_index().drop_duplicates(
-                subset=index, inplace=False
-            )
+
+            import sys
+
+            if sys.version_info < (3, 13):
+                energies = energies.drop_duplicates(index, inplace=False)
+            else:
+                energies = energies.reset_index().drop_duplicates(
+                    subset=index, inplace=False
+                )
             # (work on a copy)
 
             # reindexing to get a direct access to level database (instead of using df.v1==v1 syntax)

--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -700,7 +700,10 @@ class BaseFactory(DatabankLoader):
             # only keep vibrational energies
             # see text for how we define vibrational energy
             index = ["p", "c", "N"]
-            energies = energies.drop_duplicates(index, inplace=False)
+            # energies = energies.drop_duplicates(index, inplace=False) #fails in Python 3.13
+            energies = energies.reset_index().drop_duplicates(
+                subset=index, inplace=False
+            )
             # (work on a copy)
 
             # reindexing to get a direct access to level database (instead of using df.v1==v1 syntax)

--- a/radis/lbl/overp.py
+++ b/radis/lbl/overp.py
@@ -240,8 +240,8 @@ class LevelsList(object):
         else:
             raise NotImplementedError(levelsfmt)
 
-        vib_levels = df.drop_duplicates(subset=vib_index)  # 192 ms ± 1.13 ms
-
+        # vib_levels = df.drop_duplicates(subset=vib_index)  # fails in Python 3.13. Old comment: 192 ms ± 1.13 ms
+        vib_levels = df.reset_index().drop_duplicates(subset=vib_index)
         # Add levels
         def add_viblvl(row):
             """ """

--- a/radis/lbl/overp.py
+++ b/radis/lbl/overp.py
@@ -240,8 +240,14 @@ class LevelsList(object):
         else:
             raise NotImplementedError(levelsfmt)
 
-        # vib_levels = df.drop_duplicates(subset=vib_index)  # fails in Python 3.13. Old comment: 192 ms ± 1.13 ms
-        vib_levels = df.reset_index().drop_duplicates(subset=vib_index)
+        import sys
+
+        if sys.version_info < (3, 13):
+            vib_levels = df.drop_duplicates(
+                subset=vib_index
+            )  # fails in Python 3.13. Old comment: 192 ms ± 1.13 ms
+        else:
+            vib_levels = df.reset_index().drop_duplicates(subset=vib_index)
         # Add levels
         def add_viblvl(row):
             """ """

--- a/radis/levels/partfunc_cdsd.py
+++ b/radis/levels/partfunc_cdsd.py
@@ -262,7 +262,7 @@ class PartFuncCO2_CDSDcalc(RovibParFuncCalculator):
         self.levelsfmt = levelsfmt
         self.viblvl_label = viblvl_label
         cdsd_fragment_path = join(
-            "radis", "test", "files", "co2_cdsd_hamiltonian_fragment.levels"
+            radis.__path__[0], "test", "files", "co2_cdsd_hamiltonian_fragment.levels"
         )
         self.last_modification = time.ctime(getmtime(cdsd_fragment_path))
         if verbose >= 2:

--- a/radis/test/lbl/test_broadening.py
+++ b/radis/test/lbl/test_broadening.py
@@ -181,21 +181,21 @@ def test_broadening_methods_different_conditions(
         s_voigt = sf.eq_spectrum(Tgas=T, name="direct")
 
         # assert broadening FWHM are correct
-        assert isclose(2 * float(sf.df1.hwhm_gauss), fwhm_gauss)
-        assert isclose(2 * float(sf.df1.hwhm_lorentz), fwhm_lorentz)
+        assert isclose(2 * sf.df1.hwhm_gauss[0], fwhm_gauss)
+        assert isclose(2 * sf.df1.hwhm_lorentz[0], fwhm_lorentz)
 
         sf.params.broadening_method = "convolve"
         s_convolve = sf.eq_spectrum(Tgas=T, name="convolve")
 
         # assert broadening FWHM are correct
-        assert isclose(2 * float(sf.df1.hwhm_gauss), fwhm_gauss)
-        assert isclose(2 * float(sf.df1.hwhm_lorentz), fwhm_lorentz)
+        assert isclose(2 * sf.df1.hwhm_gauss[0], fwhm_gauss)
+        assert isclose(2 * sf.df1.hwhm_lorentz[0], fwhm_lorentz)
 
         res = get_residual(s_voigt, s_convolve, "abscoeff")
 
         if verbose:
             print(
-                f"{T} K, {p} bar: FWHM lorentz = {2 * float(sf.df1.hwhm_lorentz):.3f} cm-1, FWHM gauss = {2 * float(sf.df1.hwhm_gauss):.3f} cm-1"
+                f"{T} K, {p} bar: FWHM lorentz = {2 * sf.df1.hwhm_lorentz[0]:.3f} cm-1, FWHM gauss = {2 * sf.df1.hwhm_gauss[0]:.3f} cm-1"
             )
 
         if plot:
@@ -1133,6 +1133,6 @@ def _run_testcases(plot=False, verbose=True, *args, **kwargs):
 
 
 if __name__ == "__main__":
-
-    printm("test_broadening: ", _run_testcases(plot=True, verbose=True, debug=False))
-    printm("Testing broadening:", pytest.main(["test_broadening.py", "--pdb"]))
+    test_broadening_methods_different_conditions()
+    # printm("test_broadening: ", _run_testcases(plot=True, verbose=True, debug=False))
+    # printm("Testing broadening:", pytest.main(["test_broadening.py", "--pdb"]))

--- a/radis/test/lbl/test_calc.py
+++ b/radis/test/lbl/test_calc.py
@@ -1015,5 +1015,5 @@ def _run_testcases(plot=True, verbose=True, warnings=True, *args, **kwargs):
 
 # --------------------------
 if __name__ == "__main__":
-    test_non_air_diluent_calc()
+    test_all_calc_methods_CO2pcN()
     # printm("Testing calc.py: ", _run_testcases(verbose=True))


### PR DESCRIPTION
This little fix should:

- [x] Allow RADIS to be deployed on Pypi
- [x] Attempt a new HITRAN download in case of `ValueError: invalid literal for int() with base 10: '\x00\x00'`
- [x ] Compatibility with Python 3.13