### PR TITLE
feat: add option to drop unlabelled CO2 HITEMP lines in calc_spectrum

### DIFF
--- a/radis/lbl/base.py
+++ b/radis/lbl/base.py
@@ -331,14 +331,16 @@ class BaseFactory(DatabankLoader):
                 "This usually happens during the computation of Evib and Erot. "
                 "To solve this issue, you can perform a dry run in a try block. "
                 "Then, drop incomplete rows in the line dataframe and run again. "
-                "See also https://github.com/radis/radis/pull/942."
+                "See also https://github.com/radis/radis/pull/942.\n"
                 "Example:\n"
                 "\n"
                 "try:\n"
                 "    s1 = sf.non_eq_spectrum(Tvib=9800, Trot=8500) #dry run to compute all energy columns\n"
                 "except AssertionError:\n"
                 '    bad_cols = [c for c in sf.df0.columns if "Evib" in c or "Erot" in c]\n'
-                "    sf.df0.dropna(subset=bad_cols, inplace=True)"
+                "    sf.df0.dropna(subset=bad_cols, inplace=True)\n"
+                "\n"
+                "Alternatively, if you are using `calc_spectrum`, you can simply use the `drop_unlabelled_CO2_hitemp_lines=True` argument."
             )
 
         if self.dataframe_type == "pandas":

--- a/radis/lbl/calc.py
+++ b/radis/lbl/calc.py
@@ -718,6 +718,9 @@ def _calc_spectrum_one_molecule(
 
     # Initialize Factory
     # ------------------
+    drop_unlabelled_CO2_hitemp_lines = kwargs.pop(
+        "drop_unlabelled_CO2_hitemp_lines", False
+    )
 
     # Check inputs
 
@@ -996,6 +999,10 @@ def _calc_spectrum_one_molecule(
             drop_columns=drop_columns,
             load_columns=load_columns,
         )
+
+    if drop_unlabelled_CO2_hitemp_lines:
+        unlabelled = (sf.df0["v1u"] == -1) | (sf.df0["v1l"] == -1)
+        sf.df0.drop(sf.df0.index[unlabelled], inplace=True)
 
     #    # Get optimization strategies
     #    if lineshape_optimization == 'auto':        # NotImplemented: finally we use DLM all the time as default.

--- a/radis/test/lbl/test_calc.py
+++ b/radis/test/lbl/test_calc.py
@@ -980,6 +980,25 @@ def test_wildcard_path_error():
         )
 
 
+@pytest.mark.needs_connection
+def test_drop_unlabelled_CO2_hitemp_lines():
+    """Ensure the 'drop_unlabelled_CO2_hitemp_lines' arg drops unlabelled HITEMP lines."""
+
+    # Using the parameters from the issue that trigger the Evib nan error.
+    df = calc_spectrum(
+        2000,
+        2002,
+        molecule="CO2",
+        Trot=3000,
+        isotope=1,
+        Tvib=(3000, 3000, 1000),
+        databank="hitemp",
+        drop_unlabelled_CO2_hitemp_lines=True,
+    )
+    # the function should finish and return a spectrum without raising AssertionError
+    assert df is not None
+
+
 def _run_testcases(plot=True, verbose=True, warnings=True, *args, **kwargs):
 
     # Test sPlanck and conversion functions

--- a/radis/test/lbl/test_calc.py
+++ b/radis/test/lbl/test_calc.py
@@ -981,6 +981,7 @@ def test_wildcard_path_error():
 
 
 @pytest.mark.needs_connection
+@pytest.mark.needs_HITRAN_credentials
 def test_drop_unlabelled_CO2_hitemp_lines():
     """Ensure the 'drop_unlabelled_CO2_hitemp_lines' arg drops unlabelled HITEMP lines."""
 


### PR DESCRIPTION
Fixes: https://github.com/radis/radis/issues/509

<!-- Please be sure to check out our developer guide,
https://radis.readthedocs.io/en/latest/dev/developer.html -->

### Description
When computing non-equilibrium spectra with HITEMP for CO2, some lines are unlabelled (quantum numbers like `v1u` or `v1l` are `-1`). These lines cause `Evib1u=NaN` and `Evib1l=NaN` errors during the `assert_no_nan` energy level validation. 
