### PR TITLE
Implement parallel fetching for ExoMol databases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 24.4.2
     hooks:
       - id: black
 

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -1341,7 +1341,6 @@ class MdbExomol(DatabaseManager):
 
         if basic_exts:
             if self.parallel:
-                from concurrent.futures import ThreadPoolExecutor
 
                 with ThreadPoolExecutor(max_workers=4) as executor:
                     list(
@@ -1497,8 +1496,6 @@ class MdbExomol(DatabaseManager):
 
             if trans_downloads:
                 if self.parallel:
-                    from concurrent.futures import ThreadPoolExecutor
-
                     with ThreadPoolExecutor(
                         max_workers=min(4, len(trans_downloads))
                     ) as executor:

--- a/radis/api/exomolapi.py
+++ b/radis/api/exomolapi.py
@@ -11,6 +11,7 @@ import os
 import pathlib
 import urllib.request
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 
@@ -1113,6 +1114,10 @@ class MdbExomol(DatabaseManager):
               structure described in [1]_, unlike the states file of
               https://exomol.com/data/molecules/NO/14N-16O/XABC/ which follows the
               structure described in [2]_.
+    parallel : bool
+        If True, downloads multiple files concurrently using a thread pool, significantly
+        speeding up the fetching process especially for databases with many transition
+        or broadening files. Default is True.
 
     Notes
     -----
@@ -1204,7 +1209,8 @@ class MdbExomol(DatabaseManager):
         verbose=True,
         cache=True,
         skip_optional_data=True,
-        is_default_database=False,  # New parameter to track if using default/recommended database
+        is_default_database=False,
+        parallel=True,
     ):
         super().__init__(
             name,
@@ -1236,6 +1242,7 @@ class MdbExomol(DatabaseManager):
         self.wmin, self.wmax = np.min(nurange), np.max(nurange)
         self.broadf = broadf
         self.broadf_download = broadf_download
+        self.parallel = parallel
 
         # Initialize progress printer early (before any downloads)
         # Store database info for later header construction
@@ -1321,14 +1328,33 @@ class MdbExomol(DatabaseManager):
             self._printer.section("Download")
             self._header_printed = True
 
+        # Download basic files in parallel
+        basic_exts = []
         if need_def:
-            self.download(molec, extension=[".def"])
+            basic_exts.append(".def")
         if need_pf:
-            self.download(molec, extension=[".pf"])
+            basic_exts.append(".pf")
         if need_states:
-            self.download(molec, extension=[".states.bz2"])
+            basic_exts.append(".states.bz2")
         if need_broad:
-            self.download(molec, extension=[".broad"])
+            basic_exts.append(".broad")
+
+        if basic_exts:
+            if self.parallel:
+                from concurrent.futures import ThreadPoolExecutor
+
+                with ThreadPoolExecutor(max_workers=4) as executor:
+                    list(
+                        executor.map(
+                            lambda arg: self.download(
+                                molec, extension=[arg[1]], position=arg[0]
+                            ),
+                            enumerate(basic_exts),
+                        )
+                    )
+            else:
+                for ext in basic_exts:
+                    self.download(molec, extension=[ext])
         # self.isotope = 1  # Placeholder. TODO : implement parsing of other isotopes.
 
         # load def
@@ -1462,6 +1488,34 @@ class MdbExomol(DatabaseManager):
         # Only show Download section if we're downloading transition files
         if need_trans_download:
             self._printer.section("Download")
+
+            # Pre-download all trans files in parallel if requested
+            trans_downloads = []
+            for trans_file, num_tag in zip(self.trans_file, self.num_tag):
+                if not mgr.cache_file(trans_file).exists() and not trans_file.exists():
+                    trans_downloads.append(num_tag)
+
+            if trans_downloads:
+                if self.parallel:
+                    from concurrent.futures import ThreadPoolExecutor
+
+                    with ThreadPoolExecutor(
+                        max_workers=min(4, len(trans_downloads))
+                    ) as executor:
+                        list(
+                            executor.map(
+                                lambda arg: self.download(
+                                    molec,
+                                    extension=[".trans.bz2"],
+                                    numtag=arg[1],
+                                    position=arg[0],
+                                ),
+                                enumerate(trans_downloads),
+                            )
+                        )
+                else:
+                    for tag in trans_downloads:
+                        self.download(molec, extension=[".trans.bz2"], numtag=tag)
 
         # Look-up missing parameters and write file
         # -----------------------------------------
@@ -1788,7 +1842,7 @@ class MdbExomol(DatabaseManager):
             url = EXOMOL_URL + molname_simple + "/" + tag[0] + "/" + tag[1] + "/"
             return pfname_arr, url
 
-    def download(self, molec, extension, numtag=None):
+    def download(self, molec, extension, numtag=None, position=0):
         """Downloading Exomol files
 
         Parameters
@@ -1803,6 +1857,9 @@ class MdbExomol(DatabaseManager):
 
         """
         import os
+
+        import requests
+        from tqdm import tqdm
 
         tag = molec.split("__")
         molname_simple = exact_molname_exomol_to_simple_molname(tag[0])
@@ -1855,15 +1912,12 @@ class MdbExomol(DatabaseManager):
                     ext, molname_simple, tag, molec, numtag
                 )
 
