### PR TITLE
Require explicit database specification for ExoMol queries

### DIFF
--- a/examples/1_Spectra_handling/plot_exomol_spectrum.py
+++ b/examples/1_Spectra_handling/plot_exomol_spectrum.py
@@ -19,7 +19,10 @@ s = calc_spectrum(
     Tgas=1000,  # K
     mole_fraction=0.1,
     path_length=1,  # cm
-    databank=("exomol", "EBJT"),  # Simply use 'exomol' for the recommended database
+    databank=(
+        "exomol",
+        "EBJT",
+    ),  # Or simply use 'exomol' to auto-select the recommended database (if one exists)
 )
 s.apply_slit(1, "cm-1")  # simulate an experimental slit
 s.plot("radiance")

--- a/radis/io/exomol.py
+++ b/radis/io/exomol.py
@@ -47,7 +47,9 @@ def fetch_exomol(
     database: ``str``
         database name. Ex: ``POKAZATEL`` or ``BT2`` for ``H2O``. See
         :py:data:`~radis.api.exomolapi.KNOWN_EXOMOL_DATABASE_NAMES`. If ``None`` and
-        there is only one database available, use it.
+        there is only one database available, use it. If multiple databases are
+        available but none is recommended by ExoMol (e.g., for ``13C-16O``), a
+        ``KeyError`` is raised and you must explicitly choose one.
     local_databases: ``str``
         where to create the RADIS HDF5 files. Default ``"~/.radisdb/exomol"``.
         Can be changed in ``radis.config["DEFAULT_DOWNLOAD_PATH"]`` or in ~/radis.json config file
@@ -166,7 +168,7 @@ def fetch_exomol(
         molecule, full_molecule_name
     )
 
-    _exomol_use_hint = "Select one of them with `fetch_exomol(DATABASE_NAME)`, `SpectrumFactory.fetch_databank('exomol', exomol_database=DATABASE_NAME')`, or `calc_spectrum(..., databank=('exomol', DATABASE_NAME))` \n"
+    _exomol_use_hint = "Select one of them with `fetch_exomol(..., database=DATABASE_NAME)`, `SpectrumFactory.fetch_databank('exomol', database=DATABASE_NAME)`, or `calc_spectrum(..., databank=('exomol', DATABASE_NAME))` \n"
 
     # Track if we're using the default/recommended database
     is_default_database = False

--- a/radis/lbl/loader.py
+++ b/radis/lbl/loader.py
@@ -1044,7 +1044,7 @@ class DatabankLoader(object):
         database: str
             If fetching from HITRAN, ``'full'`` downloads the full database and registers it, ``'range'`` downloads only the lines in the range of the molecule.
             If fetching from HITEMP, Kurucz, or NIST, only ``'full'`` is available.
-            If fetching from ExoMol, use this parameter to choose which database to use. Keep ``'default'`` to use the recommended one.
+            If fetching from ExoMol, use this parameter to choose which database to use. Keep ``'default'`` to use the recommended one. If no database is recommended (e.g., for ``13C-16O``), you must explicitly provide one or a ``KeyError`` will be raised.
             Default is ``'full'``.
 
 

--- a/radis/test/io/test_query.py
+++ b/radis/test/io/test_query.py
@@ -210,13 +210,16 @@ def test_pytable_vs_vaex(verbose=True):
     Tgas = 1000
     sf_exo_pytables = SpectrumFactory(**conditions)
     sf_exo_pytables.fetch_databank(
-        "exomol", memory_mapping_engine="pytables", db_use_cached="regen"
+        "exomol",
+        database="Li2015",
+        memory_mapping_engine="pytables",
+        db_use_cached="regen",
     )
     s_exo_pytables = sf_exo_pytables.eq_spectrum(Tgas=Tgas * u.K, path_length=1 * u.cm)
 
     sf_exo_vaex = SpectrumFactory(**conditions)
     sf_exo_vaex.fetch_databank(
-        "exomol", memory_mapping_engine="vaex", db_use_cached="regen"
+        "exomol", database="Li2015", memory_mapping_engine="vaex", db_use_cached="regen"
     )
     s_exo_vaex = sf_exo_vaex.eq_spectrum(Tgas=Tgas * u.K, path_length=1 * u.cm)
 


### PR DESCRIPTION
<!-- Please be sure to check out our developer guide,
https://radis.readthedocs.io/en/latest/dev/developer.html -->

### Description
<!-- Provide a general description of what your pull request does. -->

```
FAILED radis/test/io/test_query.py::test_pytable_vs_vaex - KeyError: "Choose one of the several databases available for 13C-16O in ExoMol: [np.str_('HITEMP'), np.str_('Li'), np.str_('Li2015')]. (False is recommended by the ExoMol team). Select one of them with `fetch_exomol(DATABASE_NAME)`, `SpectrumFactory.fetch_databank('exomol', exomol_database=DATABASE_NAME')`, or `calc_spectrum(..., databank=('exomol', DATABASE_NAME))` \n"
= 1 failed, 110 passed, 1 skipped, 204 deselected, 1501 warnings in 918.15s (0:15:18) =
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes https://github.com/radis/radis/actions/runs/27862100882/job/82459704882
