### PR TITLE
Add sanity checks to slit import

### DIFF
--- a/radis/test/tools/test_slit.py
+++ b/radis/test/tools/test_slit.py
@@ -764,6 +764,57 @@ def test_resampling(
     assert bool(error < rtol)
 
 
+@pytest.mark.fast
+def test_rejects_axis_without_finite_values():
+    slit = np.array(
+        [
+            [np.nan, np.inf, -np.inf],
+            [0.0, 1.0, 0.0],
+        ]
+    )
+
+    with pytest.raises(
+        ValueError, match=r"Invalid slit axis: `w_slit` contains no finite values\."
+    ):
+        import_experimental_slit(
+            slit, auto_recenter=False, auto_crop=False, norm_by=None
+        )
+
+
+@pytest.mark.fast
+def test_rejects_axis_at_or_near_zero():
+    slit = np.array(
+        [
+            [1e-16, 632.8, 632.9],
+            [0.0, 1.0, 0.0],
+        ]
+    )
+
+    with pytest.raises(
+        ValueError, match=r"Invalid slit axis: detected 1 value\(s\) at/near zero"
+    ):
+        import_experimental_slit(
+            slit, auto_recenter=False, auto_crop=False, norm_by=None
+        )
+
+
+@pytest.mark.fast
+def test_rejects_axis_crossing_zero():
+    slit = np.array(
+        [
+            [-1.0, -0.5, 0.5, 1.0],
+            [0.0, 1.0, 1.0, 0.0],
+        ]
+    )
+
+    with pytest.raises(
+        ValueError, match=r"Invalid slit axis: sign change detected in `w_slit`"
+    ):
+        import_experimental_slit(
+            slit, auto_recenter=False, auto_crop=False, norm_by=None
+        )
+
+
 def _run_testcases(plot=True, close_plots=False, verbose=True, *args, **kwargs):
 
     # Validation
@@ -810,5 +861,8 @@ def _run_testcases(plot=True, close_plots=False, verbose=True, *args, **kwargs):
 
 
 if __name__ == "__main__":
-    print(("Testing slit.py: ", _run_testcases(plot=True)))
+    test_rejects_axis_crossing_zero()
+    test_rejects_axis_at_or_near_zero()
+    test_rejects_axis_without_finite_values()
+    # print(("Testing slit.py: ", _run_testcases(plot=True)))
     # printm("Testing slit.py:", pytest.main(["test_slit.py", "--pdb"]))

--- a/radis/tools/slit.py
+++ b/radis/tools/slit.py
@@ -1454,6 +1454,32 @@ def import_experimental_slit(
     if not I_slit[0] == 0 and I_slit[-1] == 0:
         raise ValueError("Slit function must be null on each side. Fix it")
 
+    # sanity check: slit wavespace must stay in the original measured absolute axis
+    # (not centered around 0), especially before nm <-> cm-1 conversions.
+    finite_w = w_slit[np.isfinite(w_slit)]
+    if finite_w.size == 0:
+        raise ValueError("Invalid slit axis: `w_slit` contains no finite values.")
+
+    atol_zero = max(np.finfo(float).eps * 100, np.ptp(finite_w) * 1e-15)
+    zero_mask = np.isclose(finite_w, 0.0, atol=atol_zero, rtol=0.0)
+    if np.any(zero_mask):
+        n_zero = int(np.count_nonzero(zero_mask))
+        raise ValueError(
+            f"Invalid slit axis: detected {n_zero} value(s) at/near zero in `w_slit` "
+            f"(min={finite_w.min():.6g}, max={finite_w.max():.6g}). "
+            "The slit should not be centered to zero. Use the wavespace where the slit "
+            "was actually measured (absolute nm or cm-1), which can be critical for nm <-> cm-1 conversions."
+        )
+
+    wmin = float(np.min(finite_w))
+    wmax = float(np.max(finite_w))
+    if wmin < 0.0 < wmax:
+        raise ValueError(
+            f"Invalid slit axis: sign change detected in `w_slit` "
+            f"(min={wmin:.6g}, max={wmax:.6g}). "
+            "The slit should not be centered to zero. Use the wavespace where the slit "
+            "was actually measured (absolute nm or cm-1), which can be critical for nm <-> cm-1 conversions."
+        )
     # recenter if asked for
     if auto_recenter:
         w_slit, I_slit = recenter_slit(w_slit, I_slit, verbose=verbose)


### PR DESCRIPTION
<!-- Please be sure to check out our developer guide,
https://radis.readthedocs.io/en/latest/dev/developer.html -->

### Description
<!-- Provide a general description of what your pull request does. -->

This pull request is to address the following bug. When executing this code, RADIS could not apply the slit because the slit file is centered to zero in wavelength space. The conversion from nm to cm-1 encountered a 0 converted to `inf`. These sanity checks ensure the imported slit is not near zero.

To reproduce the bug:
```python
from radis import calc_spectrum, plot_diff
s = calc_spectrum(
    332, 342, 
    wunit = 'nm',         # cm-1
                  molecule='NH',
                  isotope='1',
                  pressure=1.01325,   # bar
                  Tgas=500,           # K
                  mole_fraction=1e-3,
                  path_length=5,      # cm
                  databank=('exomol', 'MoLLIST-NH'),  # or 'hitemp', 'geisa', 'exomol'
                  # name='500 K',
                  wstep=0.02,
                  )
s.apply_slit('slit_JB.txt')       # simulate an experimental slit
```
[slit_JB.txt](https://github.com/user-attachments/files/26869822/slit_JB.txt)