-            for index, pfname in enumerate(pfname_arr):
+            def _download_single(index_pfname):
+                index, pfname = index_pfname
                 pfpath = url + pfname
                 os.makedirs(str(self.path), exist_ok=True)
                 self._printer.info(f"Downloading {pfname}", indent=2)
                 try:
-                    # Download with progress bar
-                    import requests
-                    from tqdm import tqdm
-
                     response = requests.get(pfpath, stream=True)
                     response.raise_for_status()
                     total_size = int(response.headers.get("content-length", 0))
@@ -1876,6 +1930,8 @@ class MdbExomol(DatabaseManager):
                             unit_divisor=1024,
                             desc=f"    {pfname[:30]}",
                             disable=not self.verbose,
+                            leave=True,
+                            position=position + index,
                         ) as pbar:
                             for chunk in response.iter_content(chunk_size=8192):
                                 if chunk:
@@ -1885,6 +1941,15 @@ class MdbExomol(DatabaseManager):
                     if ext == ".broad":
                         partners_success[index] = False
                     self._printer.warning(f"Couldn't download {ext} file")
+
+            if self.parallel:
+                with ThreadPoolExecutor(
+                    max_workers=min(4, len(pfname_arr))
+                ) as executor:
+                    list(executor.map(_download_single, enumerate(pfname_arr)))
+            else:
+                for index_pfname in enumerate(pfname_arr):
+                    _download_single(index_pfname)
 
             # Print broadening summary after attempting all downloads
             if ext == ".broad":

--- a/radis/io/exomol.py
+++ b/radis/io/exomol.py
@@ -34,6 +34,7 @@ def fetch_exomol(
     engine="default",
     output="pandas",
     skip_optional_data=True,
+    parallel=True,
     **kwargs,
 ):
     """Stream ExoMol file from EXOMOL website. Unzip and build a HDF5 file directly.
@@ -79,6 +80,9 @@ def fetch_exomol(
 
     Other Parameters
     ----------------
+    parallel: bool
+        if True, downloads files concurrently using a thread pool, significantly speeding up
+        the fetching process especially for databases with many transition files. Default is True.
     cache: bool, or ``'regen'`` or ``'force'``
         if ``True``, use existing HDF5 file. If ``False`` or ``'regen'``, rebuild it.
         If ``'force'``, crash if not cache file found. Default ``True``.
@@ -222,6 +226,7 @@ def fetch_exomol(
         skip_optional_data=skip_optional_data,
         verbose=verbose,
         is_default_database=is_default_database,  # Pass the flag
+        parallel=parallel,
         **kwargs,
     )
 

--- a/radis/test/io/test_exomol.py
+++ b/radis/test/io/test_exomol.py
@@ -99,6 +99,35 @@ def test_calc_exomol_vs_hitemp(verbose=True, plot=False, *args, **kwargs):
     )
 
 
+@pytest.mark.needs_connection
+def test_exomol_parallel_vs_sequential(tmp_path, verbose=True, *args, **kwargs):
+    """Test that parallel fetch_exomol produces same DataFrame as sequential"""
+    import pandas as pd
+
+    from radis.io.exomol import fetch_exomol
+
+    molecule = "CO"
+    isotope = 1
+    wmin = 2000
+    wmax = 2010
+
+    def get_df(parallel, path):
+        return fetch_exomol(
+            molecule=molecule,
+            isotope=isotope,
+            load_wavenum_min=wmin,
+            load_wavenum_max=wmax,
+            parallel=parallel,
+            clean_cache_files=False,
+            verbose=False,
+            local_databases=path,
+        )
+
+    df_seq = get_df(parallel=False, path=tmp_path / "seq")
+    df_par = get_df(parallel=True, path=tmp_path / "par")
+    pd.testing.assert_frame_equal(df_seq, df_par)
+
+
 if __name__ == "__main__":
     # test_exomol_parsing_functions()
     # test_calc_exomol_spectrum()


### PR DESCRIPTION
<!-- Please be sure to check out our developer guide,
https://radis.readthedocs.io/en/latest/dev/developer.html -->

### Description

For CO2 with this config try running this script - [test_parallel.py](https://github.com/user-attachments/files/28363069/test_parallel.py)
```
molecule = "CO"
isotope = 1
wmin = 2000
wmax = 2010
```
Time reduced from 27s to 16s.
```python
df = fetch_exomol(
        molecule=molecule,
        isotope=isotope,
        load_wavenum_min=wmin,
        load_wavenum_max=wmax,
        parallel=parallel,
        clean_cache_files=False,
        verbose=False,
        local_databases=tmpdir,
    )
df_seq = test_fetch(parallel=False, name="Sequential", tmpdir=str(base_tmp / "seq"))
df_par = test_fetch(parallel=True, name="Parallel", tmpdir=str(base_tmp / "par"))
```

<!-- Provide a general description of what your pull request does. -->

 - The definition (.def), partition function (.pf), and states (.states.bz2) files are fetched concurrently.
 - All available broadening files (e.g., H2.broad, air.broad, self.broad) are downloaded simultaneously.
 - Transition Files (.trans.bz2), previously the biggest bottleneck all missing chunks of transition files are now pre-downloaded in parallel before parsing begins.


Related to #997 
