### PR TITLE
Resolve Sphinx cross-reference warnings caused by lazy-loading re-exports 

### DIFF
--- a/docs/_templates/autosummary/module.rst
+++ b/docs/_templates/autosummary/module.rst
@@ -4,3 +4,4 @@
    :members:
    :show-inheritance:
    :undoc-members:
+   :no-index:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -184,9 +184,29 @@ def _fix_math_backslashes(app, what, name, obj, options, lines):
             in_math = False
 
 
+def _skip_reimported_members(app, what, name, obj, skip, options):
+    """Skip members that are re-imported from submodules."""
+    # We only care about objects that have a __module__ attribute
+    obj_module = getattr(obj, "__module__", None)
+    if not obj_module:
+        return skip
+
+    # Get the module currently being documented by autodoc
+    current_module = app.env.ref_context.get("py:module")
+
+    if current_module and obj_module != current_module:
+        # If the object belongs to the radis package but is not defined in the current module,
+        # it is a re-import. We skip it so it's only indexed at its true definition site.
+        if obj_module.startswith("radis."):
+            return True
+
+    return skip
+
+
 def setup(app):
     app.connect("builder-inited", run_apidoc)
     app.connect("autodoc-process-docstring", _fix_math_backslashes, priority=999)
+    app.connect("autodoc-skip-member", _skip_reimported_members)
     # Use add_css_file if available (Sphinx >= 1.6), fallback for older Sphinx
     if hasattr(app, "add_css_file"):
         app.add_css_file("custom.css")  # for scrollable sidebar


### PR DESCRIPTION

<!-- Please be sure to check out our developer guide,
https://radis.readthedocs.io/en/latest/dev/developer.html -->

### Description
<!-- Provide a general description of what your pull request does. -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


To make the lazy loading work, in #842 explicitly defined `__all__` lists in these files. However, Sphinx's autodoc extension blindly trusts `__all__`. As soon as it saw classes like Spectrum and `SpecDatabase` explicitly exported in multiple `__init__.py` files, it started indexing and documenting them in all of those locations simultaneously.

This caused core classes to be documented two or three times (e.g., Spectrum was indexed as `radis.Spectrum`, `radis.spectrum.Spectrum`, and `radis.spectrum.spectrum.Spectrum`). This massive double-indexing resulted in over 400 duplicate object description and more than one target found for cross-reference warnings during make html-noplot.

