### PR TITLE
fix: crop() silently skips when wmin=0.0 or wmax=0.0

### DIFF
--- a/radis/spectrum/operations.py
+++ b/radis/spectrum/operations.py
@@ -444,9 +444,9 @@ def crop(s: Spectrum, wmin=None, wmax=None, wunit=None, inplace=False) -> Spectr
     # Crop
     if len(s._q) > 0:
         b = ones_like(s._q["wavespace"], dtype=bool)
-        if wmin:
+        if wmin is not None:
             b *= wmin <= s._q["wavespace"]
-        if wmax:
+        if wmax is not None:
             b *= s._q["wavespace"] <= wmax
         for k, v in s._q.items():
             s._q[k] = v[b]


### PR DESCRIPTION
## Summary

Fixes #1000 — `crop()` uses `if wmin:` / `if wmax:` to check boundaries, but `0.0` is falsy in Python, so passing `wmin=0.0` or `wmax=0.0` silently skips the crop filter.

## Changes

- `if wmin:` → `if wmin is not None:` (line 447)
- `if wmax:` → `if wmax is not None:` (line 449)

Both parameters default to `None`, so this preserves existing behavior while correctly handling the zero-value edge case.

## Test

```python
# Before (buggy): crop(s, wmin=0.0) skips the lower-bound filter
# After (fixed): crop(s, wmin=0.0) correctly filters at 0.0

assert (0.0 is not None) == True   # ✅ fixed
assert (0.0) == False              # ❌ old (bug)
```

Closes #1000
