### PR TITLE
fix: avoid circular import in partition functions

### DIFF
--- a/radis/levels/partfunc.py
+++ b/radis/levels/partfunc.py
@@ -78,7 +78,6 @@ from radis.db.classes import (
     get_molecule,
     get_molecule_identifier,
 )
-from radis.lbl.labels import vib_lvl_name_hitran_class1, vib_lvl_name_hitran_class5
 from radis.misc.basics import all_in
 from radis.misc.debug import printdbg
 from radis.misc.printer import printg
@@ -1770,6 +1769,8 @@ class PartFunc_Dunham(RovibParFuncCalculator):
             - ``viblvl`` : vibrational level name
         """
 
+        from radis.lbl.labels import vib_lvl_name_hitran_class1
+
         vib_lvl_name = vib_lvl_name_hitran_class1
 
         ElecState = self.ElecState  # molecule
@@ -1923,6 +1924,8 @@ class PartFunc_Dunham(RovibParFuncCalculator):
             - ``Erot`` : rotational energy
             - ``viblvl`` : vibrational level name
         """
+
+        from radis.lbl.labels import vib_lvl_name_hitran_class5
 
         vib_lvl_name = vib_lvl_name_hitran_class5
 

--- a/radis/test/test_import_radis.py
+++ b/radis/test/test_import_radis.py
@@ -60,3 +60,15 @@ def test_import_radis_public_symbols():
         "]))"
     )
     assert result == "True"
+
+
+@pytest.mark.fast
+def test_import_partition_functions_from_submodule():
+    result = _run_python(
+        "from radis.levels.partfunc import PartFunc_Dunham, PartFuncTIPS; "
+        "print(all(["
+        "isinstance(PartFunc_Dunham, type), "
+        "isinstance(PartFuncTIPS, type)"
+        "]))"
+    )
+    assert result == "True"


### PR DESCRIPTION
 <!-- Please be sure to check out our developer guide,
  https://radis.readthedocs.io/en/latest/dev/developer.html -->

  ### Description

  This pull request fixes a circular import exposed by the lazy top-level loading introduced in #938.

  Importing partition functions directly with:

  ```python
  from radis.levels.partfunc import PartFunc_Dunham, PartFuncTIPS
  ```
  failed because radis.levels.partfunc imported radis.lbl.labels during module initialization. Initializing radis.lbl
  then loaded radis.lbl.loader, which attempted to import PartFunc_Dunham back from the partially initialized partfunc
  module.

  This change:

  - moves the two radis.lbl.labels imports into the Dunham energy-level builder methods where they are used;
  - preserves the lazy top-level import behavior;
  - adds a subprocess regression test for direct partition-function imports.

  The issue was detected while testing RADIS develop against ExoJAX for the 0.17.1 release in #1032. ExoJAX imports
  PartFuncTIPS directly and failed before this fix.

  ### Validation

  - pytest -q radis/test/test_import_radis.py: 3 passed
  - pytest -q radis/test/levels/test_partfunc.py: 15 passed, 3 deselected
  - ExoJAX pytest -q tests/unittests/database/api/api_eq_method_test.py: 2 passed
  - ExoJAX pytest -q tests/unittests/database/api_radis: 27 passed
  - Black formatting and Python compilation checks passed
