### PR TITLE
fix: crop() treats wmin=0.0/wmax=0.0 as valid boundaries

### DIFF
--- a/radis/spectrum/operations.py
+++ b/radis/spectrum/operations.py
@@ -444,9 +444,9 @@ def crop(s: Spectrum, wmin=None, wmax=None, wunit=None, inplace=False) -> Spectr
     # Crop
     if len(s._q) > 0:
         b = ones_like(s._q["wavespace"], dtype=bool)
-        if wmin:
+        if wmin is not None:
             b *= wmin <= s._q["wavespace"]
-        if wmax:
+        if wmax is not None:
             b *= s._q["wavespace"] <= wmax
         for k, v in s._q.items():
             s._q[k] = v[b]


### PR DESCRIPTION
## Summary
crop() used `if wmin:` / `if wmax:` to guard boundary conditions, but 0.0 is falsy in Python, so passing wmin=0.0 or wmax=0.0 silently skips the crop operation.

## Fix
Changed `if wmin:` → `if wmin is not None:` (same for wmax), so 0.0 is treated as a valid boundary value.

## Testing
- Syntax check: ✅

## GitHub Issue
Fixes radis/radis#1000

---
*Note: commit signed-off with noreply email per GH007*