### PR TITLE
fix: forward-compatibility with matplotlib 3.13 and pandas 3.0

### DIFF
--- a/examples/6_Misc/plot_styles.py
+++ b/examples/6_Misc/plot_styles.py
@@ -48,7 +48,7 @@ for plotlib, context, style in [
     plt.title(", ".join(f"{v}" for v in radis.config["plot"].values()))
     plt.tight_layout()
 
-#%%
+# %%
 # You can also choose to not show the figure immediately, and instead return
 # the Matplotlib or Plotly object. This allows for **advanced customization**
 # (e.g., modifying the matplotlib figure).

--- a/radis/spectrum/compare.py
+++ b/radis/spectrum/compare.py
@@ -862,6 +862,7 @@ def plot_diff(
     :py:func:`~radis.spectrum.compare.get_residual`,
     :py:meth:`~radis.spectrum.spectrum.Spectrum.compare_with`
     """
+    import matplotlib
     import matplotlib.pyplot as plt
     from matplotlib import gridspec
     from matplotlib.widgets import MultiCursor
@@ -1071,9 +1072,13 @@ def plot_diff(
     # Add tools
     # ... Add cursors
     axes = [ax0] + ax1
+    # `canvas` deprecated in matplotlib 3.11, removed in 3.13; required before
+    if getattr(matplotlib, "__version_info__", (0,)) >= (3, 11):
+        cursor_args = (axes,)
+    else:
+        cursor_args = (fig.canvas, axes)
     fig.cursors = MultiCursor(
-        fig.canvas,
-        axes,
+        *cursor_args,
         color="r",
         lw=1 * lw_multiplier,
         alpha=0.2,

--- a/radis/test/io/test_hdf5.py
+++ b/radis/test/io/test_hdf5.py
@@ -38,7 +38,7 @@ def test_hdf5_io_engines(*args, **kwargs):
     df0 = pd.DataFrame({"a": np.arange(10) ** 2, "b": np.arange(10) ** 3})
     metadata0 = {"some_metadata": True}
     # ... a Pandas HDFStore file
-    df0.to_hdf("test_pytables.h5", "df")
+    df0.to_hdf("test_pytables.h5", key="df")
     # ... a h5py file with same content
     with h5py.File("test_h5py.h5", "w") as f:
         # group = f.create_group("df")


### PR DESCRIPTION
<!-- Please be sure to check out our developer guide,
https://radis.readthedocs.io/en/latest/dev/developer.html -->

### Description
Fix two upstream deprecations that will become errors in upcoming releases.

`plot_diff` passes `fig.canvas` to matplotlib's `MultiCursor`. This is deprecated in 3.11 and will cause an error in 3.13. We can't just drop it because matplotlib < 3.11 (which Python 3.10 users get) still needs it, so we added a version check.

`test_hdf5.py` passes `key` to `to_hdf` positionally. Pandas 3.0 requires it to be a keyword argument. The behavior stays exactly the same.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

### AI-Generated Code Disclosure
<!-- Please review our AI Policy in the developer guide: https://radis.readthedocs.io/en/latest/dev/developer.html#ai-policy -->
#### Developer Confirmation
- [x] I understand all code changes in this PR (whether self-authored or AI-assisted).
- [x] I confirm that all changes are necessary and useful.

#### Checklist before review by admins:
- [x] This PR passes [linting](https://radis.readthedocs.io/en/latest/dev/developer.html#code-style-and-linting).
- [x] This PR passes all related tests.

If a test fails due to an external issue (e.g. database not downloaded), please post a comment rather than re-running the tests.
