### PR TITLE
remove unused download of hitemp database

### DIFF
--- a/radis/api/hitempapi.py
+++ b/radis/api/hitempapi.py
@@ -1166,15 +1166,11 @@ class HITEMPDatabaseManager(DatabaseManager):
             urlnames = [f"{base_url}{f}" for f in inputfiles]
 
         elif molecule in HITEMP_MOLECULES:
+            if self.verbose:
+                print("Fetching urls from HITRAN")
             session = login_to_hitran(verbose=self.verbose)
-            if session:
-                url, Ntotal_lines_expected, _, _ = self.fetch_url_Nlines_wmin_wmax(
-                    session
-                )
-                download_hitemp_file(session, url, basename(url))
-                urlnames = [url]
-            else:
-                return []  # Exit if login failed
+            url, Ntotal_lines_expected, _, _ = self.fetch_url_Nlines_wmin_wmax(session)
+            urlnames = [url]
         else:
             raise KeyError(
                 f"Please choose one of HITEMP molecules : {HITEMP_MOLECULES}. Got '{molecule}'"


### PR DESCRIPTION
```python
from radis import SpectrumFactory

sf = SpectrumFactory(
    2000,
    3000,  # cm-1
    molecule="NO",
    isotope="1",
    wstep=0.001,
    verbose=1,
    )

sf.fetch_databank("hitemp")
```

When running this code before, the OH database was downloaded twice. In this current version, the database is downloaded only in the end.
