### PR TITLE
fix random segfault in GPU tests by clamping the FFT workgroup count

### DIFF
--- a/radis/gpu/vulkan/pyvkfft_vulkan.py
+++ b/radis/gpu/vulkan/pyvkfft_vulkan.py
@@ -320,7 +320,7 @@ class VkFFTApp(VkFFTAppBase):
 
         shape = np.ones(vkfft_max_fft_dimensions(), dtype=vkfft_long_type)
         skip = np.zeros(vkfft_max_fft_dimensions(), dtype=vkfft_long_type)
-        grouped_batch = -np.ones(vkfft_max_fft_dimensions(), dtype=vkfft_long_type)
+        grouped_batch = np.ones(vkfft_max_fft_dimensions(), dtype=vkfft_long_type)
 
         shape[0] = self.shape[-1]
         # skip[1 : len(self.shape)] = 1


### PR DESCRIPTION
`setFFTWorkGroupSize()` is passed a number of batches (`N_G * N_L`), but writes it into the
indirect buffer as a number of workgroups. For short transforms VkFFT puts several batches
in one workgroup, so the surplus workgroups ran past the end of `S_klm_d`  a random SIGSEGV
inside the FFT shader, surfacing as a crash in `vkWaitForFences`.

On the GEISA test the plan is built for 6 batches and VkFFT asks for 1 workgroup; we were
overwriting that with 4. Wide-range spectra use one workgroup per batch, which is why only the
small-range test crashed.

Fix: remember the workgroup counts VkFFT planned (it writes them when the transform is
recorded) and clamp to them. Where VkFFT uses one workgroup per batch this is a no-op, so the
usual path is unchanged.

Fixes #1024 
