### PR TITLE
fix: handle wmin=0.0 and wmax=0.0 in crop()

### DIFF
--- a/radis/spectrum/operations.py
+++ b/radis/spectrum/operations.py
@@ -393,14 +393,14 @@ def crop(s: Spectrum, wmin=None, wmax=None, wunit=None, inplace=False) -> Spectr
     if stored_waveunit == "cm-1":
         # convert wmin, wmax to wavenumber
         if wunit == "nm":
-            if wmax0:
+            if wmax0 is not None:
                 wmin = nm_air2cm(wmax0)  # note: min/max inverted
-            if wmin0:
+            if wmin0 is not None:
                 wmax = nm_air2cm(wmin0)  # note: min/max inverted
         elif wunit == "nm_vac":
-            if wmax0:
+            if wmax0 is not None:
                 wmin = nm2cm(wmax0)  # note: min/max inverted
-            if wmin0:
+            if wmin0 is not None:
                 wmax = nm2cm(wmin0)  # note: min/max inverted
         elif wunit == "cm-1":
             pass
@@ -411,30 +411,30 @@ def crop(s: Spectrum, wmin=None, wmax=None, wunit=None, inplace=False) -> Spectr
         if wunit == "nm":
             pass
         elif wunit == "nm_vac":
-            if wmin0:
+            if wmin0 is not None:
                 wmin = vacuum2air(wmin0)
-            if wmax0:
+            if wmax0 is not None:
                 wmax = vacuum2air(wmax0)
         elif wunit == "cm-1":
-            if wmax0:
+            if wmax0 is not None:
                 wmin = cm2nm_air(wmax0)  # note: min/max inverted
-            if wmin0:
+            if wmin0 is not None:
                 wmax = cm2nm_air(wmin0)  # note: min/max inverted
         else:
             raise ValueError(wunit)
     elif stored_waveunit == "nm_vac":
         # convert wmin, wmax to wavelength vacuum
         if wunit == "nm":
-            if wmin0:
+            if wmin0 is not None:
                 wmin = air2vacuum(wmin0)
-            if wmax0:
+            if wmax0 is not None:
                 wmax = air2vacuum(wmax0)
         elif wunit == "nm_vac":
             pass
         elif wunit == "cm-1":
-            if wmax0:
+            if wmax0 is not None:
                 wmin = cm2nm(wmax0)  # note: min/max inverted
-            if wmin0:
+            if wmin0 is not None:
                 wmax = cm2nm(wmin0)  # note: min/max inverted
         else:
             raise ValueError(wunit)
@@ -444,9 +444,9 @@ def crop(s: Spectrum, wmin=None, wmax=None, wunit=None, inplace=False) -> Spectr
     # Crop
     if len(s._q) > 0:
         b = ones_like(s._q["wavespace"], dtype=bool)
-        if wmin:
+        if wmin is not None:
             b *= wmin <= s._q["wavespace"]
-        if wmax:
+        if wmax is not None:
             b *= s._q["wavespace"] <= wmax
         for k, v in s._q.items():
             s._q[k] = v[b]

--- a/radis/test/spectrum/test_operations.py
+++ b/radis/test/spectrum/test_operations.py
@@ -63,6 +63,20 @@ def test_crop(verbose=True, *args, **kwargs):
     w3 = s3.get_wavelength()
     assert np.array_equal(w, w3)
 
+    # 5) A crop example with wmin=0.0 to verify 0.0 is not treated as None (GH #1000)
+    s4 = load_spec(getTestFile("CO_Tgas1500K_mole_fraction0.01.spec"), binary=True)
+    # Store original wavelengths and crop with wmin=0.0
+    s4_w_orig = s4.get_wavelength()
+    s4.crop(0.0, 4600, "nm")
+
+    w4 = s4.get_wavelength()
+    assert w4.min() >= 0.0 - 1e-10, "crop(wmin=0.0) should have applied the lower bound"
+    assert w4.max() <= 4600, "crop(wmax=4600) should have applied the upper bound"
+    # The result should differ from the original if the crop was actually applied
+    assert len(w4) < len(s4_w_orig), (
+        "crop(wmin=0.0, wmax=4600) should have removed points above 4600nm"
+    )
+
     print("Crop test cases passed successfully.")
 
 


### PR DESCRIPTION
Fixes #1000

`crop()` was using `if wmin:` / `if wmax:` to check boundaries, but `0.0` is falsy in Python, so passing `wmin=0.0` silently skips the crop.

Changed all boundary checks to use `is not None` instead of truthiness. Also added a test case that crops with `wmin=0.0` to verify the fix.