### PR TITLE
fix(docs): pin MathJax to v3 and add graphviz for RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,7 @@ build:
   apt_packages:
     - mesa-vulkan-drivers #for running GPU examples
     - libvulkan1          #for running GPU examples
+    - graphviz            # render inheritance diagrams
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,6 +95,10 @@ extensions = [
     "sphinx.ext.linkcode",
 ]
 
+# Pin MathJax to v3; v4 output is rendering incorrectly for RADIS docs.
+mathjax_path = "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
+
+
 sphinx_gallery_conf = {
     "examples_dirs": "../examples",  # path to your example scripts
     "gallery_dirs": "auto_examples",  # path to where to save gallery generated output
@@ -162,8 +166,29 @@ def run_apidoc(_):
         apidoc.main(argv)
 
 
+def _fix_math_backslashes(app, what, name, obj, options, lines):
+    """Normalize LaTeX backslashes in autodoc math blocks.
+
+    Docstrings are raw strings with doubled backslashes (\\frac, \\sqrt, ...),
+    which MathJax interprets as line breaks. Convert to single backslashes
+    inside ".. math::" blocks so formulas render correctly.
+    """
+    in_math = False
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith(".. math::"):
+            in_math = True
+            continue
+        if in_math:
+            if stripped == "" or line.startswith(" "):
+                lines[i] = line.replace("\\\\", "\\")
+                continue
+            in_math = False
+
+
 def setup(app):
     app.connect("builder-inited", run_apidoc)
+    app.connect("autodoc-process-docstring", _fix_math_backslashes, priority=999)
     # Use add_css_file if available (Sphinx >= 1.6), fallback for older Sphinx
     if hasattr(app, "add_css_file"):
         app.add_css_file("custom.css")  # for scrollable sidebar


### PR DESCRIPTION
### Description

Fix broken formula and inheritance diagram rendering in the online documentation (readthedocs).

- **Math formulas** were displaying as raw LaTeX text due to a MathJax v4 incompatibility. Fixed by pinning MathJax to v3 and adding a backslash-normalization hook for `.. math::` blocks in autodoc.
- **Inheritance diagrams** were displaying as raw DOT source instead of rendered graphs because Graphviz was not installed on the Read the Docs build server. Fixed by adding `graphviz` to the `apt_packages` in `.readthedocs.yml`.

Fixes #1008
