### PR TITLE
Fix NumPy 2.5 string dtype compatibility

### DIFF
--- a/radis/api/tools.py
+++ b/radis/api/tools.py
@@ -188,9 +188,11 @@ def _format_dtype(dtype):
         formatted_dtype = [
             (
                 str(k),
-                f"S{c[1:]}"
-                if isinstance(c, str) and c.startswith("a") and c[1:].isdigit()
-                else c,
+                (
+                    f"S{c[1:]}"
+                    if isinstance(c, str) and c.startswith("a") and c[1:].isdigit()
+                    else c
+                ),
             )
             for k, c in dtype
         ]

--- a/radis/api/tools.py
+++ b/radis/api/tools.py
@@ -184,9 +184,17 @@ def _format_dtype(dtype):
     Crash with hopefully helping error message
     """
     try:
-        dt = np.dtype(
-            [(str(k), c) for k, c in dtype]
-        )  # DeprecationWarning: Data type alias 'a' was deprecated in NumPy 2.0. Use the 'S' alias instead.
+        # NumPy 2.5 removed the legacy "aN" fixed-width string alias; use "SN".
+        formatted_dtype = [
+            (
+                str(k),
+                f"S{c[1:]}"
+                if isinstance(c, str) and c.startswith("a") and c[1:].isdigit()
+                else c,
+            )
+            for k, c in dtype
+        ]
+        dt = np.dtype(formatted_dtype)
         # Note: dtype names cannot be `unicode` in Python2. Hence the str()
     except TypeError as err:
         # Cant read database. Try to be more explicit for user before crashing

--- a/radis/test/io/test_hitran_cdsd.py
+++ b/radis/test/io/test_hitran_cdsd.py
@@ -30,8 +30,14 @@ import pytest
 
 from radis.api.cdsdapi import cdsd2df
 from radis.api.hitranapi import hit2df
+from radis.api.tools import _format_dtype
 from radis.misc.warning import IrrelevantFileWarning
 from radis.test.utils import getTestFile, setup_test_line_databases
+
+
+@pytest.mark.fast
+def test_format_dtype_with_legacy_string_alias():
+    assert _format_dtype([("id", "a2")]) == np.dtype([("id", "S2")])
 
 
 @pytest.mark.fast


### PR DESCRIPTION
## Summary

- Normalize legacy fixed-width string dtype codes from `aN` to `SN` in `_format_dtype`.
- Add a fast regression test for the `a2` to `S2` conversion.

## Root cause

NumPy 2.5 removed the deprecated `a` dtype alias in favor of `S`. RADIS still passes codes such as `a1`, `a2`, and `a25` to `np.dtype` while parsing HITRAN-family fixed-width files, which raises:

```text
TypeError: data type 'a2' not understood
```

The normalization is kept in the shared formatter so existing column definitions and the HITRAN, HITEMP, CDSD, and GEISA parser paths continue to work without broader changes.

Related downstream issue: HajimeKawahara/exojax#735

## Validation

Using Python 3.12 and NumPy 2.5.2:

```text
5 passed in 0.51s
```

The selected tests cover the new regression test and the local HITRAN/HITEMP parser tests. The same five tests also pass with NumPy 2.1.0.
